### PR TITLE
feat(todos-for-dues): bump to v0.5.0 — MVP UI loop + Admin view + role mgmt

### DIFF
--- a/kubernetes/main/apps/frontend/todos-for-dues/app/helmrelease.yaml
+++ b/kubernetes/main/apps/frontend/todos-for-dues/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           migrate:
             image: &mainImage
               repository: ghcr.io/thaynes43/todos-for-dues
-              tag: v0.2.2
+              tag: v0.5.0
               pullPolicy: IfNotPresent
             command:
               - tsx


### PR DESCRIPTION
## Summary
- Bumps todos-for-dues from v0.2.2 → v0.5.0.
- Includes PLAN-010 (MVP job-loop UI), PLAN-011 (Admin view), PLAN-012 (role management).
- No migrations or env-var changes vs v0.2.2 — schema-stable.

## Test plan
- [ ] CI on this PR green (Flux Local manifest validation if present).
- [ ] After merge: `flux reconcile source git haynes-ops -n flux-system` + `flux reconcile helmrelease todos-for-dues -n <ns>`.
- [ ] Pod becomes Ready on the new image tag.
- [ ] Smoke (mirroring PLAN-009 §6): HTTP 200 on /, auth handler 4xx on bad payload, no test-only routes in prod, pod logs quiet on boot, chapter_settings rows present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)