### PR TITLE
feat(upgrade-shepherd): Tier-4 breaking-change shepherd (4b.1, summoned)

### DIFF
--- a/kubernetes/main/apps/upgrade-agent/kustomization.yaml
+++ b/kubernetes/main/apps/upgrade-agent/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./namespace.yaml
   # Flux-Kustomizations
   - ./health-gate/ks.yaml
+  - ./shepherd/ks.yaml

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/externalsecret.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/externalsecret.yaml
@@ -1,0 +1,44 @@
+---
+# TWO separate secrets, deliberately, so the LLM (main) container can mount the
+# Anthropic key WITHOUT ever mounting the bot PEM:
+#   - upgrade-shepherd-bot-secret : the github-bot PEM + IDs. Mounted ONLY by the
+#     initContainer, which mints a short-lived ghs_ token and hands ONLY that token
+#     to the main container via a shared emptyDir. The PEM never enters the LLM env.
+#   - upgrade-shepherd-llm-secret : the Anthropic key. Mounted ONLY by the main
+#     (LLM) container.
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: upgrade-shepherd-bot
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: upgrade-shepherd-bot-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: GITHUB_BOT_APP_ID
+      remoteRef: { key: github-bot, property: GITHUB_BOT_APP_ID }
+    - secretKey: GITHUB_BOT_APP_CLIENT_ID
+      remoteRef: { key: github-bot, property: GITHUB_BOT_APP_CLIENT_ID }
+    - secretKey: GITHUB_BOT_APP_INSTALLATION_ID
+      remoteRef: { key: github-bot, property: GITHUB_BOT_APP_INSTALLATION_ID }
+    - secretKey: GITHUB_BOT_APP_PRIVATE_KEY
+      remoteRef: { key: github-bot, property: GITHUB_BOT_APP_PRIVATE_KEY }
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: upgrade-shepherd-llm
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: upgrade-shepherd-llm-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: ANTHROPIC_API_KEY
+      remoteRef: { key: anthropic, property: ANTHROPIC_API_KEY }

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
@@ -1,0 +1,108 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: upgrade-shepherd
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  values:
+    controllers:
+      upgrade-shepherd:
+        type: cronjob
+        # SUSPENDED — never auto-runs. Summon it (supervised) with:
+        #   kubectl -n upgrade-agent create job shep-$(date +%s) --from=cronjob/upgrade-shepherd
+        # Default UPGRADE_AGENT_MODE=dryrun (read-only). Set MODE=shepherd for the real
+        # edit+PR run once you trust it. NEVER unattended before the 4b.2 guardrails.
+        cronjob:
+          suspend: true
+          schedule: "0 0 31 2 *"        # 31 Feb — never fires
+          concurrencyPolicy: Forbid
+          backoffLimit: 0
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+        pod:
+          restartPolicy: Never
+        initContainers:
+          # Mint a short-lived (1h) installation token from the bot PEM and hand ONLY
+          # the token to the main container via the shared /creds emptyDir. The PEM
+          # lives ONLY in this initContainer's env — never in the LLM container.
+          mint-token:
+            image:
+              repository: ghcr.io/thaynes43/upgrade-shepherd
+              tag: 0.1.0@sha256:b40eb95ae478021e3bb49e9a1514bf437cb7286c5d79765b5a1f6f9d73b61051
+            command:
+              - /bin/bash
+              - -c
+              - /opt/upgrade-shepherd/github-app-token.sh > /creds/gh_token && chmod 0400 /creds/gh_token
+            env:
+              # Down-scope to exactly what opening a PR needs — NOT merge-capable at
+              # the endpoint level is impossible (GitHub bundles merge into PRs:write),
+              # so merge-prevention is enforced by the run script's allowlist.
+              GITHUB_BOT_TOKEN_PERMISSIONS: '{"contents":"write","pull_requests":"write","checks":"read"}'
+            envFrom:
+              - secretRef:
+                  name: upgrade-shepherd-bot-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+        containers:
+          app:
+            image:
+              repository: ghcr.io/thaynes43/upgrade-shepherd
+              tag: 0.1.0@sha256:b40eb95ae478021e3bb49e9a1514bf437cb7286c5d79765b5a1f6f9d73b61051
+            command: ["/bin/bash", "/opt/shepherd/run-shepherd.sh"]
+            env:
+              UPGRADE_AGENT_MODE: dryrun   # override to 'shepherd' for the real edit+PR run
+              UPGRADE_AGENT_MODEL: sonnet
+              # ANTHROPIC_API_KEY comes from the LLM secret ONLY (never the bot secret).
+              ANTHROPIC_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: upgrade-shepherd-llm-secret
+                    key: ANTHROPIC_API_KEY
+            resources:
+              requests:
+                cpu: 200m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+    defaultPodOptions:
+      automountServiceAccountToken: true   # read-only cluster diagnosis via the SA
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+    serviceAccount:
+      upgrade-shepherd: {}
+    persistence:
+      # Minted token handoff (init writes, main reads) — shared, in-memory.
+      creds:
+        type: emptyDir
+        medium: Memory
+        globalMounts:
+          - path: /creds
+      # The auditable run script (ConfigMap).
+      shepherd-scripts:
+        type: configMap
+        name: upgrade-shepherd-scripts
+        defaultMode: 0555
+        globalMounts:
+          - path: /opt/shepherd
+      # HOME + CLAUDE_CONFIG_DIR + the shallow clone (readOnlyRootFilesystem).
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/kustomization.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/common/repos/app-template
+resources:
+  - ./externalsecret.yaml
+  - ./rbac.yaml
+  - ./networkpolicy.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: upgrade-shepherd-scripts
+    files:
+      - resources/run-shepherd.sh
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    app.kubernetes.io/name: upgrade-shepherd

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/networkpolicy.yaml
@@ -1,0 +1,64 @@
+---
+# CiliumNetworkPolicy for the shepherd pod: the gate's read egress (DNS, apiserver,
+# Prometheus) PLUS GitHub (clone/push/PRs, release notes) and Anthropic (the LLM).
+# Default-deny for everything else. This is the exfil boundary for a prompt-injectable
+# LLM: even if talked into it, it can only reach github/anthropic/cluster-read.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: upgrade-shepherd
+  namespace: upgrade-agent
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: upgrade-shepherd
+  egress:
+    # 1. DNS via CoreDNS (required for toFQDNs). Only cluster-internal + the exact
+    #    external names the shepherd needs — closes DNS-tunnel exfil.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*.cluster.local"
+              - matchPattern: "*.svc"
+              - matchPattern: "*.github.com"
+              - matchPattern: "*.githubusercontent.com"
+              - matchName: "api.anthropic.com"
+    # 2. Kube API server — read-only diagnosis (kubectl get/describe, flux get).
+    - toEntities: [kube-apiserver]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "6443"
+              protocol: TCP
+    # 3. In-cluster Prometheus — mode-2 diagnosis queries.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP
+    # 4. GitHub — git clone/push, gh PRs, gh release view (release notes).
+    - toFQDNs:
+        - matchPattern: "*.github.com"
+        - matchPattern: "*.githubusercontent.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # 5. Anthropic — the LLM API.
+    - toFQDNs:
+        - matchName: api.anthropic.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+  # No ingress rules -> all ingress denied.

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/rbac.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/rbac.yaml
@@ -1,0 +1,20 @@
+---
+# The shepherd VERIFIES/diagnoses read-only — its only WRITE path is git push -> a PR
+# -> Flux (never a direct cluster write). So it reuses the gate's read-only ClusterRole
+# `upgrade-health-gate` (get/list/watch only; no secrets/exec/log/write) via a new
+# binding for the shepherd's own ServiceAccount. No new permissions are granted.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app upgrade-shepherd
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: upgrade-health-gate # the shared read-only role (defined by the gate)
+subjects:
+  - kind: ServiceAccount
+    name: *app
+    namespace: upgrade-agent

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/run-shepherd.sh
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/run-shepherd.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Tier-4 breaking-change shepherd — main-container entrypoint (phase 4b.1, summoned).
+# Mounted from a ConfigMap so the tool allowlist + prompt are auditable in every PR
+# diff (not hidden in an image layer).
+#
+# CONTAINMENT (defense-in-depth; the LLM is prompt-injectable — it reads release notes):
+#   - Read-only k8s SA (get/list/watch; no secrets/exec/write) — verify only.
+#   - Egress CiliumNetworkPolicy: GitHub + Anthropic + cluster-read ONLY.
+#   - The bot PEM is NEVER here — an initContainer minted a short-lived ghs_ token to
+#     /creds/gh_token; this container only sees that token (contents+PRs:write, 1h TTL).
+#   - --permission-mode dontAsk + an explicit --allowedTools allowlist (auto-denies
+#     everything else). NO `gh pr merge`, NO WebFetch/WebSearch, NO kubectl write.
+#   - DRY-RUN by default: makes NO changes. Set UPGRADE_AGENT_MODE=shepherd to enable
+#     edits + PR authorship.
+#
+# KNOWN 4b.1 GAP (closed by the 4b.2 guardrails): the token has contents:write, so a
+# rogue/injected agent could in principle `git push` straight to main. 4b.1 is
+# SUMMONED + SUPERVISED (a human triggers this Job and watches). Do NOT run it
+# unattended until the Kyverno admission baseline + diff-scope check + push protection
+# land. `gh pr merge` is already blocked here regardless.
+set -uo pipefail
+
+MODE="${UPGRADE_AGENT_MODE:-dryrun}"
+MODEL="${UPGRADE_AGENT_MODEL:-sonnet}"
+MAX_TURNS="${UPGRADE_AGENT_MAX_TURNS:-40}"
+MAX_BUDGET="${UPGRADE_AGENT_MAX_BUDGET_USD:-5.00}"
+RUN_TIMEOUT="${UPGRADE_AGENT_TIMEOUT:-20m}"
+REPO="thaynes43/haynes-ops"
+WORKDIR="${HOME}/repo"
+
+log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" >&2; }
+
+# Quiet claude-code's phone-home (the egress CNP would block it anyway).
+export DISABLE_TELEMETRY=1 CLAUDE_CODE_ENABLE_TELEMETRY=0 \
+       DISABLE_ERROR_REPORTING=1 DISABLE_AUTOUPDATER=1 DISABLE_NON_ESSENTIAL_MODEL_CALLS=1
+
+: "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY unset (llm secret not mounted?)}"
+[ -s /creds/gh_token ] || { log "FATAL: /creds/gh_token missing — initContainer token mint failed"; exit 1; }
+GH_TOKEN="$(cat /creds/gh_token)"; export GH_TOKEN
+# Assert the PEM did NOT leak into this (the LLM) container.
+if [ -n "${GITHUB_BOT_APP_PRIVATE_KEY:-}" ]; then
+  log "FATAL: bot PEM present in the LLM container env — refusing to run."; exit 3
+fi
+
+git config --global user.name  "haynes-ops-bot[bot]"
+git config --global user.email "haynes-ops-bot[bot]@users.noreply.github.com"
+git config --global safe.directory "${WORKDIR}"
+
+log "cloning ${REPO} (shallow)…"
+rm -rf "${WORKDIR}"
+git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "${WORKDIR}" >&2 || {
+  log "FATAL: clone failed (token/egress?)"; exit 1; }
+cd "${WORKDIR}"
+
+# ── Tool allowlist + task, per mode. dontAsk auto-denies anything NOT listed. ──
+READONLY_TOOLS=(Read Grep Glob
+  "Bash(git log:*)" "Bash(git diff:*)" "Bash(git show:*)" "Bash(git status:*)"
+  "Bash(gh pr list:*)" "Bash(gh pr view:*)" "Bash(gh pr diff:*)" "Bash(gh pr checks:*)"
+  "Bash(gh release view:*)" "Bash(gh release list:*)" "Bash(gh api repos/thaynes43/*)"
+  "Bash(kubectl get:*)" "Bash(kubectl describe:*)" "Bash(flux get:*)" "Bash(grep:*)" "Bash(cat:*)")
+WRITE_TOOLS=(Edit Write
+  "Bash(git switch:*)" "Bash(git checkout -b:*)" "Bash(git add:*)" "Bash(git commit:*)"
+  "Bash(git push:*)" "Bash(gh pr create:*)" "Bash(gh pr comment:*)")
+
+if [ "$MODE" = "shepherd" ]; then
+  ALLOWED=("${READONLY_TOOLS[@]}" "${WRITE_TOOLS[@]}")
+  PROMPT="${UPGRADE_AGENT_PROMPT:-You are the Tier-4 upgrade shepherd. Follow .agents/runbooks/upgrade-shepherd.md exactly. Survey open manual-tier Renovate PRs (gh pr list); pick the NEXT one by the runbook merge-order. CONSULT .renovate/holds.json5 first (skip if held). Read the release notes (gh release view) and the component's section in .agents/runbooks/tier4-component-playbooks.md. Make the required supporting helmrelease/values edits on a NEW branch shepherd/<pkg>-<version>, commit, push, and open a PR with gh pr create. Do NOT merge, do NOT push to main, do NOT touch anything outside kubernetes/**. One PR only, then stop and summarize.}"
+else
+  ALLOWED=("${READONLY_TOOLS[@]}")
+  PROMPT="${UPGRADE_AGENT_PROMPT:-DRY RUN — make NO changes. You are the Tier-4 upgrade shepherd. Survey open manual-tier Renovate PRs (gh pr list) and, for the next one per .agents/runbooks/upgrade-shepherd.md, REPORT: is it held (.renovate/holds.json5)? what supporting helmrelease/values edits would it need (per tier4-component-playbooks.md)? Output a concise plan. Do NOT edit files, push, or open PRs.}"
+fi
+
+log "MODE=$MODE model=$MODEL max_turns=$MAX_TURNS budget=\$$MAX_BUDGET"
+set +e
+timeout "$RUN_TIMEOUT" claude -p "$PROMPT" \
+  --permission-mode dontAsk \
+  --allowedTools "${ALLOWED[@]}" \
+  --disallowedTools "WebFetch" "WebSearch" \
+  --append-system-prompt "SAFETY: read-only cluster default; ALL cluster changes go via a PR to kubernetes/**; NEVER kubectl apply/exec/delete; NEVER 'gh pr merge'; NEVER push to main; stay inside kubernetes/**." \
+  --max-turns "$MAX_TURNS" \
+  --max-budget-usd "$MAX_BUDGET" \
+  --model "$MODEL" \
+  --output-format json
+rc=$?
+set -e 2>/dev/null || true
+log "claude exited rc=$rc"
+exit "$rc"

