### PR TITLE
fix(todos-for-dues): bump image to v0.2.1 (users.image column)

### DIFF
--- a/kubernetes/main/apps/frontend/todos-for-dues/app/helmrelease.yaml
+++ b/kubernetes/main/apps/frontend/todos-for-dues/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           migrate:
             image: &mainImage
               repository: ghcr.io/thaynes43/todos-for-dues
-              tag: v0.2.0
+              tag: v0.2.1
               pullPolicy: IfNotPresent
             command:
               - tsx


### PR DESCRIPTION
First Workspace SSO attempt against v0.2.0 failed with `BetterAuthError: The field 'image' does not exist in the 'users' Drizzle schema` — Better Auth maps the OIDC `picture` claim into `users.image` on first sign-in. v0.2.1 ships the missing column via migration 0007_users_add_image. Bumping the pinned image tag so the init container picks up the migration on next reconcile.