### PR TITLE
feat(upgrade-agent): Tier-4 health gate (phase 4a)

### DIFF
--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/externalsecret.yaml
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/externalsecret.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Phase-4a gate secret: page channel (Pushover) + a read-only HA token ONLY.
+# NEVER add github-bot (the repo-write PEM) or anthropic here — those belong to the
+# SEPARATE 4b shepherd ExternalSecret, so the always-on gate can never mount a
+# write/LLM credential. Explicit per-field refs (no `extract`) so the gate's Secret
+# holds exactly these three keys and nothing else.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: upgrade-health-gate
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: upgrade-health-gate-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: PUSHOVER_TOKEN
+      remoteRef:
+        key: upgrade-gate
+        property: PUSHOVER_TOKEN
+    - secretKey: PUSHOVER_USER_KEY
+      remoteRef:
+        key: upgrade-gate
+        property: PUSHOVER_USER_KEY
+    # Read-only HA long-lived token, reused from the ha-mcp item (no new HA setup).
+    - secretKey: HASS_TOKEN
+      remoteRef:
+        key: ha-mcp
+        property: HOMEASSISTANT_TOKEN

--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/helmrelease.yaml
@@ -34,7 +34,6 @@ spec:
               PROMETHEUS_URL: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
               HA_URL: http://home-assistant.home-automation.svc.cluster.local:8123
               PERSIST_OFFSET: "10m"       # "still bad N ago" => persisted past one cycle => page
-              FLUX_STALE_SECONDS: "2700"  # GitRepository fetch older than this => Flux stopped pulling
             envFrom:
               - secretRef:
                   name: upgrade-health-gate-secret

--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/helmrelease.yaml
@@ -1,0 +1,74 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: upgrade-health-gate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  values:
+    controllers:
+      upgrade-health-gate:
+        type: cronjob
+        pod:
+          restartPolicy: Never
+        cronjob:
+          schedule: "*/30 * * * *"       # aligned to Flux's ~30-min GitRepository poll
+          concurrencyPolicy: Forbid
+          startingDeadlineSeconds: 300
+          backoffLimit: 0
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+        containers:
+          app:
+            image:
+              repository: ghcr.io/thaynes43/upgrade-agent
+              tag: 0.1.0@sha256:103c09f32f23412c3bf5e5f1919f5608142674110b1c2f499c64d425bbe34de4
+            # Deterministic gate: run the ConfigMap-mounted script directly. No LLM,
+            # no token, no git — read the six checks and page Pushover on a regression.
+            command: ["/bin/bash", "/opt/gate/gate.sh"]
+            env:
+              PROMETHEUS_URL: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+              HA_URL: http://home-assistant.home-automation.svc.cluster.local:8123
+              PERSIST_OFFSET: "10m"       # "still bad N ago" => persisted past one cycle => page
+              FLUX_STALE_SECONDS: "2700"  # GitRepository fetch older than this => Flux stopped pulling
+            envFrom:
+              - secretRef:
+                  name: upgrade-health-gate-secret
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+    defaultPodOptions:
+      # app-template v5 defaults automountServiceAccountToken to false; the gate's
+      # Flux CR reads (kubectl via the SA token) require it.
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+    serviceAccount:
+      upgrade-health-gate: {}
+    persistence:
+      gate-scripts:
+        type: configMap
+        name: upgrade-health-gate-scripts
+        defaultMode: 0555
+        globalMounts:
+          - path: /opt/gate
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/kustomization.yaml
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/common/repos/app-template
+resources:
+  - ./externalsecret.yaml
+  - ./rbac.yaml
+  - ./networkpolicy.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: upgrade-health-gate-scripts
+    files:
+      - resources/gate.sh
+      - resources/page.sh
+generatorOptions:
+  # Stable name so the HelmRelease can mount it by name.
+  disableNameSuffixHash: true
+  labels:
+    app.kubernetes.io/name: upgrade-health-gate

