### PR TITLE
feat(todos-for-dues): bump v0.7.3 → v0.8.0 — MVP-FIX-C wave

### DIFF
--- a/kubernetes/main/apps/frontend/todos-for-dues/app/helmrelease.yaml
+++ b/kubernetes/main/apps/frontend/todos-for-dues/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           migrate:
             image: &mainImage
               repository: ghcr.io/thaynes43/todos-for-dues
-              tag: v0.7.3
+              tag: v0.8.0
               pullPolicy: IfNotPresent
             command:
               - tsx


### PR DESCRIPTION
## Summary
- Bumps todos-for-dues from v0.7.3 → v0.8.0.
- Bundles MVP-FIX-A (PR #42 stale-UI fix), MVP-FIX-B (PR #43 UI polish), PRD-010 (PR #44 job content enrichment), PRD-011 (PR #45 editability), PRD-012 (PR #46 real-time SSE).
- TWO new migrations apply at first boot. No new env vars. Probe paths unchanged.

## Test plan
- [ ] CI on this PR green (Flux Local manifest validation).
- [ ] Existing `RESEND_FROM_ADDRESS` env var in the live secret is non-placeholder (verified pre-deploy via kubectl exec).
- [ ] After merge: `flux reconcile source git haynes-ops -n flux-system` + `flux reconcile helmrelease todos-for-dues -n frontend`.
- [ ] New v0.8.0 pod becomes Ready (probes still hit `/api/health`).
- [ ] Smoke (PLAN-009 §6 + PLAN-013): HTTP 200 on `/`, `/api/health` returns 200 healthy, `chapter_settings` populated, **migrate init applies 0009 + 0010 cleanly**.
- [ ] Live smoke spec passes 3/3.
- [ ] SSE keepalive verified via `curl -N` (Step 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)