### PR TITLE
feat(media): radarr + sonarr (fresh cutover) + recyclarr TRaSH guide-sync

### DIFF
--- a/kubernetes/main/apps/frontend/homepage/app/externalsecret.yaml
+++ b/kubernetes/main/apps/frontend/homepage/app/externalsecret.yaml
@@ -27,10 +27,12 @@ spec:
         # because the field inside the `plexops` item is also named
         # HAYNESKUBE_PLEX_API_KEY and a dataFrom merge would clobber k8plex's)
         HOMEPAGE_VAR_PLEXOPS_API_KEY: "{{ .PLEXOPS_PLEX_API_KEY }}"
-        # Downloads stack — keys from the shared media-stack item
+        # Downloads/media stack — keys from the shared media-stack item
         HOMEPAGE_VAR_PROWLARR_API_KEY: "{{ .PROWLARR_API_KEY }}"
         HOMEPAGE_VAR_SABNZBD_API_KEY: "{{ .SABNZBD_API_KEY }}"
         HOMEPAGE_VAR_SABNZBD_FAST_API_KEY: "{{ .SABNZBD_FAST_API_KEY }}"
+        HOMEPAGE_VAR_RADARR_API_KEY: "{{ .RADARR_API_KEY }}"
+        HOMEPAGE_VAR_SONARR_API_KEY: "{{ .SONARR_API_KEY }}"
         # Grafana
         HOMEPAGE_VAR_GRAFANA_USERNAME: "{{ .GRAFANA_USERNAME }}"
         HOMEPAGE_VAR_GRAFANA_PASSWORD: "{{ .GRAFANA_PASSWORD }}"

--- a/kubernetes/main/apps/media/kustomization.yaml
+++ b/kubernetes/main/apps/media/kustomization.yaml
@@ -12,3 +12,6 @@ resources:
   - ./lidarr/ks.yaml
   - ./plexops/ks.yaml
   - ./plex/ks.yaml
+  - ./radarr/ks.yaml
+  - ./recyclarr/ks.yaml
+  - ./sonarr/ks.yaml

--- a/kubernetes/main/apps/media/radarr/app/externalsecret.yaml
+++ b/kubernetes/main/apps/media/radarr/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: radarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: radarr-secret
+    template:
+      engineVersion: v2
+      data:
+        # Pinned API key — prowlarr/seerr/recyclarr/homepage consume the
+        # same media-stack field.
+        RADARR__AUTH__APIKEY: "{{ .RADARR_API_KEY }}"
+  data:
+    - secretKey: RADARR_API_KEY
+      remoteRef:
+        key: media-stack
+        property: RADARR_API_KEY

--- a/kubernetes/main/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/radarr/app/helmrelease.yaml
@@ -1,0 +1,144 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: radarr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      radarr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          # Keep off the control-plane nodes (critical smart-home stack).
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/radarr
+              tag: 6.0.0.10217
+            env:
+              TZ: America/New_York
+              RADARR__APP__INSTANCENAME: Radarr
+              # LAN-only ingress; no login form. Swap to Forms/Authentik later
+              # if exposed beyond traefik-internal.
+              RADARR__AUTH__METHOD: External
+              RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              RADARR__LOG__DBENABLED: "False"
+              RADARR__LOG__LEVEL: info
+              RADARR__SERVER__PORT: &port 7878
+            envFrom:
+              - secretRef:
+                  name: radarr-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: *port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 200m
+                memory: 512Mi
+              limits:
+                cpu: 2000m
+                memory: 4Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        forceRename: "{{ .Release.Name }}"
+        primary: true
+        ports:
+          http:
+            port: *port
+    ingress:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: internal.haynesops
+          gethomepage.dev/href: &url "https://radarr.haynesops.com"
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Media
+          gethomepage.dev/name: Radarr
+          gethomepage.dev/description: Movie collection manager
+          gethomepage.dev/icon: radarr
+          gethomepage.dev/app: radarr
+          gethomepage.dev/siteMonitor: *url
+          gethomepage.dev/widget.type: radarr
+          gethomepage.dev/widget.url: "http://radarr.media.svc.cluster.local:7878"
+          # app-template uses tpl on annotations; escape Homepage var so Helm doesn't render it
+          gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_RADARR_API_KEY}}" }}'
+        className: traefik-internal
+        hosts:
+          - host: radarr.haynesops.com
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      config:
+        existingClaim: radarr
+      # Same mount convention as qbittorrent/sabnzbd so download-client paths
+      # resolve identically here — hardlinks/atomic moves stay on-filesystem.
+      data-tower:
+        type: nfs
+        server: haynestower.haynesnetwork
+        path: /mnt/user/data
+        advancedMounts:
+          radarr:
+            app:
+              - path: /data/haynestower
+                readOnly: false
+      data-proxmox:
+        type: nfs
+        server: gasha01.haynesnetwork
+        path: /hdd-nfs-repl
+        advancedMounts:
+          radarr:
+            app:
+              - path: /data/cephfs-hdd
+                readOnly: false
+      tmp:
+        type: emptyDir