--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/networkpolicy.yaml
@@ -1,0 +1,65 @@
+---
+# CiliumNetworkPolicy (NOT vanilla NetworkPolicy — we need toFQDNs + toEntities).
+# The cluster has no other netpols, so selecting ONLY the gate pod creates a
+# default-deny egress *for this pod alone*, additively. enable-l7-proxy=true is live,
+# so toFQDNs + the L7 DNS rule work. Gate egress is the tightest set: DNS, apiserver,
+# Prometheus, HA, Pushover. NO GitHub, NO Anthropic — the gate never pushes or LLMs.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: upgrade-health-gate
+  namespace: upgrade-agent
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: upgrade-health-gate
+  egress:
+    # 1. DNS via CoreDNS (required for toFQDNs). Restricted to cluster-internal names
+    #    + the ONE allowlisted external, to close DNS-tunnel exfil.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*.cluster.local"
+              - matchPattern: "*.svc"
+              - matchName: "api.pushover.net"
+    # 2. Kube API server — the ONLY cluster read path (Flux CRs via kubectl).
+    - toEntities: [kube-apiserver]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "6443"
+              protocol: TCP
+    # 3. In-cluster Prometheus (checks 2-5 PromQL). NOT Loki/Grafana/Alertmanager.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+    # 4. Home Assistant REST (check 6).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home-automation
+            app.kubernetes.io/name: home-assistant
+      toPorts:
+        - ports:
+            - port: "8123"
+              protocol: TCP
+    # 5. Pushover — the INDEPENDENT external page channel (must not depend on the
+    #    in-cluster Alertmanager the gate monitors).
+    - toFQDNs:
+        - matchName: api.pushover.net
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+  # No ingress rules -> all ingress denied (the gate serves nothing).

--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/rbac.yaml
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/rbac.yaml
@@ -1,0 +1,68 @@
+---
+# Least-privilege identity for the Tier-4 upgrade health gate. READ-ONLY,
+# cluster-wide, get/list/watch ONLY — the tightest posture for an unattended pod.
+#
+# HARD DENIALS (do NOT add without re-review — each is a documented attack surface):
+#   * secrets   (any verb) -> the ESO check reads ExternalSecret .status only, never
+#                             Secret contents; granting it would expose the whole
+#                             HaynesKube vault (incl. the bot PEM). NEVER.
+#   * pods/exec (create)    -> arbitrary command in any pod = cluster takeover. Ceph
+#                             `ceph -s` toolbox exec is break-glass; the gate reads
+#                             Ceph health via Prometheus + the CephCluster CR instead.
+#   * pods/log             -> none of the checks read logs (they read STATUS); logs
+#                             routinely print secrets.
+#   * configmaps           -> not read by any check.
+#   * create/update/patch/delete on ANYTHING -> in particular NO patch on
+#                             kustomizations/helmreleases/gitrepositories (= flux
+#                             suspend/annotate/reconcile writes). The gate is
+#                             stateless, so it needs no write verb at all.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: &app upgrade-health-gate
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+rules:
+  # Check 2 (pod sweep) — names the offending pod; plus Warning events + node/ns context.
+  - apiGroups: [""]
+    resources: [pods, events, nodes, namespaces]
+    verbs: [get, list, watch]
+  # Check 1 (Flux) — the ONLY path (gotk_* metrics are not scraped here).
+  - apiGroups: [kustomize.toolkit.fluxcd.io]
+    resources: [kustomizations]
+    verbs: [get, list, watch]
+  - apiGroups: [helm.toolkit.fluxcd.io]
+    resources: [helmreleases]
+    verbs: [get, list, watch]
+  - apiGroups: [source.toolkit.fluxcd.io]
+    resources: [gitrepositories, ocirepositories, helmrepositories, helmcharts, buckets]
+    verbs: [get, list, watch]
+  # Check 3 (ESO) — ExternalSecret + ClusterSecretStore .status. NOT the Secrets.
+  - apiGroups: [external-secrets.io]
+    resources: [externalsecrets, clustersecretstores]
+    verbs: [get, list, watch]
+  # Check 5 (Ceph) — CephCluster .status.ceph.health (kubectl fallback for the promql).
+  - apiGroups: [ceph.rook.io]
+    resources: [cephclusters]
+    verbs: [get, list, watch]
+  # Bonus context — VolSync ReplicationSource results (checkHealth.sh parity).
+  - apiGroups: [volsync.backube]
+    resources: [replicationsources]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app upgrade-health-gate
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+subjects:
+  - kind: ServiceAccount
+    name: *app
+    namespace: upgrade-agent # MUST match the pod's namespace (else every read 403s)

