### PR TITLE
feat(todos-for-dues): bump to v0.6.0 — Admin invite management + nav link + single-use tokens

### DIFF
--- a/kubernetes/main/apps/frontend/todos-for-dues/app/helmrelease.yaml
+++ b/kubernetes/main/apps/frontend/todos-for-dues/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           migrate:
             image: &mainImage
               repository: ghcr.io/thaynes43/todos-for-dues
-              tag: v0.5.0
+              tag: v0.6.0
               pullPolicy: IfNotPresent
             command:
               - tsx


### PR DESCRIPTION
## Summary
- Bumps todos-for-dues from v0.5.0 → v0.6.0.
- Includes PLAN-014: Admin invite-management UI + `/admin` nav link + single-use redemption security fix.
- No migrations or env-var changes vs v0.5.0 — schema-stable.

## Test plan
- [ ] CI on this PR green (Flux Local manifest validation if present).
- [ ] After merge: `flux reconcile source git haynes-ops -n flux-system` + `flux reconcile helmrelease todos-for-dues -n <ns>`.
- [ ] Pod becomes Ready on v0.6.0.
- [ ] Smoke (PLAN-009 §6): HTTP 200 on /, auth handler 4xx on bad payload, no test-only routes in prod, pod logs quiet on boot, chapter_settings rows present, migrate init clean (no-op).
- [ ] **PLAN-014-specific smoke:** signed-in Admin sees `/admin` link in top nav; `/admin/invites` route loads and shows empty state; mint generates a URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)