--- a/kubernetes/main/apps/upgrade-agent/shepherd/ks.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/ks.yaml
@@ -24,6 +24,6 @@ spec:
   wait: true
   interval: 30m
   timeout: 5m
-  postBuild:
-    substitute:
-      APP: *app
+  # NO postBuild.substitute: Flux envsubst would rewrite the shell `${VAR:-default}`
+  # in run-shepherd.sh (breaking the MODE override) and errors on `${ARRAY[@]}`.
+  # These manifests use YAML anchors, not `${APP}`, so no substitution is needed.

--- a/kubernetes/main/apps/upgrade-agent/shepherd/ks.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app upgrade-shepherd
+  namespace: upgrade-agent
+spec:
+  targetNamespace: upgrade-agent
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: upgrade-health-gate # reuse its read-only ClusterRole
+      namespace: upgrade-agent
+  path: ./kubernetes/main/apps/upgrade-agent/shepherd/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app


### PR DESCRIPTION
Phase 4b.1 — the LLM shepherd (summoned/dry-run-default, PR-only). initContainer token-mint keeps the PEM out of the LLM container; `dontAsk` + allowlist (no `gh pr merge`, no web); egress-CNP to GitHub+Anthropic+cluster-read; reuses the gate's read-only role. Suspended CronJob — deploys inert until summoned. Known 4b.1 gap (contents:write can push to main) is closed by the 4b.2 guardrails; run supervised only until then. 🤖 Generated with [Claude Code](https://claude.com/claude-code)