--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/resources/gate.sh
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/resources/gate.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Deterministic Tier-4 upgrade health gate (phase 4a). READ + PAGE only, no LLM.
+# Runs the six upgrade-health-gate.md checks; pages ONLY on a regression that
+# persisted past one poll cycle (stateless: Prometheus `offset` + Flux
+# lastTransitionTime are the prior-state stores). Pages DIRECTLY to Pushover, so an
+# Alertmanager outage can't mute it. Always exits 0 (a Job failure is not the signal).
+set -uo pipefail
+
+GATE_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROM="${PROMETHEUS_URL:-http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090}"
+HA="${HA_URL:-http://home-assistant.home-automation.svc.cluster.local:8123}"
+OFFSET="${PERSIST_OFFSET:-10m}"
+FLUX_STALE="${FLUX_STALE_SECONDS:-2700}"
+REGRESSIONS=0
+NOW="$(date -u +%s)"
+
+log()  { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" >&2; }
+page() { "$GATE_DIR/page.sh" "$@"; REGRESSIONS=$((REGRESSIONS+1)); }
+
+# Prometheus instant query -> series count / first value / joined label values.
+prom_count() { curl -sf --max-time 15 "$PROM/api/v1/query" --data-urlencode "query=$1" 2>/dev/null | jq -r '.data.result | length' 2>/dev/null; }
+prom_val()   { curl -sf --max-time 15 "$PROM/api/v1/query" --data-urlencode "query=$1" 2>/dev/null | jq -r '.data.result[0].value[1] // "NaN"' 2>/dev/null; }
+prom_names() { curl -sf --max-time 15 "$PROM/api/v1/query" --data-urlencode "query=$1" 2>/dev/null | jq -r "[.data.result[].metric.$2] | unique | join(\",\")" 2>/dev/null; }
+gt0() { [ -n "$1" ] && [ "$1" -gt 0 ] 2>/dev/null; }
+
+# ---- Gate self-health: if we can reach NEITHER the API server NOR Prometheus we are
+#      blind — page a warning and bail so a silently-broken gate is never "green". ----
+kubectl version -o json >/dev/null 2>&1; API_OK=$?
+[ "$(prom_count 'vector(1)')" = "1" ]; PROM_OK=$?
+if [ "$API_OK" -ne 0 ] && [ "$PROM_OK" -ne 0 ]; then
+  page warning gate-blind self "Gate cannot reach the API server OR Prometheus — health unknown."
+  exit 0
+fi
+
+# ---- Check 1: Flux (kubectl ONLY — gotk_* unscraped). ks/HR NotReady past a settle
+#      window; and the flux-system GitRepository must be Ready + freshly fetched. ----
+if [ "$API_OK" -eq 0 ]; then
+  for kind in kustomizations.kustomize.toolkit.fluxcd.io helmreleases.helm.toolkit.fluxcd.io; do
+    bad="$(kubectl get "$kind" -A -o json 2>/dev/null | jq -r --argjson now "$NOW" '
+      .items[] | . as $i
+      | ( .status.conditions[]? | select(.type=="Ready" and .status!="True") ) as $c
+      | ( $c.lastTransitionTime | sub("\\.[0-9]+";"") | fromdateiso8601 ) as $t
+      | select( ($now - $t) > 600 )
+      | "\($i.metadata.namespace)/\($i.metadata.name): \($c.message // "not ready")"' 2>/dev/null)"
+    [ -n "$bad" ] && page critical flux "${kind%%.*}" "NotReady >10m: $(echo "$bad" | head -3 | tr '\n' ';')"
+  done
+  gr="$(kubectl -n flux-system get gitrepository flux-system -o json 2>/dev/null)"
+  gr_ready="$(echo "$gr" | jq -r '.status.conditions[]? | select(.type=="Ready") | .status' 2>/dev/null)"
+  gr_ts="$(echo "$gr" | jq -r '.status.artifact.lastUpdateTime // empty | sub("\\.[0-9]+";"") | fromdateiso8601' 2>/dev/null)"
+  if [ -z "$gr_ready" ]; then
+    page warning flux-blind flux-system "Cannot read flux-system GitRepository status — Flux dimension is blind."
+  elif [ "$gr_ready" != "True" ]; then
+    page critical flux flux-system "flux-system GitRepository Ready=$gr_ready (fetch failing)."
+  elif [ -n "$gr_ts" ] && [ "$((NOW - gr_ts))" -gt "$FLUX_STALE" ]; then
+    page critical flux flux-system "flux-system GitRepository last fetch >${FLUX_STALE}s ago — Flux stopped pulling main."
+  fi
+fi
+
+if [ "$PROM_OK" -eq 0 ]; then
+  # ---- Check 2: pods bad NOW and at offset (persisted past a cycle) => regression. ----
+  waiting='kube_pod_container_status_waiting_reason{reason=~"CrashLoopBackOff|ImagePullBackOff|ErrImagePull|CreateContainerError|CreateContainerConfigError"} == 1'
+  phase='kube_pod_status_phase{phase=~"Pending|Failed|Unknown"} == 1'
+  q_pods="( (${waiting}) or (${phase}) ) and ( (${waiting}) or (${phase}) ) offset ${OFFSET}"
+  gt0 "$(prom_count "$q_pods")" && page critical pods "$(prom_names "$q_pods" pod)" "Pod(s) unhealthy now AND ${OFFSET} ago (persisted): $(prom_names "$q_pods" pod)"
+
+  # ---- Check 3: ExternalSecret Ready=False persisted past a cycle. ----
+  q_eso='(externalsecret_status_condition{condition="Ready",status="False"} == 1) and (externalsecret_status_condition{condition="Ready",status="False"} offset '"$OFFSET"' == 1)'
+  gt0 "$(prom_count "$q_eso")" && page critical eso "$(prom_names "$q_eso" name)" "ExternalSecret(s) Ready=False, persisted ${OFFSET}: $(prom_names "$q_eso" name)"
+
+  # ---- Check 4: any firing severity=critical (already 'for:'-debounced by the rules). ----
+  q_crit='ALERTS{alertstate="firing",severity="critical"}'
+  gt0 "$(prom_count "$q_crit")" && page critical alerts "$(prom_names "$q_crit" alertname)" "Firing severity=critical: $(prom_names "$q_crit" alertname)"
+
+  # ---- Check 5: Ceph HEALTH_ERR (==2) pages; WARN (==1) is a benign note. ----
+  ceph="$(prom_val 'ceph_health_status')"
+  if [ "$ceph" = "2" ]; then
+    page critical ceph rook-ceph "Ceph HEALTH_ERR (ceph_health_status==2). Ceph majors are forward-only — a git revert does NOT recover the data plane."
+  elif [ "$ceph" = "1" ]; then
+    log "note: ceph HEALTH_WARN (==1) — benign unless a NEW OSD/PG/mon fault (see runbook allowlist)."
+  fi
+fi
+
+# ---- Check 6: Home Assistant availability (only if HASS_TOKEN is set). ----
+if [ -n "${HASS_TOKEN:-}" ]; then
+  hastate() { curl -sf --max-time 10 -H "Authorization: Bearer $HASS_TOKEN" "$HA/api/states/$1" 2>/dev/null | jq -r '.state // "ERR"' 2>/dev/null; }
+  z2m="$(hastate binary_sensor.zigbee2mqtt_bridge_connection_state)"
+  [ "$z2m" = "off" ] && page critical ha zigbee2mqtt "Zigbee2MQTT bridge connection == off (mesh down / Z2M-HA restart race)."
+  for lk in front_door_lock side_door_lock bulkhead_lock mudroom_door_lock; do
+    st="$(hastate "lock.$lk")"
+    case "$st" in unavailable|unknown) page critical ha "lock.$lk" "Door lock lock.$lk == $st." ;; esac
+  done
+  # Spa (Gecko in.touch3) is chronically flaky over RF — benign, deliberately NOT paged.
+fi
+
+# ---- Dead-man's-switch: a successful cycle pings the heartbeat (if configured). ----
+[ -n "${GATE_HEARTBEAT_URL:-}" ] && curl -fsS --max-time 10 "$GATE_HEARTBEAT_URL" >/dev/null 2>&1
+log "gate cycle complete: regressions=$REGRESSIONS"
+exit 0

