### PR TITLE
feat(observability): exportarr sidecars for radarr/sonarr/lidarr/prowlarr/sab x2

### DIFF
--- a/kubernetes/main/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -79,6 +79,42 @@ spec:
               capabilities:
                 drop: ["ALL"]
               readOnlyRootFilesystem: true
+          exportarr:
+            image:
+              repository: ghcr.io/onedr0p/exportarr
+              tag: v2.3.0
+            args: ["prowlarr"]
+            env:
+              PORT: &metricsPort 9710
+              URL: http://localhost:9696
+              APIKEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: prowlarr-secret
+                    key: PROWLARR__AUTH__APIKEY
+            probes:
+              liveness: &exportarrProbes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *metricsPort
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *exportarrProbes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -94,6 +130,17 @@ spec:
         ports:
           http:
             port: *port
+          metrics:
+            port: *metricsPort
+    serviceMonitor:
+      app:
+        serviceName: prowlarr
+        endpoints:
+          - port: metrics
+            scheme: http
+            path: /metrics
+            interval: 4m
+            scrapeTimeout: 90s
     ingress:
       app:
         annotations:

--- a/kubernetes/main/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -94,6 +94,42 @@ spec:
               capabilities:
                 drop: ["ALL"]
               readOnlyRootFilesystem: true
+          exportarr:
+            image:
+              repository: ghcr.io/onedr0p/exportarr
+              tag: v2.3.0
+            args: ["sabnzbd"]
+            env:
+              PORT: &metricsPort 9711
+              URL: http://localhost:8080
+              APIKEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: sabnzbd-secret
+                    key: SABNZBD__API_KEY
+            probes:
+              liveness: &exportarrProbes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *metricsPort
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *exportarrProbes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -109,6 +145,17 @@ spec:
         ports:
           http:
             port: *port
+          metrics:
+            port: *metricsPort
+    serviceMonitor:
+      app:
+        serviceName: sabnzbd
+        endpoints:
+          - port: metrics
+            scheme: http
+            path: /metrics
+            interval: 4m
+            scrapeTimeout: 90s
     ingress:
       app:
         annotations:

--- a/kubernetes/main/apps/downloads/sabnzbd/fast/helmrelease.yaml
+++ b/kubernetes/main/apps/downloads/sabnzbd/fast/helmrelease.yaml
@@ -94,6 +94,42 @@ spec:
               capabilities:
                 drop: ["ALL"]
               readOnlyRootFilesystem: true
+          exportarr:
+            image:
+              repository: ghcr.io/onedr0p/exportarr
+              tag: v2.3.0
+            args: ["sabnzbd"]
+            env:
+              PORT: &metricsPort 9711
+              URL: http://localhost:8080
+              APIKEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: sabnzbd-fast-secret
+                    key: SABNZBD__API_KEY
+            probes:
+              liveness: &exportarrProbes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *metricsPort
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *exportarrProbes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -109,6 +145,17 @@ spec:
         ports:
           http:
             port: *port
+          metrics:
+            port: *metricsPort
+    serviceMonitor:
+      app:
+        serviceName: sabnzbd-fast
+        endpoints:
+          - port: metrics
+            scheme: http
+            path: /metrics
+            interval: 4m
+            scrapeTimeout: 90s
     ingress:
       app:
         annotations:

--- a/kubernetes/main/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/lidarr/app/helmrelease.yaml
@@ -68,6 +68,42 @@ spec:
               capabilities:
                 drop: ["ALL"]
               readOnlyRootFilesystem: true
+          exportarr:
+            image:
+              repository: ghcr.io/onedr0p/exportarr
+              tag: v2.3.0
+            args: ["lidarr"]
+            env:
+              PORT: &metricsPort 9709
+              URL: http://localhost:8686
+              APIKEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: lidarr-secret
+                    key: LIDARR__AUTH__APIKEY
+            probes:
+              liveness: &exportarrProbes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *metricsPort
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *exportarrProbes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -83,6 +119,17 @@ spec:
         ports:
           http:
             port: *port
+          metrics:
+            port: *metricsPort
+    serviceMonitor:
+      app:
+        serviceName: lidarr
+        endpoints:
+          - port: metrics
+            scheme: http
+            path: /metrics
+            interval: 4m
+            scrapeTimeout: 90s
     ingress:
       app:
         annotations:

--- a/kubernetes/main/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/radarr/app/helmrelease.yaml
@@ -78,6 +78,42 @@ spec:
               capabilities:
                 drop: ["ALL"]
               readOnlyRootFilesystem: true
+          exportarr:
+            image:
+              repository: ghcr.io/onedr0p/exportarr
+              tag: v2.3.0
+            args: ["radarr"]
+            env:
+              PORT: &metricsPort 9707
+              URL: http://localhost:7878
+              APIKEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: radarr-secret
+                    key: RADARR__AUTH__APIKEY
+            probes:
+              liveness: &exportarrProbes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *metricsPort
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *exportarrProbes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -93,6 +129,17 @@ spec:
         ports:
           http:
             port: *port
+          metrics:
+            port: *metricsPort
+    serviceMonitor:
+      app:
+        serviceName: radarr
+        endpoints:
+          - port: metrics
+            scheme: http
+            path: /metrics
+            interval: 4m
+            scrapeTimeout: 90s
     ingress:
       app:
         annotations:

--- a/kubernetes/main/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/sonarr/app/helmrelease.yaml
@@ -78,6 +78,42 @@ spec:
               capabilities:
                 drop: ["ALL"]
               readOnlyRootFilesystem: true
+          exportarr:
+            image:
+              repository: ghcr.io/onedr0p/exportarr
+              tag: v2.3.0
+            args: ["sonarr"]
+            env:
+              PORT: &metricsPort 9708
+              URL: http://localhost:8989
+              APIKEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: sonarr-secret
+                    key: SONARR__AUTH__APIKEY
+            probes:
+              liveness: &exportarrProbes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *metricsPort
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *exportarrProbes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -93,6 +129,17 @@ spec:
         ports:
           http:
             port: *port
+          metrics:
+            port: *metricsPort
+    serviceMonitor:
+      app:
+        serviceName: sonarr
+        endpoints:
+          - port: metrics
+            scheme: http
+            path: /metrics
+            interval: 4m
+            scrapeTimeout: 90s
     ingress:
       app:
         annotations:


### PR DESCRIPTION
onedr0p exportarr v2.3.0 as an app-template sidecar in each HR: metrics on
a dedicated service port + ServiceMonitor (4m interval, 90s timeout — arr
API scrapes are heavy at 9.5k movies). API keys from each app's existing
secret; probes on /healthz; conservative resources.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CeNbTXarmoGUB4eN9EaEfy
