### PR TITLE
feat: deploy todos-for-dues frontend internal

### DIFF
--- a/kubernetes/main/apps/frontend/kustomization.yaml
+++ b/kubernetes/main/apps/frontend/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - ./homepage/ks.yaml
   - ./headlamp/ks.yaml
   - ./omni/ks.yaml
+  - ./todos-for-dues/ks.yaml

--- a/kubernetes/main/apps/frontend/todos-for-dues/app/externalsecret.yaml
+++ b/kubernetes/main/apps/frontend/todos-for-dues/app/externalsecret.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: todos-for-dues
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: todos-for-dues-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # App — Better Auth
+        BETTER_AUTH_SECRET: "{{ .BETTER_AUTH_SECRET }}"
+        BETTER_AUTH_URL: "https://todos-for-dues.haynesops.com"
+
+        # App — Workspace OIDC (Phase 1.1: enabled iff all three are set)
+        OIDC_CLIENT_ID: "{{ .OIDC_CLIENT_ID }}"
+        OIDC_CLIENT_SECRET: "{{ .OIDC_CLIENT_SECRET }}"
+        OIDC_HOSTED_DOMAIN: "{{ .OIDC_HOSTED_DOMAIN }}"
+
+        # App — bootstrap admin (auto-promoted on first sign-in)
+        BOOTSTRAP_ADMIN_EMAIL: "{{ .BOOTSTRAP_ADMIN_EMAIL }}"
+
+        # App — notifications (Resend)
+        RESEND_API_KEY: "{{ .RESEND_API_KEY }}"
+        RESEND_WEBHOOK_SECRET: "{{ .RESEND_WEBHOOK_SECRET }}"
+
+        # Migrator + app — chapter_settings seed (DESIGN-001 §5.5 → GUCs via
+        # set_config() inside packages/db/src/migrate.ts; without these, the
+        # bootstrap migration leaves *.invalid placeholders and the first
+        # treasurer email misfires).
+        BOOTSTRAP_ADMIN_RECIPIENT_EMAIL: "{{ .BOOTSTRAP_ADMIN_RECIPIENT_EMAIL }}"
+        BOOTSTRAP_TREASURER_RECIPIENT_EMAIL: "{{ .BOOTSTRAP_TREASURER_RECIPIENT_EMAIL }}"
+        BOOTSTRAP_MODERATORS_RECIPIENT_EMAIL: "{{ .BOOTSTRAP_MODERATORS_RECIPIENT_EMAIL }}"
+        BOOTSTRAP_CHAPTER_TIMEZONE: "{{ .BOOTSTRAP_CHAPTER_TIMEZONE }}"
+        BOOTSTRAP_CHAPTER_DISPLAY_NAME: "{{ .BOOTSTRAP_CHAPTER_DISPLAY_NAME }}"
+
+        # Database connection — composed from the cluster16 cnpg creds.
+        DATABASE_URL: "postgres://{{ .TODOS_FOR_DUES_POSTGRESQL__USER }}:{{ .TODOS_FOR_DUES_POSTGRESQL__PASSWORD }}@postgres16-rw.database.svc.cluster.local:5432/todos_for_dues"
+
+        # postgres-init bootstrap (creates DB + role idempotently on every
+        # pod start). Same INIT_POSTGRES_* contract as authentik / paperless.
+        INIT_POSTGRES_DBNAME: &dbName todos_for_dues
+        INIT_POSTGRES_HOST: &dbHost postgres16-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: &dbUser "{{ .TODOS_FOR_DUES_POSTGRESQL__USER }}"
+        INIT_POSTGRES_PASS: &dbPass "{{ .TODOS_FOR_DUES_POSTGRESQL__PASSWORD }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: todos-for-dues
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/main/apps/frontend/todos-for-dues/app/helmrelease.yaml
+++ b/kubernetes/main/apps/frontend/todos-for-dues/app/helmrelease.yaml
@@ -1,0 +1,111 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app todos-for-dues
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      main:
+        replicas: 1
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # 1. Create the app's database + role inside cluster16 if they
+          #    don't exist. Idempotent. Uses the home-operations
+          #    postgres-init image (same pattern as authentik/paperless).
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: "18.3"
+              pullPolicy: IfNotPresent
+            envFrom:
+              - secretRef:
+                  name: todos-for-dues-secret
+          # 2. Apply Drizzle migrations + seed chapter_settings from the
+          #    BOOTSTRAP_* env vars (PLAN-002 tsx wrapper at
+          #    packages/db/src/scripts/migrate.ts → set_config() into
+          #    app.bootstrap_* GUCs before drizzle migrate).
+          migrate:
+            image: &mainImage
+              repository: ghcr.io/thaynes43/todos-for-dues
+              tag: v0.2.0
+              pullPolicy: IfNotPresent
+            command:
+              - tsx
+              - /migrator/src/scripts/migrate.ts
+            envFrom:
+              - secretRef:
+                  name: todos-for-dues-secret
+        containers:
+          app:
+            image: *mainImage
+            env:
+              NODE_ENV: production
+              PORT: "3000"
+              HOSTNAME: "0.0.0.0"
+            envFrom:
+              - secretRef:
+                  name: todos-for-dues-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3000
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3000
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 3
+                  failureThreshold: 24
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    service:
+      main:
+        ports:
+          http:
+            port: 3000

