### PR TITLE
feat(media): opsplex — second cluster Plex mirroring the Unraid library

### DIFF
--- a/kubernetes/main/apps/media/kustomization.yaml
+++ b/kubernetes/main/apps/media/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
   - ./namespace.yaml
   # Flux-Kustomizations
   - ./lidarr/ks.yaml
+  - ./opsplex/ks.yaml
   - ./plex/ks.yaml

--- a/kubernetes/main/apps/media/opsplex/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/opsplex/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: &app plex
+  name: &app opsplex
 spec:
   chartRef:
     kind: OCIRepository
@@ -18,7 +18,7 @@ spec:
       retries: 3
   values:
     controllers:
-      plex:
+      opsplex:
         annotations:
           reloader.stakater.com/auto: "true"
         pod:
@@ -33,7 +33,7 @@ spec:
                   podAffinityTerm:
                     labelSelector:
                       matchLabels:
-                        app.kubernetes.io/name: opsplex
+                        app.kubernetes.io/name: plex
                     topologyKey: kubernetes.io/hostname
         containers:
           app:
@@ -42,7 +42,7 @@ spec:
               tag: 1.43.2.10687@sha256:be00a2ad851ea3193cd870636f908eb6425ad89390f23cdb08daa35ab5cceacc
             env:
               TZ: America/New_York
-              PLEX_ADVERTISE_URL: https://k8plex.haynesnetwork.com:443,http://192.168.40.209:32400
+              PLEX_ADVERTISE_URL: https://opsplex.haynesnetwork.com:443,http://192.168.40.211:32400
               PLEX_NO_AUTH_NETWORKS: 192.168.0.0/24
             probes:
               liveness: &probes
@@ -83,10 +83,10 @@ spec:
         supplementalGroups: [44]
     service:
       app:
-        controller: plex
+        controller: opsplex
         type: LoadBalancer
         annotations:
-          lbipam.cilium.io/ips: 192.168.40.209
+          lbipam.cilium.io/ips: 192.168.40.211
         ports:
           http:
             port: 32400
@@ -95,23 +95,18 @@ spec:
         annotations:
           external-dns.alpha.kubernetes.io/target: ingress-ext.haynesnetwork.com
           # Homepage
-          gethomepage.dev/href: &url "https://k8plex.haynesnetwork.com"
+          gethomepage.dev/href: &url "https://opsplex.haynesnetwork.com"
           gethomepage.dev/enabled: "true"
           gethomepage.dev/group: Media
-          gethomepage.dev/name: Plex
-          gethomepage.dev/description: Media server
+          gethomepage.dev/name: OpsPlex
+          gethomepage.dev/description: Media server (Unraid mirror)
           gethomepage.dev/icon: plex
-          # Needed for Kubernetes status/metrics lookup
-          gethomepage.dev/app: plex
+          gethomepage.dev/app: opsplex
           # Use Service directly for accurate monitoring
-          gethomepage.dev/siteMonitor: "http://plex.media.svc.cluster.local:32400/identity"
-          gethomepage.dev/widget.type: plex
-          gethomepage.dev/widget.url: "http://plex.media.svc.cluster.local:32400"
-          # app-template uses tpl on annotations; escape Homepage var so Helm doesn't render it
-          gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_HAYNESKUBE_PLEX_API_KEY}}" }}'
+          gethomepage.dev/siteMonitor: "http://opsplex.media.svc.cluster.local:32400/identity"
         className: traefik-external
         hosts:
-          - host: "k8plex.haynesnetwork.com"
+          - host: "opsplex.haynesnetwork.com"
             paths:
               - path: /
                 service:
@@ -120,18 +115,18 @@ spec:
         tls:
           - secretName: certificate-haynesnetwork
             hosts:
-                - k8plex.haynesnetwork.com
+                - opsplex.haynesnetwork.com
     persistence:
       config:
-        existingClaim: plex
+        existingClaim: opsplex
       config-cache:
-        existingClaim: plex-cache
+        existingClaim: opsplex-cache
         globalMounts:
           - path: /config/Library/Application Support/Plex Media Server/Cache
       # Regenerable artwork on a separate, non-backed-up PVC (keeps the VolSync
-      # backup of `plex` to just the library DB + prefs). Plex re-fetches if lost.
+      # backup of `opsplex` to just the library DB + prefs). Plex re-fetches if lost.
       config-metadata:
-        existingClaim: plex-metadata
+        existingClaim: opsplex-metadata
         globalMounts:
           - path: /config/Library/Application Support/Plex Media Server/Metadata
             subPath: Metadata
@@ -143,14 +138,27 @@ spec:
           - path: /config/Library/Application Support/Plex Media Server/Logs
       transcode:
         type: emptyDir
-      media:
+      # Unraid media library (movies/TV) — read-only mirror of what the
+      # haynestower Plex serves.
+      media-haynestower:
+        type: nfs
+        server: haynestower.haynesnetwork
+        path: /mnt/user/data
+        advancedMounts:
+          opsplex:
+            app:
+              - path: /data/haynestower
+                readOnly: true
+      # Cluster-side media root (music from lidarr, ytdl content) so opsplex
+      # can take over everything when it becomes the primary server.
+      media-gasha:
         type: nfs
         server: gasha01.haynesnetwork
         path: /hdd-nfs-repl
         advancedMounts:
