### PR TITLE
feat(media): seerr (jellyseerr 2.7.3) — internal-only until cutover

### DIFF
--- a/kubernetes/main/apps/media/kustomization.yaml
+++ b/kubernetes/main/apps/media/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - ./plex/ks.yaml
   - ./radarr/ks.yaml
   - ./recyclarr/ks.yaml
+  - ./seerr/ks.yaml
   - ./sonarr/ks.yaml

--- a/kubernetes/main/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/seerr/app/helmrelease.yaml
@@ -1,0 +1,119 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: seerr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      seerr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          # Keep off the control-plane nodes (critical smart-home stack).
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
+        containers:
+          app:
+            image:
+              repository: ghcr.io/fallenbagel/jellyseerr
+              tag: 2.7.3
+            env:
+              TZ: America/New_York
+              PORT: &port 5055
+              LOG_LEVEL: info
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v1/status
+                    port: *port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 2000m
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              # Next.js writes inside /app at runtime; config PVC covers state
+              # but the rootfs can't be locked down like the *arrs.
+              readOnlyRootFilesystem: false
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        forceRename: "{{ .Release.Name }}"
+        primary: true
+        ports:
+          http:
+            port: *port
+    ingress:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: internal.haynesops
+          gethomepage.dev/href: &url "https://seerr.haynesops.com"
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Media
+          gethomepage.dev/name: Seerr
+          gethomepage.dev/description: Media requests
+          gethomepage.dev/icon: jellyseerr
+          gethomepage.dev/app: seerr
+          gethomepage.dev/siteMonitor: *url
+        # INTERNAL ONLY for now — the family-facing URL is still the Unraid
+        # instance behind the traefik-external ingressroute-overseerr
+        # (overseerr.haynesnetwork.com). Cutover flips that route here later;
+        # do NOT claim overseerr.haynesnetwork.com from this app.
+        className: traefik-internal
+        hosts:
+          - host: seerr.haynesops.com
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      config:
+        existingClaim: seerr
+        globalMounts:
+          - path: /app/config
+      tmp:
+        type: emptyDir

--- a/kubernetes/main/apps/media/seerr/app/kustomization.yaml
+++ b/kubernetes/main/apps/media/seerr/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/gatus/gaurded
+  - ../../../../../shared/components/volsync/aws
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/main/apps/media/seerr/ks.yaml
+++ b/kubernetes/main/apps/media/seerr/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app seerr
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/main/apps/media/seerr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: seerr
+      GATUS_PATH: /api/v1/status
+      # SQLite + settings only — small config.
+      VOLSYNC_CAPACITY: 5Gi


### PR DESCRIPTION
Fresh instance at seerr.haynesops.com on traefik-internal. Deliberately does
NOT touch overseerr.haynesnetwork.com — that external ingressroute still
proxies the Unraid instance until cutover day, when it flips to this
service. API key is app-generated; harvested into media-stack post-setup.
Worker-only nodeAffinity, gatus Pushover check on /api/v1/status, 5Gi
VolSync config.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CeNbTXarmoGUB4eN9EaEfy