--- a/kubernetes/main/apps/frontend/todos-for-dues/app/ingressroute.yaml
+++ b/kubernetes/main/apps/frontend/todos-for-dues/app/ingressroute.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: todos-for-dues
+  annotations:
+    external-dns.alpha.kubernetes.io/target: internal.haynesops
+    kubernetes.io/ingress.class: traefik-internal
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`todos-for-dues.haynesops.com`) && PathPrefix(`/`)
+      services:
+        - kind: Service
+          name: todos-for-dues
+          port: 3000
+  tls:
+    secretName: certificate-haynesops

--- a/kubernetes/main/apps/frontend/todos-for-dues/app/kustomization.yaml
+++ b/kubernetes/main/apps/frontend/todos-for-dues/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ingressroute.yaml

--- a/kubernetes/main/apps/frontend/todos-for-dues/ks.yaml
+++ b/kubernetes/main/apps/frontend/todos-for-dues/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app todos-for-dues
+  namespace: &namespace frontend
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: cloudnative-pg-cluster
+      namespace: database
+  path: ./kubernetes/main/apps/frontend/todos-for-dues/app
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  prune: true
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app


### PR DESCRIPTION
## Summary

Phase 1.1 internal deploy of the **TODOs for Dues** walking-skeleton SaaS (per ADR-006 + PLAN-009). New app under `kubernetes/main/apps/frontend/todos-for-dues/`, mirroring the existing `frontend/homepage/` pattern:

- **Image:** pinned to `ghcr.io/thaynes43/todos-for-dues:v0.2.0` (release-please tag from the SaaS repo). NOT `:latest` — reproducible deploys per PLAN-009 §3.
- **Database:** dedicated `todos_for_dues` DB inside the existing `postgres16` cnpg cluster. Created idempotently on every pod start by an `init-db` container using `ghcr.io/home-operations/postgres-init:18.3` and `INIT_POSTGRES_*` env (same contract as authentik/paperless/immich).
- **Migrations:** a second init container reuses the app image with the command override `tsx /migrator/src/scripts/migrate.ts` — PLAN-002's tsx wrapper that pipes the 5 `BOOTSTRAP_*` env vars into `app.bootstrap_*` Postgres GUCs via `set_config()` before the drizzle migrator, so `chapter_settings` seeds with real values instead of the `*.invalid` placeholders.
- **Ingress:** Traefik internal on `todos-for-dues.haynesops.com`, TLS via `certificate-haynesops`, external-dns target `internal.haynesops`. Phase 1.2 public exposure (`*.haynesnetwork.com` via cloudflare-tunnel) is a future PR.
- **Secrets:** ExternalSecret against `onepassword-connect` ClusterSecretStore, pulls from two items.

## Required out-of-band setup before this PR helps reconcile cleanly

1. **Create `todos-for-dues` 1Password item** in the same vault `cloudnative-pg` lives in. Fields:
   - `BETTER_AUTH_SECRET` (≥32 random chars, e.g. `openssl rand -base64 32`)
   - `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_HOSTED_DOMAIN`
   - `BOOTSTRAP_ADMIN_EMAIL` (the founding admin's Workspace email)
   - `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET` (Svix signing secret)
   - `BOOTSTRAP_ADMIN_RECIPIENT_EMAIL`, `BOOTSTRAP_TREASURER_RECIPIENT_EMAIL`, `BOOTSTRAP_MODERATORS_RECIPIENT_EMAIL`
   - `BOOTSTRAP_CHAPTER_TIMEZONE` (e.g., `America/New_York`)
   - `BOOTSTRAP_CHAPTER_DISPLAY_NAME` (e.g., `Sigma Phi Omicron`)
   - `TODOS_FOR_DUES_POSTGRESQL__USER` (e.g., `todos_for_dues_user`)
   - `TODOS_FOR_DUES_POSTGRESQL__PASSWORD` (random)
2. **Register the Workspace OIDC redirect URI:** `https://todos-for-dues.haynesops.com/api/auth/callback/oauth/google-workspace`
3. **Verify the Resend sending domain** (SPF + DKIM DNS records).
4. **Configure the Resend webhook** to POST to `https://todos-for-dues.haynesops.com/api/webhooks/resend` with the matching `RESEND_WEBHOOK_SECRET`.
5. **Make `ghcr.io/thaynes43/todos-for-dues` public** (or add an imagepullsecret to the `frontend` namespace). Currently private after first push; Phase 1.1 internal cluster has no GHCR creds.

## Test plan
- [ ] (after merge + Flux reconcile) `kubectl -n frontend get pods` shows `todos-for-dues-*` Ready
- [ ] init-db init container exits 0
- [ ] migrate init container exits 0
- [ ] `kubectl -n database exec postgres16-1 -- psql -U todos_for_dues_user -d todos_for_dues -c '\dt'` returns ≥ 7 tables
- [ ] `kubectl -n database exec postgres16-1 -- psql -U todos_for_dues_user -d todos_for_dues -c 'SELECT key, value FROM chapter_settings'` shows 5 rows with real values (no `*.invalid`)
- [ ] `curl -sI https://todos-for-dues.haynesops.com/` returns 200
- [ ] `curl -sI https://todos-for-dues.haynesops.com/api/test/resend-calls` returns 404 (RESEND_TEST_MODE not set in prod)
- [ ] Sign in once as `BOOTSTRAP_ADMIN_EMAIL` via Workspace SSO → Admin role auto-granted
- [ ] Walking-skeleton happy-path click-through closes the loop; treasurer email lands in Resend dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)