### PR TITLE
fix(observability): scope NodeNetwork{Transmit,Receive}Errs to real NICs

### DIFF
--- a/kubernetes/main/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/main/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -29,6 +29,15 @@ spec:
     crds:
       enabled: false
     cleanPrometheusOperatorObjectNames: true
+    defaultRules:
+      # The stock node-exporter network-error rules watch EVERY interface,
+      # including virtual/tunnel devices (siderolink WireGuard, cilium_*, lxc*),
+      # which legitimately show TX/RX "errors" (e.g. WG encapsulation drops) and
+      # fire false positives. Disabled here and replaced with device-filtered
+      # versions in prometheusrule.yaml that only watch real NICs.
+      disabled:
+        NodeNetworkTransmitErrs: true
+        NodeNetworkReceiveErrs: true
     alertmanager:
       ingress:
         enabled: true

--- a/kubernetes/main/apps/observability/kube-prometheus-stack/app/prometheusrule.yaml
+++ b/kubernetes/main/apps/observability/kube-prometheus-stack/app/prometheusrule.yaml
@@ -32,3 +32,27 @@ spec:
           for: 15m
           labels:
             severity: critical
+    # Replaces the stock NodeNetworkTransmitErrs/ReceiveErrs (disabled in the
+    # HelmRelease defaultRules) — same expr but excludes virtual/tunnel devices
+    # (siderolink WireGuard, cilium_*, lxc*, veth*, etc.) that throw benign
+    # TX/RX "errors", so we only alert on real NICs (eth*/enp*).
+    - name: node-network
+      rules:
+        - alert: NodeNetworkTransmitErrs
+          annotations:
+            description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} transmit errors in the last two minutes.'
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodenetworktransmiterrs
+            summary: Network interface is reporting many transmit errors.
+          expr: rate(node_network_transmit_errs_total{job="node-exporter", device!~"siderolink|veth.*|cilium.*|lxc.*|cni.*|cali.*|tunl.*|wg.*|flannel.*|dummy.*|kube-ipvs.*|nodelocaldns.*"}[2m]) / rate(node_network_transmit_packets_total{job="node-exporter", device!~"siderolink|veth.*|cilium.*|lxc.*|cni.*|cali.*|tunl.*|wg.*|flannel.*|dummy.*|kube-ipvs.*|nodelocaldns.*"}[2m]) > 0.01
+          for: 1h
+          labels:
+            severity: warning
+        - alert: NodeNetworkReceiveErrs
+          annotations:
+            description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} receive errors in the last two minutes.'
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodenetworkreceiveerrs
+            summary: Network interface is reporting many receive errors.
+          expr: rate(node_network_receive_errs_total{job="node-exporter", device!~"siderolink|veth.*|cilium.*|lxc.*|cni.*|cali.*|tunl.*|wg.*|flannel.*|dummy.*|kube-ipvs.*|nodelocaldns.*"}[2m]) / rate(node_network_receive_packets_total{job="node-exporter", device!~"siderolink|veth.*|cilium.*|lxc.*|cni.*|cali.*|tunl.*|wg.*|flannel.*|dummy.*|kube-ipvs.*|nodelocaldns.*"}[2m]) > 0.01
+          for: 1h
+          labels:
+            severity: warning


### PR DESCRIPTION
Stock node-exporter network-error rules watch every interface, so they fire on the Omni SideroLink WireGuard tunnel (`siderolink`) — currently firing `NodeNetworkTransmitErrs` on m01 (~2% ratio, a benign control-tunnel artifact, surfaced after m01's reboot today). Disables the two stock rules (`defaultRules.disabled`) and adds device-filtered replacements that exclude virtual/tunnel interfaces while keeping alerting on real NICs (eth*/enp*).