--- a/kubernetes/main/apps/media/radarr/app/kustomization.yaml
+++ b/kubernetes/main/apps/media/radarr/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/gatus/gaurded
+  - ../../../../../shared/components/volsync/aws
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/main/apps/media/radarr/ks.yaml
+++ b/kubernetes/main/apps/media/radarr/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app radarr
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/main/apps/media/radarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: radarr
+      GATUS_PATH: /ping
+      # DB + MediaCover headroom (lidarr's 4.4k-artist library fits in 25Gi)
+      VOLSYNC_CAPACITY: 25Gi

--- a/kubernetes/main/apps/media/recyclarr/app/externalsecret.yaml
+++ b/kubernetes/main/apps/media/recyclarr/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: recyclarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: recyclarr-secret
+  # Field names pass straight through as env vars — recyclarr.yml reads them
+  # via !env_var.
+  data:
+    - secretKey: RADARR_API_KEY
+      remoteRef:
+        key: media-stack
+        property: RADARR_API_KEY
+    - secretKey: SONARR_API_KEY
+      remoteRef:
+        key: media-stack
+        property: SONARR_API_KEY

--- a/kubernetes/main/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/recyclarr/app/helmrelease.yaml
@@ -1,0 +1,84 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: recyclarr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      recyclarr:
+        type: cronjob
+        cronjob:
+          schedule: "30 5 * * *"
+          timeZone: America/New_York
+          successfulJobsHistory: 1
+          failedJobsHistory: 2
+        pod:
+          # Keep off the control-plane nodes (critical smart-home stack).
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
+        containers:
+          app:
+            image:
+              repository: ghcr.io/recyclarr/recyclarr
+              tag: 7.3.0
+            args: ["sync"]
+            env:
+              TZ: America/New_York
+            envFrom:
+              - secretRef:
+                  name: recyclarr-secret
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                cpu: 1000m
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    persistence:
+      # Writable /config for recyclarr's cache/logs; the actual config file
+      # is projected read-only from git below.
+      config:
+        type: emptyDir
+        globalMounts:
+          - path: /config
+      config-file:
+        type: configMap
+        name: recyclarr-config
+        globalMounts:
+          - path: /config/recyclarr.yml
+            subPath: recyclarr.yml
+            readOnly: true
+      tmp:
+        type: emptyDir

--- a/kubernetes/main/apps/media/recyclarr/app/kustomization.yaml
+++ b/kubernetes/main/apps/media/recyclarr/app/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: recyclarr-config
+    files:
+      - recyclarr.yml=./recyclarr.yml
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/main/apps/media/recyclarr/app/recyclarr.yml
+++ b/kubernetes/main/apps/media/recyclarr/app/recyclarr.yml
@@ -1,0 +1,21 @@
+# TRaSH Guides sync (https://trash-guides.info) via Recyclarr.
+# Starter profiles from the official config templates — tune here in git,
+# never in the arr UIs (recyclarr re-asserts this config on every sync).
+# Radarr: HD Bluray + WEB. Sonarr v4: WEB-1080p.
+radarr:
+  radarr:
+    base_url: http://radarr.media.svc.cluster.local:7878
+    api_key: !env_var RADARR_API_KEY
+    include:
+      - template: radarr-quality-definition-movie
+      - template: radarr-quality-profile-hd-bluray-web
+      - template: radarr-custom-formats-hd-bluray-web
+
+sonarr:
+  sonarr:
+    base_url: http://sonarr.media.svc.cluster.local:8989
+    api_key: !env_var SONARR_API_KEY
+    include:
+      - template: sonarr-quality-definition-series
+      - template: sonarr-v4-quality-profile-web-1080p
+      - template: sonarr-v4-custom-formats-web-1080p