--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/resources/gate.sh
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/resources/gate.sh
@@ -10,7 +10,6 @@ GATE_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROM="${PROMETHEUS_URL:-http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090}"
 HA="${HA_URL:-http://home-assistant.home-automation.svc.cluster.local:8123}"
 OFFSET="${PERSIST_OFFSET:-10m}"
-FLUX_STALE="${FLUX_STALE_SECONDS:-2700}"
 REGRESSIONS=0
 NOW="$(date -u +%s)"
 
@@ -44,15 +43,17 @@ if [ "$API_OK" -eq 0 ]; then
       | "\($i.metadata.namespace)/\($i.metadata.name): \($c.message // "not ready")"' 2>/dev/null)"
     [ -n "$bad" ] && page critical flux "${kind%%.*}" "NotReady >10m: $(echo "$bad" | head -3 | tr '\n' ';')"
   done
-  gr="$(kubectl -n flux-system get gitrepository flux-system -o json 2>/dev/null)"
+  # The GitRepository is named 'haynes-ops' (in ns flux-system). Ready=False is the
+  # reliable "Flux can't fetch main" signal (auth/repo failure). We deliberately do
+  # NOT staleness-check artifact.lastUpdateTime: it only advances on a CONTENT change,
+  # so a quiet period with no commits would false-page. A wedged/down source-controller
+  # surfaces via the pod sweep + NotReady kustomizations instead.
+  gr="$(kubectl -n flux-system get gitrepository haynes-ops -o json 2>/dev/null)"
   gr_ready="$(echo "$gr" | jq -r '.status.conditions[]? | select(.type=="Ready") | .status' 2>/dev/null)"
