### PR TITLE
feat(kyverno,ci): Tier-4 4b.2 Phase A — Kyverno (audit) + diff-scope (advisory)

### DIFF
--- a/.github/workflows/diff-scope.yml
+++ b/.github/workflows/diff-scope.yml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# Phase 4b.2 guardrail (b): diff-scope — the PRIMARY gate for shepherd auto-merge.
+#
+# PHASE A: ADVISORY (not a required check yet) — it runs on every PR and reports its
+# verdict in the Step Summary so we can observe its behaviour on real Renovate/human/
+# shepherd PRs before making it required in Phase B.
+#
+# Runs UNCONDITIONALLY on every PR to main AND edge (no path filter) so the
+# "Diff Scope - Success" context always reports. AUTHOR-SCOPED: it only FAILS for PRs
+# authored by the shepherd App (haynes-ops-bot[bot]); it always passes for
+# renovate[bot] and the human (trusted / admin-bypass). The enforcement logic is
+# fetched from the BASE branch so a PR that edits the script can't neuter its own
+# check. This YAML is un-editable by the bot (no Workflows scope).
+name: Diff Scope
+
+on:
+  pull_request:
+    branches: [main, edge]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scope:
+    name: Diff Scope - Success
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch base branch
+        run: git fetch --no-tags origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - name: Run diff-scope (from BASE — tamper-proof), gate by author
+        env:
+          DIFF_SCOPE_BASE_BRANCH: ${{ github.base_ref }}
+          DIFF_SCOPE_REMOTE: origin
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -uo pipefail
+          # Execute the trusted BASE version of the script, never the PR's copy.
+          git show "origin/${DIFF_SCOPE_BASE_BRANCH}:scripts/diff-scope.sh" > /tmp/diff-scope.base.sh
+          bash /tmp/diff-scope.base.sh; rc=$?
+          echo "diff-scope exit=${rc} author=${PR_AUTHOR}"
+          if [ "${PR_AUTHOR}" = "haynes-ops-bot[bot]" ]; then
+            echo "Author is the shepherd bot — enforcing (advisory in Phase A)."
+            exit "${rc}"
+          fi
+          echo "Author '${PR_AUTHOR}' is trusted (renovate/human) — reporting success."
+          exit 0

--- a/.github/workflows/diff-scope.yml
+++ b/.github/workflows/diff-scope.yml
@@ -45,9 +45,17 @@ jobs:
           DIFF_SCOPE_REMOTE: origin
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          set -uo pipefail
-          # Execute the trusted BASE version of the script, never the PR's copy.
-          git show "origin/${DIFF_SCOPE_BASE_BRANCH}:scripts/diff-scope.sh" > /tmp/diff-scope.base.sh
+          # GitHub invokes `run:` with `bash -e`; disable errexit so we handle the
+          # git-show / diff-scope exit codes explicitly (an -e abort would bypass the
+          # author gate and fail on trusted/human PRs).
+          set +e -u -o pipefail
+          # Execute the trusted BASE version of the script, never the PR's copy. If the
+          # base branch has no diff-scope.sh yet (the bootstrap PR that adds it), there
+          # is nothing to enforce from base -> report success; future PRs have it on base.
+          if ! git show "origin/${DIFF_SCOPE_BASE_BRANCH}:scripts/diff-scope.sh" > /tmp/diff-scope.base.sh 2>/dev/null; then
+            echo "diff-scope: not present on base '${DIFF_SCOPE_BASE_BRANCH}' (bootstrap) — reporting success."
+            exit 0
+          fi
           bash /tmp/diff-scope.base.sh; rc=$?
           echo "diff-scope exit=${rc} author=${PR_AUTHOR}"
           if [ "${PR_AUTHOR}" = "haynes-ops-bot[bot]" ]; then

--- a/kubernetes/main/apps/kyverno/kustomization.yaml
+++ b/kubernetes/main/apps/kyverno/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Pre Flux-Kustomizations
+  - ./namespace.yaml
+  # Flux-Kustomizations
+  - ./kyverno/ks.yaml
+  - ./policies/ks.yaml

