### PR TITLE
feat(downloads): prowlarr (fresh, no VPN) + homepage widgets for the download stack

### DIFF
--- a/kubernetes/main/apps/downloads/kustomization.yaml
+++ b/kubernetes/main/apps/downloads/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   # Pre Flux-Kustomizations
   - ./namespace.yaml
   # Flux-Kustomizations
+  - ./prowlarr/ks.yaml
   - ./qbittorrent/ks.yaml
   - ./sabnzbd/ks.yaml
   - ./slskd/ks.yaml

--- a/kubernetes/main/apps/downloads/prowlarr/app/externalsecret.yaml
+++ b/kubernetes/main/apps/downloads/prowlarr/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: prowlarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: prowlarr-secret
+    template:
+      engineVersion: v2
+      data:
+        # Pinned API key so the *arrs and Homepage consume the same
+        # media-stack field instead of a hand-copied value.
+        PROWLARR__AUTH__APIKEY: "{{ .PROWLARR_API_KEY }}"
+  # Targeted fetch from the shared media-stack item — only this app's key
+  # lands in the namespace.
+  data:
+    - secretKey: PROWLARR_API_KEY
+      remoteRef:
+        key: media-stack
+        property: PROWLARR_API_KEY

--- a/kubernetes/main/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -1,0 +1,125 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prowlarr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      prowlarr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          # No VPN for prowlarr (user call) — but still keep it OFF the
+          # control-plane nodes, where the critical smart-home stack lives.
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/prowlarr
+              tag: 2.1.5.5216
+            env:
+              TZ: America/New_York
+              PROWLARR__APP__INSTANCENAME: Prowlarr
+              # LAN-only ingress; no login form. Swap to Forms/Authentik later
+              # if exposed beyond traefik-internal.
+              PROWLARR__AUTH__METHOD: External
+              PROWLARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              PROWLARR__LOG__DBENABLED: "False"
+              PROWLARR__LOG__LEVEL: info
+              PROWLARR__SERVER__PORT: &port 9696
+            envFrom:
+              - secretRef:
+                  name: prowlarr-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: *port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 2000m
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        forceRename: "{{ .Release.Name }}"
+        primary: true
+        ports:
+          http:
+            port: *port
+    ingress:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: internal.haynesops
+          gethomepage.dev/href: &url "https://prowlarr.haynesops.com"
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Downloads
+          gethomepage.dev/name: Prowlarr
+          gethomepage.dev/description: Indexer manager
+          gethomepage.dev/icon: prowlarr
+          gethomepage.dev/app: prowlarr
+          gethomepage.dev/siteMonitor: *url
+          gethomepage.dev/widget.type: prowlarr
+          gethomepage.dev/widget.url: "http://prowlarr.downloads.svc.cluster.local:9696"
+          # app-template uses tpl on annotations; escape Homepage var so Helm doesn't render it
+          gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_PROWLARR_API_KEY}}" }}'
+        className: traefik-internal
+        hosts:
+          - host: prowlarr.haynesops.com
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      config:
+        existingClaim: prowlarr
+      tmp:
+        type: emptyDir

--- a/kubernetes/main/apps/downloads/prowlarr/app/kustomization.yaml
+++ b/kubernetes/main/apps/downloads/prowlarr/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/gatus/gaurded
+  - ../../../../../shared/components/volsync/aws
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/main/apps/downloads/prowlarr/ks.yaml
+++ b/kubernetes/main/apps/downloads/prowlarr/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app prowlarr
+  namespace: downloads
+spec:
+  targetNamespace: downloads
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/main/apps/downloads/prowlarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: prowlarr
+      GATUS_PATH: /ping
+      # Indexer defs + history DB only (no artwork) — small config.
+      VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/main/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -121,6 +121,10 @@ spec:
           gethomepage.dev/icon: sabnzbd
           gethomepage.dev/app: sabnzbd
           gethomepage.dev/siteMonitor: *url
+          gethomepage.dev/widget.type: sabnzbd
+          gethomepage.dev/widget.url: "http://sabnzbd.downloads.svc.cluster.local:8080"
+          # app-template uses tpl on annotations; escape Homepage var so Helm doesn't render it
+          gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_SABNZBD_API_KEY}}" }}'
         className: traefik-internal
         hosts:
           - host: sabnzbd.haynesops.com

--- a/kubernetes/main/apps/downloads/sabnzbd/fast/helmrelease.yaml
+++ b/kubernetes/main/apps/downloads/sabnzbd/fast/helmrelease.yaml
@@ -121,6 +121,10 @@ spec:
           gethomepage.dev/icon: sabnzbd
           gethomepage.dev/app: sabnzbd-fast
           gethomepage.dev/siteMonitor: *url
+          gethomepage.dev/widget.type: sabnzbd
+          gethomepage.dev/widget.url: "http://sabnzbd-fast.downloads.svc.cluster.local:8080"
+          # app-template uses tpl on annotations; escape Homepage var so Helm doesn't render it
+          gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_SABNZBD_FAST_API_KEY}}" }}'
         className: traefik-internal
         hosts:
           - host: sabnzbd-fast.haynesops.com

--- a/kubernetes/main/apps/frontend/homepage/app/externalsecret.yaml
+++ b/kubernetes/main/apps/frontend/homepage/app/externalsecret.yaml
@@ -27,6 +27,10 @@ spec:
         # because the field inside the `plexops` item is also named
         # HAYNESKUBE_PLEX_API_KEY and a dataFrom merge would clobber k8plex's)
         HOMEPAGE_VAR_PLEXOPS_API_KEY: "{{ .PLEXOPS_PLEX_API_KEY }}"
+        # Downloads stack — keys from the shared media-stack item
+        HOMEPAGE_VAR_PROWLARR_API_KEY: "{{ .PROWLARR_API_KEY }}"
+        HOMEPAGE_VAR_SABNZBD_API_KEY: "{{ .SABNZBD_API_KEY }}"
+        HOMEPAGE_VAR_SABNZBD_FAST_API_KEY: "{{ .SABNZBD_FAST_API_KEY }}"
         # Grafana
         HOMEPAGE_VAR_GRAFANA_USERNAME: "{{ .GRAFANA_USERNAME }}"
         HOMEPAGE_VAR_GRAFANA_PASSWORD: "{{ .GRAFANA_PASSWORD }}"
@@ -49,3 +53,7 @@ spec:
         key: homepage
     - extract:
         key: paperless
+    # Shared media-pipeline keys (unique <APP>_API_KEY field names by
+    # convention, so merges here are collision-safe).
+    - extract:
+        key: media-stack


### PR DESCRIPTION
Prowlarr per the cutover plan: fresh install, API key pinned from the shared
media-stack 1Password item (PROWLARR__AUTH__APIKEY), worker-only via
control-plane-label nodeAffinity (no VPN per user call — indexers over
HTTPS), gatus/gaurded Pushover check on /ping, 5Gi VolSync config.

Homepage: extract media-stack once (collision-safe unique field names) and
wire widgets for prowlarr + both SABs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CeNbTXarmoGUB4eN9EaEfy