-  gr_ts="$(echo "$gr" | jq -r '.status.artifact.lastUpdateTime // empty | sub("\\.[0-9]+";"") | fromdateiso8601' 2>/dev/null)"
   if [ -z "$gr_ready" ]; then
-    page warning flux-blind flux-system "Cannot read flux-system GitRepository status — Flux dimension is blind."
+    page warning flux-blind haynes-ops "Cannot read the haynes-ops GitRepository status — Flux source dimension is blind."
   elif [ "$gr_ready" != "True" ]; then
-    page critical flux flux-system "flux-system GitRepository Ready=$gr_ready (fetch failing)."
-  elif [ -n "$gr_ts" ] && [ "$((NOW - gr_ts))" -gt "$FLUX_STALE" ]; then
-    page critical flux flux-system "flux-system GitRepository last fetch >${FLUX_STALE}s ago — Flux stopped pulling main."
+    page critical flux haynes-ops "haynes-ops GitRepository Ready=$gr_ready — Flux can't fetch main (auth/repo failure)."
   fi
 fi
 

--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/resources/page.sh
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/resources/page.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Direct Pushover page — the gate's INDEPENDENT alert channel (does not route through
+# the in-cluster Alertmanager the gate monitors). Never echoes the token.
+# Usage: page.sh <severity> <check> <component> <summary>
+set -u
+SEV="${1:?severity}"; CHECK="${2:?check}"; COMP="${3:-unknown}"; SUM="${4:?summary}"
+: "${PUSHOVER_TOKEN:?PUSHOVER_TOKEN unset}"; : "${PUSHOVER_USER_KEY:?PUSHOVER_USER_KEY unset}"
+
+# critical -> priority 1 (breaks through quiet hours); else 0.
+prio=0; [ "$SEV" = "critical" ] && prio=1
+
+if curl -sf --max-time 10 https://api.pushover.net/1/messages.json \
+     --form-string "token=${PUSHOVER_TOKEN}" \
+     --form-string "user=${PUSHOVER_USER_KEY}" \
+     --form-string "title=[upgrade-gate] ${SEV} ${CHECK}/${COMP}" \
+     --form-string "message=${SUM}" \
+     --form-string "priority=${prio}" >/dev/null; then
+  printf 'paged: %s %s/%s — %s\n' "$SEV" "$CHECK" "$COMP" "$SUM" >&2
+else
+  printf 'PAGE FAILED: %s %s/%s\n' "$SEV" "$CHECK" "$COMP" >&2
+fi