--- a/kubernetes/main/apps/kyverno/kyverno/app/helmrelease.yaml
+++ b/kubernetes/main/apps/kyverno/kyverno/app/helmrelease.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kyverno
+spec:
+  interval: 30m
+  timeout: 15m
+  chartRef:
+    kind: OCIRepository
+    name: kyverno
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    # HA so admission is not a single point of failure.
+    admissionController:
+      replicas: 2
+      container:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 512Mi
+    backgroundController:
+      replicas: 1
+    reportsController:
+      replicas: 1
+    cleanupController:
+      replicas: 1
+    features:
+      # PolicyExceptions ONLY creatable in the kyverno namespace (GHSA-qjvc-p88j-j9rm)
+      # — otherwise the shepherd could commit a self-exempting exception anywhere.
+      policyExceptions:
+        enabled: true
+        namespace: kyverno
+    config:
+      # Exclude ONLY Kyverno's own components from admission — NOT flux-system/
+      # kube-system (the two highest-value namespaces the shepherd could target).
+      excludeKyvernoNamespace: true

--- a/kubernetes/main/apps/kyverno/kyverno/app/kustomization.yaml
+++ b/kubernetes/main/apps/kyverno/kyverno/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/main/apps/kyverno/kyverno/app/ocirepository.yaml
+++ b/kubernetes/main/apps/kyverno/kyverno/app/ocirepository.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kyverno
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # MANUAL merge only — a bad Kyverno chart bump is a cluster-wide admission
+    # outage. NEVER add kyverno/** to a Tier-2 autoMerge domain glob; held in
+    # .renovate/holds.json5 against a future glob sweep.
+    tag: 3.8.1
+  url: oci://ghcr.io/kyverno/charts/kyverno

--- a/kubernetes/main/apps/kyverno/kyverno/ks.yaml
+++ b/kubernetes/main/apps/kyverno/kyverno/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kyverno
+  namespace: kyverno
+spec:
+  targetNamespace: kyverno
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/main/apps/kyverno/kyverno/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 15m

--- a/kubernetes/main/apps/kyverno/namespace.yaml
+++ b/kubernetes/main/apps/kyverno/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyverno
+  labels:
+    # Kyverno is a trusted system controller; its own ns is excluded from admission
+    # (excludeKyvernoNamespace: true). PSA privileged to avoid gating its components.
+    pod-security.kubernetes.io/enforce: privileged
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/main/apps/kyverno/policies/app/exceptions/multus-rbac.yaml
+++ b/kubernetes/main/apps/kyverno/policies/app/exceptions/multus-rbac.yaml
@@ -1,0 +1,26 @@
+---
+# multus ships a legitimate wildcard ClusterRole (resources:"*"/verbs:"*", verified at
+# network/multus/app/rbac.yaml). It is cluster-scoped, so a namespace exclude does NOT
+# cover it — exempt it by NAME. PolicyException lives in the kyverno namespace
+# (features.policyExceptions.namespace: kyverno). In Phase A (audit) this just removes
+# the already-known multus noise from the report; enumerate the rest from the report
+# before Phase C enforce.
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: multus-wildcard-clusterrole
+  namespace: kyverno
+spec:
+  exceptions:
+    - policyName: restrict-rbac-escalation
+      ruleNames:
+        - no-wildcard-or-escalate-role
+        - autogen-no-wildcard-or-escalate-role
+  match:
+    any:
+      - resources:
+          kinds:
+            - ClusterRole
+            - ClusterRoleBinding
+          names:
+            - "multus*"

--- a/kubernetes/main/apps/kyverno/policies/app/kustomization.yaml
+++ b/kubernetes/main/apps/kyverno/policies/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./restrict-image-registries.yaml
+  - ./restrict-rbac-escalation.yaml
+  - ./pod-security-baseline.yaml
+  - ./exceptions/multus-rbac.yaml

--- a/kubernetes/main/apps/kyverno/policies/app/pod-security-baseline.yaml
+++ b/kubernetes/main/apps/kyverno/policies/app/pod-security-baseline.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/api/kyverno/v1/clusterpolicy.json
+# Kyverno-native Pod Security Standards (baseline) — covers hostNamespaces, privileged,
+# capabilities.add, hostPath, hostPorts, procMount, seccomp, sysctls, runAsUser:0 (the
+# holes a hand-rolled pattern would miss). Autogen covers all controllers.
+#
+# PHASE A: Audit-only (failureAction: Audit) with NO namespace excludes — so the
+# ClusterPolicyReport enumerates the FULL real violator set (VolSync movers across 18
+# ns, device-plugins, multus, rook, comfyui, subchart pods, ...) before Phase C adds
+# per-workload PolicyExceptions and flips to Enforce. fail-open so a Kyverno outage
+# never wedges a Flux apply.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: pod-security-baseline
+spec:
+  background: true
+  webhookConfiguration:
+    failurePolicy: Ignore
+  rules:
+    - name: baseline
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        failureAction: Audit
+        podSecurity:
+          level: baseline
+          version: latest