--- a/kubernetes/main/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/main/apps/media/recyclarr/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app recyclarr
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: radarr
+      namespace: media
+    - name: sonarr
+      namespace: media
+  path: ./kubernetes/main/apps/media/recyclarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/main/apps/media/sonarr/app/externalsecret.yaml
+++ b/kubernetes/main/apps/media/sonarr/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: sonarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: sonarr-secret
+    template:
+      engineVersion: v2
+      data:
+        # Pinned API key — prowlarr/seerr/recyclarr/homepage consume the
+        # same media-stack field.
+        SONARR__AUTH__APIKEY: "{{ .SONARR_API_KEY }}"
+  data:
+    - secretKey: SONARR_API_KEY
+      remoteRef:
+        key: media-stack
+        property: SONARR_API_KEY

--- a/kubernetes/main/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/sonarr/app/helmrelease.yaml
@@ -1,0 +1,144 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: sonarr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      sonarr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          # Keep off the control-plane nodes (critical smart-home stack).
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/sonarr
+              tag: 4.0.18.2978
+            env:
+              TZ: America/New_York
+              SONARR__APP__INSTANCENAME: Sonarr
+              # LAN-only ingress; no login form. Swap to Forms/Authentik later
+              # if exposed beyond traefik-internal.
+              SONARR__AUTH__METHOD: External
+              SONARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              SONARR__LOG__DBENABLED: "False"
+              SONARR__LOG__LEVEL: info
+              SONARR__SERVER__PORT: &port 8989
+            envFrom:
+              - secretRef:
+                  name: sonarr-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: *port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 200m
+                memory: 512Mi
+              limits:
+                cpu: 2000m
+                memory: 4Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        forceRename: "{{ .Release.Name }}"
+        primary: true
+        ports:
+          http:
+            port: *port
+    ingress:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: internal.haynesops
+          gethomepage.dev/href: &url "https://sonarr.haynesops.com"
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Media
+          gethomepage.dev/name: Sonarr
+          gethomepage.dev/description: TV collection manager
+          gethomepage.dev/icon: sonarr
+          gethomepage.dev/app: sonarr
+          gethomepage.dev/siteMonitor: *url
+          gethomepage.dev/widget.type: sonarr
+          gethomepage.dev/widget.url: "http://sonarr.media.svc.cluster.local:8989"
+          # app-template uses tpl on annotations; escape Homepage var so Helm doesn't render it
+          gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_SONARR_API_KEY}}" }}'
+        className: traefik-internal
+        hosts:
+          - host: sonarr.haynesops.com
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      config:
+        existingClaim: sonarr
+      # Same mount convention as qbittorrent/sabnzbd so download-client paths
+      # resolve identically here — hardlinks/atomic moves stay on-filesystem.
+      data-tower:
+        type: nfs
+        server: haynestower.haynesnetwork
+        path: /mnt/user/data
+        advancedMounts:
+          sonarr:
+            app:
+              - path: /data/haynestower
+                readOnly: false
+      data-proxmox:
+        type: nfs
+        server: gasha01.haynesnetwork
+        path: /hdd-nfs-repl
+        advancedMounts:
+          sonarr:
+            app:
+              - path: /data/cephfs-hdd
+                readOnly: false
+      tmp:
+        type: emptyDir

--- a/kubernetes/main/apps/media/sonarr/app/kustomization.yaml
+++ b/kubernetes/main/apps/media/sonarr/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/gatus/gaurded
+  - ../../../../../shared/components/volsync/aws
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/main/apps/media/sonarr/ks.yaml
+++ b/kubernetes/main/apps/media/sonarr/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app sonarr
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/main/apps/media/sonarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: sonarr
+      GATUS_PATH: /ping
+      # DB + MediaCover headroom (lidarr's 4.4k-artist library fits in 25Gi)
+      VOLSYNC_CAPACITY: 25Gi


### PR DESCRIPTION
Radarr 6.0.0 / Sonarr 4.0.18 per the ditch-the-old-stack cutover: fresh DBs,
API keys pinned from media-stack, worker-only nodeAffinity, same
/data/haynestower + /data/cephfs-hdd mounts as the download clients so
hardlinks/atomic moves stay on-filesystem, gatus Pushover checks, 25Gi
VolSync configs, homepage widgets.

Recyclarr 7.3.0 as a daily CronJob (05:30): config-as-code in git renders
TRaSH quality definitions/profiles/custom formats into both arrs
(starter: HD Bluray+WEB for radarr, WEB-1080p for sonarr v4) — profiles are
tuned in the repo, never hand-edited in the UIs. Keys via !env_var from the
same media-stack fields.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CeNbTXarmoGUB4eN9EaEfy