--- a/kubernetes/main/apps/upgrade-agent/health-gate/ks.yaml
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app upgrade-health-gate
+  namespace: upgrade-agent
+spec:
+  targetNamespace: upgrade-agent
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/main/apps/upgrade-agent/health-gate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/main/apps/upgrade-agent/kustomization.yaml
+++ b/kubernetes/main/apps/upgrade-agent/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Pre Flux-Kustomizations
+  - ./namespace.yaml
+  # Flux-Kustomizations
+  - ./health-gate/ks.yaml

--- a/kubernetes/main/apps/upgrade-agent/namespace.yaml
+++ b/kubernetes/main/apps/upgrade-agent/namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: upgrade-agent
+  labels:
+    # The credential-bearing Tier-4 agent gets a TIGHTER boundary than the
+    # privileged app namespaces — Pod Security Admission "restricted".
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Tier-4 in-cluster health gate — phase 4a (watch + page)

Deterministic, credential-minimal health gate. Runs every 30m, reads the six
`upgrade-health-gate.md` checks (Flux / pods / ESO / alerts / Ceph / HA), and pages
**Pushover directly** on a regression that persisted past one poll cycle. **No LLM,
no bot key, no Anthropic key** — read + page only.

### Security posture (per the adversarial design review)
- **Read-only** ClusterRole (get/list/watch only): **no** `secrets`, `pods/exec`,
  `pods/log`, or any write verb. Stateless (Flux `lastTransitionTime` + Prometheus
  `offset`) → no write access at all.
- Dedicated `upgrade-agent` namespace at **PSA restricted**; `runAsNonRoot` 65534,
  `readOnlyRootFilesystem`, drop ALL caps, seccomp RuntimeDefault.
- **CiliumNetworkPolicy** egress-allowlist: DNS / apiserver / Prometheus / HA /
  Pushover only — **no GitHub, no Anthropic**.
- Minimal image (`kubectl`/`jq`/`curl`/`bash`), pinned by digest.

### Validated against the live cluster
Service URLs, CoreDNS + HA labels, the `zigbee2mqtt` bridge entity, and the
`externalsecret_status_condition` metric all confirmed.

### Deploy prerequisites
- Image built ✅ (`ghcr.io/thaynes43/upgrade-agent@sha256:103c09f3…`).
- 1Password `upgrade-gate` item (Pushover) created ✅.

Design + rationale: `docs/renovate/README.md` Tier 4, `.agents/runbooks/upgrade-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)