### PR TITLE
feat(todos-for-dues): bump v0.6.0 → v0.7.3 — /api/health probes + SDLC wrap-up

### DIFF
--- a/kubernetes/main/apps/frontend/todos-for-dues/app/helmrelease.yaml
+++ b/kubernetes/main/apps/frontend/todos-for-dues/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           migrate:
             image: &mainImage
               repository: ghcr.io/thaynes43/todos-for-dues
-              tag: v0.6.0
+              tag: v0.7.3
               pullPolicy: IfNotPresent
             command:
               - tsx
@@ -84,7 +84,7 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /
+                    path: /api/health
                     port: 3000
                   initialDelaySeconds: 15
                   periodSeconds: 30
@@ -95,7 +95,7 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /
+                    path: /api/health
                     port: 3000
                   initialDelaySeconds: 5
                   periodSeconds: 10
@@ -106,7 +106,7 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /
+                    path: /api/health
                     port: 3000
                   initialDelaySeconds: 5
                   periodSeconds: 5


### PR DESCRIPTION
## Summary
- Bumps todos-for-dues from v0.6.0 → v0.7.3.
- Bundles v0.7.0 (`/api/health` + probe-path bump + `RESEND_FROM_ADDRESS` fail-fast), v0.7.1 (hybrid release trigger), v0.7.2 (PAT auto-build verified), v0.7.3 (e2e infra wrap-up).
- No new migrations between v0.6.0 and v0.7.3. No new env vars.

## Test plan
- [ ] CI on this PR green (Flux Local manifest validation).
- [ ] Existing `RESEND_FROM_ADDRESS` env var in the live secret is non-placeholder (verified pre-deploy via kubectl exec).
- [ ] After merge: `flux reconcile source git haynes-ops -n flux-system` + `flux reconcile helmrelease todos-for-dues -n frontend`.
- [ ] New v0.7.3 pod becomes Ready (probes now hit `/api/health`).
- [ ] Smoke (PLAN-009 §6 + PLAN-013): HTTP 200 on `/`, `/api/health` returns `{ status: 'ok', db: true }`, pod logs quiet, `chapter_settings` populated, migrate init no-op.
- [ ] Live smoke spec passes all 3 cases (incl. `/api/health` which was the expected-fail against v0.6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)