--- a/kubernetes/main/apps/kyverno/policies/app/restrict-image-registries.yaml
+++ b/kubernetes/main/apps/kyverno/policies/app/restrict-image-registries.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/api/kyverno/v1/clusterpolicy.json
+# Catches an image-registry swap (e.g. ghcr.io/... -> attacker.io/...). PHASE A:
+# Audit-only, fail-open, generous allowlist — the report will show every registry
+# actually in use so the allowlist can be tightened before Enforce. (An org-swap on
+# an allowed HOST, e.g. ghcr.io/home-operations -> ghcr.io/attacker, is caught by
+# diff-scope, not this host-level policy.)
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-image-registries
+spec:
+  background: true
+  webhookConfiguration:
+    failurePolicy: Ignore
+  rules:
+    - name: allowed-registries
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        failureAction: Audit
+        message: "Container images must come from an allowlisted registry."
+        pattern:
+          spec:
+            =(ephemeralContainers):
+              - image: "ghcr.io/* | docker.io/* | quay.io/* | registry.k8s.io/* | gcr.io/* | k8s.gcr.io/* | public.ecr.aws/* | mcr.microsoft.com/* | cgr.dev/* | registry.gitlab.com/*"
+            =(initContainers):
+              - image: "ghcr.io/* | docker.io/* | quay.io/* | registry.k8s.io/* | gcr.io/* | k8s.gcr.io/* | public.ecr.aws/* | mcr.microsoft.com/* | cgr.dev/* | registry.gitlab.com/*"
+            containers:
+              - image: "ghcr.io/* | docker.io/* | quay.io/* | registry.k8s.io/* | gcr.io/* | k8s.gcr.io/* | public.ecr.aws/* | mcr.microsoft.com/* | cgr.dev/* | registry.gitlab.com/*"

--- a/kubernetes/main/apps/kyverno/policies/app/restrict-rbac-escalation.yaml
+++ b/kubernetes/main/apps/kyverno/policies/app/restrict-rbac-escalation.yaml
@@ -1,0 +1,69 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/kyverno/main/api/kyverno/v1/clusterpolicy.json
+# Denies the RBAC-escalation paths a prompt-injected shepherd would use: binding to a
+# privileged built-in (cluster-admin/admin/edit) or a cluster-admin-equivalent
+# controller role, and Roles granting '*/*' or escalate/bind/impersonate.
+# PHASE A: Audit-only, fail-open, no namespace excludes (full report). helm-controller
+# is excluded (legitimate chart-internal RBAC). NEVER exclude kustomize-controller.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-rbac-escalation
+spec:
+  background: true
+  webhookConfiguration:
+    failurePolicy: Ignore
+  rules:
+    - name: no-privileged-role-binding
+      match:
+        any:
+          - resources:
+              kinds:
+                - ClusterRoleBinding
+                - RoleBinding
+      exclude: &excludeHelm
+        any:
+          - subjects:
+              - kind: ServiceAccount
+                name: helm-controller
+                namespace: flux-system
+      validate:
+        failureAction: Audit
+        message: "Binding to a privileged built-in (cluster-admin/admin/edit) or a controller role is not allowed."
+        deny:
+          conditions:
+            any:
+              - key: "{{ request.object.roleRef.name }}"
+                operator: AnyIn
+                value:
+                  - cluster-admin
+                  - admin
+                  - edit
+              - key: "{{ request.object.roleRef.name }}"
+                operator: AnyIn
+                value:
+                  - kustomize-controller
+                  - helm-controller
+                  - rook-ceph-system
+                  - cilium
+                  - cert-manager-controller
+    - name: no-wildcard-or-escalate-role
+      match:
+        any:
+          - resources:
+              kinds:
+                - ClusterRole
+                - Role
+      exclude: *excludeHelm
+      validate:
+        failureAction: Audit
+        message: "Roles granting '*' verbs+resources or escalate/bind/impersonate are not allowed."
+        deny:
+          conditions:
+            any:
+              - key: "{{ request.object.rules[?contains(not_null(verbs, `[]`), '*') && contains(not_null(resources, `[]`), '*')] | length(@) }}"
+                operator: GreaterThan
+                value: 0
+              - key: "{{ request.object.rules[?contains(not_null(verbs, `[]`), 'escalate') || contains(not_null(verbs, `[]`), 'bind') || contains(not_null(verbs, `[]`), 'impersonate')] | length(@) }}"
+                operator: GreaterThan
+                value: 0

--- a/kubernetes/main/apps/kyverno/policies/ks.yaml
+++ b/kubernetes/main/apps/kyverno/policies/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kyverno-policies
+  namespace: kyverno
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    # Kyverno CRDs (ClusterPolicy/PolicyException) must exist before these apply.
+    - name: kyverno
+      namespace: kyverno
+  path: ./kubernetes/main/apps/kyverno/policies/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m