-          plex:
+          opsplex:
             app:
-              - path: /cephfs-hdd
+              - path: /data/gasha01
                 subPath: data
                 readOnly: true
       tmp:

--- a/kubernetes/main/apps/media/opsplex/app/kustomization.yaml
+++ b/kubernetes/main/apps/media/opsplex/app/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/gatus/external
+  - ../../../../../shared/components/volsync/aws
+resources:
+  - ./pvc.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: opsplex-loki-rules
+    files:
+      - opsplex.yaml=./lokirule.yaml
+    options:
+      labels:
+        loki_rule: "true"
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/main/apps/media/opsplex/app/lokirule.yaml
+++ b/kubernetes/main/apps/media/opsplex/app/lokirule.yaml
@@ -1,0 +1,13 @@
+---
+groups:
+  - name: opsplex
+    rules:
+      - alert: OpsplexDatabaseIsBusy
+        expr: |
+          sum by (app) (count_over_time({app="opsplex"} |~ "(?i)retry busy DB"[5m])) > 0
+        for: 5m
+        annotations:
+          summary: >-
+            {{ $labels.app }} is experiencing database issues
+        labels:
+          severity: critical

--- a/kubernetes/main/apps/media/opsplex/app/pvc.yaml
+++ b/kubernetes/main/apps/media/opsplex/app/pvc.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: opsplex-cache
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: ceph-block
+---
+# Regenerable Plex artwork (Metadata + Media). Kept OFF the backed-up `opsplex`
+# config PVC so VolSync only protects the library DB. Plex re-fetches anything
+# missing here, so it is intentionally not backed up. Sized above k8plex's
+# 120Gi — opsplex mirrors the full Unraid video library.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: opsplex-metadata
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 200Gi
+  storageClassName: ceph-block

--- a/kubernetes/main/apps/media/opsplex/ks.yaml
+++ b/kubernetes/main/apps/media/opsplex/ks.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app opsplex
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/main/apps/media/opsplex/app
+  dependsOn:
+    - name: intel-device-plugin-gpu
+      namespace: kube-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      # Config PVC holds ONLY the library DB + prefs — artwork (Metadata/Media)
+      # and Cache live on separate non-backed-up PVCs (see pvc.yaml), so the
+      # VolSync repo stays small even with libraries larger than k8plex's.
+      VOLSYNC_CAPACITY: 50Gi
+      VOLSYNC_CACHE_CAPACITY: 10Gi
+      # Weekly like plex; the DB churns constantly so daily buys little.
+      VOLSYNC_SCHEDULE: "0 0 * * 0" # Sundays 00:00
+      GATUS_SUBDOMAIN: opsplex
+      GATUS_PATH: /identity
+      GATUS_STATUS_MAX: "500"


### PR DESCRIPTION
## What

Adds **opsplex**, a second in-cluster Plex, alongside the existing `plex` (k8plex) — one Plex per Intel iGPU twin (`talosw02`/`talosw03`). opsplex mounts the Unraid share (`haynestower:/mnt/user/data`) **read-only** to mirror the Unraid Plex video library, and also mounts the gasha01 media root read-only so it can eventually take over as the primary server (Arrow Lake iGPU = AV1 transcode the Unraid box can't do).

## Design notes

- **Scheduling**: both Plexes keep the `intel-arrow-lake-gpu` nodeSelector; a **soft podAntiAffinity** (each against the other's `app.kubernetes.io/name`) spreads one per twin while both are up but lets either fail over to the surviving node (each twin has 3 `gpu.intel.com/i915` slots; each Plex requests 1).
- **VolSync scope (the k8plex artwork lesson)**: the backed-up `opsplex` config PVC is **50Gi and holds only the library DB + prefs**. Cache (100Gi) and Metadata/Media artwork (200Gi) are separate `prune: disabled` PVCs that are *not* backed up — regenerable artwork stays out of the restic repo. Weekly backup schedule, matching plex.
- **Network**: LB IP `192.168.40.211` (next free in the `.203–.254` pool), `opsplex.haynesnetwork.com` via `traefik-external` with the existing `*.haynesnetwork.com` wildcard cert, `PLEX_ADVERTISE_URL` set for both paths.
- **Observability**: Gatus external check on `/identity`, Loki busy-DB rule cloned from plex (`OpsplexDatabaseIsBusy`).

## Post-merge steps (manual, in the Plex UI once the pod is up)

1. Claim the server (LAN: `http://192.168.40.211:32400/web`), name it distinctly (e.g. `OpsPlex`) so three local servers aren't confusable.
2. Build libraries against `/data/haynestower/Media/...` (video mirror) — music can stay on k8plex/gasha01 per the migration plan.
3. Homepage widget annotations intentionally omitted — needs this server's own `X-Plex-Token` after claiming; add in a follow-up.

## Notes for reviewers

- Media mount paths are `/data/haynestower` + `/data/gasha01`. If you ever want to transplant the Unraid Plex DB into opsplex (to keep watch state), the library paths should instead match the Unraid container's internal paths — flag it now if so, trivial to change before first library build.
- `task kubernetes:kubeconform` is currently broken repo-wide (expects a nonexistent `kubernetes/flux` dir) — unrelated to this change; flux-local CI is the validation gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CeNbTXarmoGUB4eN9EaEfy