--- a/scripts/diff-scope.sh
+++ b/scripts/diff-scope.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# scripts/diff-scope.sh — Phase 4b.2 PRIMARY gate (the control that must PREVENT a
+# malicious shepherd merge, since the shepherd can edit the Kyverno backstop itself).
+# Proves a PR diff never reaches beyond a pure image tag/digest + chart-version (+
+# pinned-action) bump and touches nothing sensitive.
+#
+# TAMPER-PROOFING: the workflow executes THIS script from the BASE branch
+# (git show origin/<base>:scripts/diff-scope.sh), never the PR-editable copy, and the
+# workflow YAML holds the author gate (the bot lacks Workflows scope). A PR that edits
+# scripts/diff-scope.sh runs the trusted base version AND is flagged below.
+#
+# GATE A (sensitive denylist, hard fail) scans ADDED (+) lines + changed paths, so
+# EXISTING privileged workloads (their host*/privileged lines are unchanged context)
+# never trip it. GATE B (shape allowlist, fail-closed) requires masked-multiset
+# equality of removed vs added lines per file — only a pure version/digest/action-pin
+# bump satisfies it. Exit 0 = safe shape; exit 1 = human review required.
+set -uo pipefail
+
+BASE_BRANCH="${DIFF_SCOPE_BASE_BRANCH:-main}"
+REMOTE="${DIFF_SCOPE_REMOTE:-origin}"
+
+if [ -n "${DIFF_SCOPE_RANGE:-}" ]; then
+  RANGE="${DIFF_SCOPE_RANGE}"
+else
+  if git rev-parse --verify --quiet "${REMOTE}/${BASE_BRANCH}" >/dev/null; then
+    BASE_REF="${REMOTE}/${BASE_BRANCH}"
+  elif git rev-parse --verify --quiet "${BASE_BRANCH}" >/dev/null; then
+    BASE_REF="${BASE_BRANCH}"
+  else
+    echo "diff-scope: FATAL cannot resolve base '${BASE_BRANCH}'" >&2; exit 2
+  fi
+  MERGE_BASE="$(git merge-base "${BASE_REF}" HEAD)" || { echo "diff-scope: FATAL merge-base failed" >&2; exit 2; }
+  RANGE="${MERGE_BASE}..HEAD"
+fi
+
+fail=0
+declare -a VIOLATIONS=()
+violation() { VIOLATIONS+=("$1"); fail=1; }
+
+normalize() {
+  perl -pe '
+    s{(uses:\s*[^\s@]+)@[^\s#]+}{$1@REF}g;
+    s/sha256:[0-9a-f]{7,64}/sha256:DIGEST/g;
+    s/\@[0-9a-f]{7,40}(?![0-9a-f])/@GITSHA/g;
+    s/\bv?\d+\.\d+(?:\.[0-9A-Za-z][\w.\-]*)*\b/VER/g;
+    s/#\s*v?\d+\b/# VER/g;
+    s/\s+$//;
+  '
+}
+
+mapfile -t NAME_STATUS < <(git diff --no-renames --name-status "${RANGE}")
+
+SENSITIVE_ADD_RE='^\+[[:space:]]*(hostPath|hostNetwork|hostPID|hostIPC|hostUsers|hostPort|privileged:[[:space:]]*true|allowPrivilegeEscalation:[[:space:]]*true|runAsUser:[[:space:]]*0|runAsNonRoot:[[:space:]]*false|procMount|automountServiceAccountToken:[[:space:]]*true|securityContext:|capabilities:|hostAliases:|serviceAccountName:|serviceAccount:)'
+SENSITIVE_KIND_RE='^\+[[:space:]]*kind:[[:space:]]*(ClusterRole|ClusterRoleBinding|Role|RoleBinding|ServiceAccount|NetworkPolicy|CiliumNetworkPolicy|CiliumClusterwideNetworkPolicy|CustomResourceDefinition|MutatingWebhookConfiguration|ValidatingWebhookConfiguration|ClusterPolicy|Policy|PolicyException|CleanupPolicy|Deployment|StatefulSet|DaemonSet|Job|CronJob|Pod|ExternalSecret)([[:space:]]|$)'
+SENSITIVE_WORD_RE='(cluster-admin|system:masters|:default:default)'
+SENSITIVE_NS_RE='^\+[[:space:]]*(namespace|targetNamespace):[[:space:]]*(kube-system|flux-system|kyverno)([[:space:]]|$)'
+
+for entry in "${NAME_STATUS[@]}"; do
+  [ -z "$entry" ] && continue
+  status="${entry%%$'\t'*}"; path="${entry#*$'\t'}"; base="$(basename "$path")"
+
+  # ---- GATE A: sensitive PATHS ----
+  printf '%s' "$base" | grep -qiE 'rbac' && violation "sensitive path (rbac file): ${path}"
+  [[ "$path" == kubernetes/*/apps/kyverno/* ]] && violation "touches the Kyverno guardrail tree: ${path}"
+  [[ "$path" == scripts/diff-scope.sh ]]      && violation "touches the diff-scope guard itself: ${path}"
+  if [[ "$path" == .github/* ]] && [[ "$path" != .github/workflows/* ]]; then
+    violation "sensitive path (.github non-workflow): ${path}"
+  fi
+  if [ "${status:0:1}" = "A" ] && [[ "$path" != kubernetes/* ]]; then
+    violation "new file outside kubernetes/**: ${path}"
+  fi
+
+  # ---- GATE A: sensitive ADDED content (only '+' lines) ----
+  added="$(git diff --no-color "${RANGE}" -- "$path" | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+  printf '%s\n' "$added" | grep -qEi "$SENSITIVE_ADD_RE"  && violation "adds security-sensitive field in ${path}"
+  printf '%s\n' "$added" | grep -qE  "$SENSITIVE_KIND_RE" && violation "adds sensitive resource kind in ${path}"
+  printf '%s\n' "$added" | grep -qE  "$SENSITIVE_WORD_RE" && violation "adds sensitive token in ${path}"
+  printf '%s\n' "$added" | grep -qE  "$SENSITIVE_NS_RE"   && violation "targets kube-system/flux-system/kyverno in ${path}"
+
+  # ---- GATE B: shape allowlist (masked-multiset equality of removed vs added) ----
+  rm_lines="$(git diff --no-color "${RANGE}" -- "$path" | grep -E '^-'  | grep -vE '^---' | sed 's/^-//' | normalize | LC_ALL=C sort)"
+  add_lines="$(git diff --no-color "${RANGE}" -- "$path" | grep -E '^\+' | grep -vE '^\+\+\+' | sed 's/^+//' | normalize | LC_ALL=C sort)"
+  [ "$rm_lines" != "$add_lines" ] && violation "diff exceeds allowed shape (not a pure version/digest bump): ${path}"
+done
+
+if [ "$fail" -ne 0 ]; then
+  report="$(
+    echo "### Diff Scope — human review required"; echo ""
+    echo "This PR's diff reaches beyond the auto-mergeable shape (pure image tag/digest +"
+    echo "chart \`version:\` + pinned-action bumps) or touches a security-sensitive path/"
+    echo "resource, so shepherd auto-merge is blocked. An admin can still merge after review."
+    echo ""; echo "Violations:"
+    printf '%s\n' "${VIOLATIONS[@]}" | sort -u | sed 's/^/- /'
+  )"
+  printf '%s\n' "$report"
+  [ -n "${GITHUB_STEP_SUMMARY:-}" ] && printf '%s\n' "$report" >> "$GITHUB_STEP_SUMMARY"
+  exit 1
+fi
+
+echo "diff-scope: OK — pure version/digest/chart-version (or pinned-action) bump. Safe to auto-merge."
+[ -n "${GITHUB_STEP_SUMMARY:-}" ] && echo "### Diff Scope — OK (auto-mergeable shape)" >> "$GITHUB_STEP_SUMMARY"
+exit 0


### PR DESCRIPTION
## Phase 4b.2 — Phase A (observe-only, blocks nothing)

The first, reversible step of the shepherd auto-merge guardrails.

- **Kyverno 3.8.1** — HA, **fail-open** (a Kyverno outage never wedges a Flux apply), PolicyExceptions pinned to the `kyverno` ns (GHSA-qjvc-p88j-j9rm), excludes only its own ns (**not** flux-system/kube-system). Three ClusterPolicies **all in `Audit`** with **no namespace excludes**, so the `ClusterPolicyReport` enumerates the full real violator set before Phase C adds `PolicyException`s and flips to Enforce.
- **diff-scope** (`scripts/diff-scope.sh` + workflow) — the PRIMARY gate, **advisory** in Phase A. Author-scoped (fails only for `haynes-ops-bot[bot]`), tamper-proof (runs the base-branch copy).

**Nothing enforces.** Phase B (diff-scope required + push protection) and C (Kyverno Enforce, one policy at a time) follow after reading the audit reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)