### PR TITLE
feat(media): kometa v2.4.4 — research-driven rebuild of the 2023 PMM setup

### DIFF
--- a/kubernetes/main/apps/media/kometa/app/config/movies-charts.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/movies-charts.yml
@@ -1,0 +1,27 @@
+# Chart collections rebuilt from scratch (2026): the old config's
+# tmdb_popular/trakt_chart pulls had no language gate and flooded collections
+# (and, with add_missing, the radarr library) with international titles.
+# tmdb_discover filters SERVER-SIDE (with_original_language / vote_count.gte)
+# so nothing slow or foreign ever reaches Kometa. Display-only: no arr flags.
+collections:
+  Popular Now:
+    sort_title: "!020 Popular Now"
+    summary: "Currently popular English-language movies (in this library)"
+    tmdb_discover:
+      sort_by: popularity.desc
+      with_original_language: en
+      vote_count.gte: 300
+      limit: 60
+    sync_mode: sync
+    collection_order: custom
+
+  Top Rated:
+    sort_title: "!021 Top Rated"
+    summary: "All-time top-rated English-language movies (in this library)"
+    tmdb_discover:
+      sort_by: vote_average.desc
+      with_original_language: en
+      vote_count.gte: 2000
+      limit: 100
+    sync_mode: sync
+    collection_order: custom

--- a/kubernetes/main/apps/media/kometa/app/config/movies-collections.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/movies-collections.yml
@@ -1,0 +1,28 @@
+# Custom movie collections — the survivors of the 2023 config cleanup.
+# Franchises/universes/studios/directors/actors/awards now come from Kometa
+# Defaults (see config.yml); only genuinely custom things live here.
+collections:
+  Christmas HNet:
+    sort_title: "!001 Christmas HNet"
+    imdb_list: https://www.imdb.com/list/ls000096828/
+    summary: "Hand-picked Christmas movies"
+    collection_order: release.desc
+    url_poster: https://theposterdb.com/api/assets/48897
+    # display-only during the Nov-Jan window; items persist year-round
+    schedule: range(11/01-01/07)
+
+  Spatial Surround:
+    sort_title: "!001 Spatial Surround"
+    plex_all: true
+    url_poster: https://haynesnetwork.com/wp-content/uploads/2023/11/SurroundTestCollection.png
+    collection_order: release.desc
+    # Full-library regex filter pass — deliberately weekly (filters are slow
+    # at 9.4k items per official docs).
+    schedule: weekly(saturday)
+    filters:
+      - filepath.regex: '(?i)^(?=.*\btrue[ ._-]?hd(\b|\d))(?=.*\batmos(\b|\d))'
+      - audio_track_title.regex: '(?i)^(?=.*\btrue[ ._-]?hd(\b|\d))(?=.*\batmos(\b|\d))'
+      - filepath.regex: '(?i)^(?=.*\b(dd[p+])|(dolby digital plus)\b)(?=.*\batmos(\b|\d))'
+      - audio_track_title.regex: '(?i)^(?=.*\b(dd[p+])|(dolby digital plus)\b)(?=.*\batmos(\b|\d))'
+      - filepath.regex: '(?i)\batmos(\b|\d)'
+      - audio_track_title.regex: '(?i)\batmos(\b|\d)'

--- a/kubernetes/main/apps/media/kometa/app/config/shows-collections.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/shows-collections.yml
@@ -1,0 +1,192 @@
+# Family curated TV collections — ported verbatim from the 2023 PMM config
+# (sonarr_tag/add_missing stripped: Kometa builds from EXISTING items only;
+# see the cutover checklist before ever re-enabling arr integration flags).
+collections:
+  Curated for Jackson:
+    sort_title: "!010AA Curated for Jackson"
+    url_poster: https://theposterdb.com/api/assets/82398
+    tmdb_show:
+      - 15260  # Adventure Time
+      - 37606  # The Amazing World of Gumball
+      - 78254  # Apple & Onion
+      - 246    # Avatar: The Last Airbender
+      - 68295  # Ben 10
+      - 50035  # Clarence
+      - 79061  # Craig of the Creek
+      - 72350  # DuckTales (2017)
+      - 99127  # LEGO Jurassic World: The Secret Exhibit
+      - 68073  # The Loud House
+      - 59427  # Marvel's Avengers Assemble
+      - 111110 # ONE PIECE
+      - 1877   # Phineas and Ferb
+      - 211779 # The Really Loud House
+      - 81026  # Rise of the Teenage Mutant Ninja Turtles
+      - 387    # SpongeBob SquarePants
+      - 4194   # Star Wars: The Clone Wars
+      - 604    # Teen Titans
+      - 45140  # Teen Titans Go!
+    tvdb_show:
+      - 389511 # The Amazing World of Gumball: The Gumball Chronicles (2020)
+      - 384123 # The Amazing World of Gumball: Darwin's Yearbook
+      - 408850 # Adventure Time: Fionna and Cake
+      - 328982 # Freedom Fighters: The Ray
+      - 298305 # Vixen
+      - 435612 # LEGO Ninjago: Dragons Rising
+      - 253323 # Ninjago: Masters of Spinjitzu
+      - 76703  # Pokemon
+      - 336771 # UniKitty!
+      - 343608 # Total DramaRama
+      - 330710 # Star Wars: Forces of Destiny
+      - 351575 # Star Wars Resistance
+      - 393190 # Star Wars: Visions
+      - 283468 # Star Wars Rebels
+      - 385376 # Star Wars: The Bad Batch
+      - 366607 # The Cuphead Show!
+      - 367138 # Star Trek: Lower Decks
+      - 251085 # The Legend of Korra
+      - 77038  # Rugrats (TODO: get 2021 version)
+      - 72210  # Doug
+      - 72005  # Hey Arnold!
+
+  Curated for Kellie:
+    sort_title: "!010AA Curated for Kellie"
+    url_poster: https://theposterdb.com/api/assets/411741
+    tmdb_show:
+      - 1418   # The Big Bang Theory
+      - 2327   # Dawson's Creek
+      - 1940   # Entourage
+      - 203728 # Flowers in the Attic: The Origin
+      - 4278   # Friday Night Lights
+      - 1668   # Friends
+      - 4586   # Gilmore Girls
+      - 68799  # Gilmore Girls: A Year in the Life (2016)
+      - 1416   # Grey's Anatomy
+      - 1421   # Modern Family
+      - 107113 # Only Murders in the Building
+      - 93825  # Saved by the Bell
+      - 70453  # Sharp Objects
+      - 97546  # Ted Lasso
+      - 4454   # Will & Grace
+    tvdb_show:
+      - 72164  # The O.C.
+      - 380213 # Saved By the Bell (2020)
+      - 193131 # Downton Abbey
+      - 248841 # Scandal
+      - 83610  # Glee
+      - 72158  # One Tree Hill
+      - 75760  # How I Met Your Mother
+      - 82696  # Sons of Anarchy
+      - 321239 # The Handmaid's Tale
+      - 70500  # Full House
+      - 301236 # Fuller House
+
+  Curated for Penelope:
+    sort_title: "!010AA Curated for Penelope"
+    url_poster: https://theposterdb.com/api/assets/243003
+    tmdb_show:
+      - 39107  # Bubble Guppies
+      - 100088 # The Last of Us
+      - 3934   # Mickey Mouse Clubhouse
+      - 57532  # Paw Patrol
+      - 12225  # Peppa Pig
+      - 387    # SpongeBob SquarePants
+      - 119051 # Wednesday
+      - 74323  # Vampirina
+    tvdb_show:
+      - 354345 # Butterbean's Cafe
+      - 320725 # Mickey Mouse: Mixed-Up Adventures
+      - 353546 # Bluey
+      - 71416  # The Magic School Bus
+      - 334579 # The Magic School Bus Rides Again
+      - 78419  # Sesame Street
+      - 77750  # Mister Rogers' Neighborhood
+      - 391183 # Gabby's Dollhouse
+      - 368781 # Muppets Now
+      - 301376 # Be Cool, Scooby-Doo!
+
+  Big Kid Cartoons:
+    sort_title: "!010AB Big Kid Cartoons"
+    url_poster: https://theposterdb.com/api/assets/342075
+    tvdb_show:
+      - 371028 # Arcane
+      - 110381 # Archer
+      - 375892 # Solar Opposites
+      - 75978  # Family Guy
+      - 275274 # Rick and Morty
+      - 75897  # South Park
+      - 73871  # Futurama
+      - 71663  # The Simpsons
+      - 77120  # Aqua Teen Hunger Force
+      - 331431 # Big Mouth
+      - 93991  # The Cleveland Show
+
+  Kid Cartoons:
+    sort_title: "!010AB Kid Cartoons"
+    url_poster: https://theposterdb.com/api/assets/316188
+    tmdb_show:
+      - 15260  # Adventure Time
+      - 37606  # The Amazing World of Gumball
+      - 78254  # Apple & Onion
+      - 246    # Avatar: The Last Airbender
+      - 68295  # Ben 10
+      - 50035  # Clarence
+      - 79061  # Craig of the Creek
+      - 72350  # DuckTales (2017)
+      - 99127  # LEGO Jurassic World: The Secret Exhibit
+      - 68073  # The Loud House
+      - 59427  # Marvel's Avengers Assemble
+      - 111110 # ONE PIECE
+      - 1877   # Phineas and Ferb
+      - 211779 # The Really Loud House
+      - 81026  # Rise of the Teenage Mutant Ninja Turtles
+      - 387    # SpongeBob SquarePants
+      - 4194   # Star Wars: The Clone Wars
+      - 604    # Teen Titans
+      - 45140  # Teen Titans Go!
+      - 39107  # Bubble Guppies
+      - 3934   # Mickey Mouse Clubhouse
+      - 57532  # Paw Patrol
+      - 12225  # Peppa Pig
+      - 74323  # Vampirina
+    tvdb_show:
+      - 354345 # Butterbean's Cafe
+      - 320725 # Mickey Mouse: Mixed-Up Adventures
+      - 353546 # Bluey
+      - 389511 # The Amazing World of Gumball: The Gumball Chronicles (2020)
+      - 384123 # The Amazing World of Gumball: Darwin's Yearbook
+      - 408850 # Adventure Time: Fionna and Cake
+      - 328982 # Freedom Fighters: The Ray
+      - 298305 # Vixen
+      - 71416  # The Magic School Bus
+      - 334579 # The Magic School Bus Rides Again
+      - 391183 # Gabby's Dollhouse
+      - 435612 # LEGO Ninjago: Dragons Rising
+      - 253323 # Ninjago: Masters of Spinjitzu
+      - 76703  # Pokemon
+      - 368781 # Muppets Now
+      - 336771 # UniKitty!
+      - 343608 # Total DramaRama
+      - 301376 # Be Cool, Scooby-Doo!
+      - 330710 # Star Wars: Forces of Destiny
+      - 351575 # Star Wars Resistance
+      - 393190 # Star Wars: Visions
+      - 283468 # Star Wars Rebels
+      - 385376 # Star Wars: The Bad Batch
+      - 366607 # The Cuphead Show!
+      - 367138 # Star Trek: Lower Decks
+      - 251085 # The Legend of Korra
+      - 77038  # Rugrats
+      - 72210  # Doug
+      - 72005  # Hey Arnold!
+
+  Earth & Space Wonders:
+    sort_title: "!010AC Earth & Space Wonders"
+    url_poster: https://theposterdb.com/api/assets/121577
+    tvdb_show:
+      - 417835 # Our Great National Parks
+      - 74372  # The Blue Planet
+      - 260586 # Cosmos (2014)
+      - 79257  # Planet Earth
+      - 318408 # Planet Earth II
+      - 330942 # Blue Planet II
+      - 413197 # Planet Earth III

--- a/kubernetes/main/apps/media/kometa/app/externalsecret.yaml
+++ b/kubernetes/main/apps/media/kometa/app/externalsecret.yaml
@@ -1,0 +1,142 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Renders the config.yml SEED. An init container copies it to the PVC ONLY IF
+# /config/config.yml doesn't exist — after that the PVC copy is authoritative
+# (Kometa rewrites config.yml itself, e.g. the trakt authorization block if
+# trakt is ever added). To force a re-seed: delete /config/config.yml.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kometa
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: kometa-secret
+    template:
+      engineVersion: v2
+      data:
+        config.yml: |
+          ## Seeded from git (kometa externalsecret.yaml) — LIVE copy is on the
+          ## PVC and may drift (Kometa self-writes). Collection/overlay FILES
+          ## are always live from git via /config/git (ConfigMap mount).
+          libraries:
+            Movies:
+              collection_files:
+                - default: franchise
+                - default: universe
+                - default: studio
+                - default: director
+                  template_variables:
+                    data:
+                      depth: 5
+                      limit: 25
+                - default: actor
+                  template_variables:
+                    data:
+                      depth: 5
+                      limit: 25
+                - default: oscars
+                - default: golden
+                - default: seasonal
+                - file: config/git/movies-charts.yml
+                - file: config/git/movies-collections.yml
+              overlay_files:
+                - default: resolution
+                - default: ribbon
+              operations:
+                mass_critic_rating_update: mdb_tomatoes
+                mass_audience_rating_update: mdb_tomatoesaudience
+                mass_user_rating_update: imdb
+            TV Shows:
+              collection_files:
+                - default: franchise
+                - file: config/git/shows-collections.yml
+              # SHOW-LEVEL ONLY. The old config ran resolution/audio/video
+              # overlays at builder_level: episode+season across ~100k episodes
+              # — the documented dominant cost of day-long runs. Never again.
+              overlay_files:
+                - default: resolution
+                - default: status
+                - default: ribbon
+              operations:
+                mass_critic_rating_update: mdb_tomatoes
+                mass_audience_rating_update: mdb_tomatoesaudience
+                mass_user_rating_update: imdb
+          settings:
+            cache: true
+            cache_expiration: 60
+            sync_mode: sync
+            minimum_items: 2
+            delete_below_minimum: true
+            run_again_delay: 2
+            show_unmanaged: true
+            show_unconfigured: true
+            show_missing: false
+            save_report: false
+          plex:
+            url: http://plexops.media.svc.cluster.local:32400
+            token: "{{ .PLEXOPS_TOKEN }}"
+            timeout: 120
+            db_cache: 4096
+            clean_bundles: false
+            empty_trash: false
+            optimize: false
+          tmdb:
+            apikey: "{{ .TMDB_API_KEY }}"
+            language: en
+            region: US
+            cache_expiration: 60
+          mdblist:
+            apikey: "{{ .MDBLIST_API_KEY }}"
+            cache_expiration: 60
+          # CUTOVER FLIP-LIST: add_missing/search stay FALSE (also the Kometa
+          # defaults) so collections only ever organize EXISTING library items.
+          # The 2023 config had both true — that's what auto-added chart junk.
+          # Recommendation: leave false permanently even after cutover.
+          radarr:
+            url: http://radarr.media.svc.cluster.local:7878
+            token: "{{ .RADARR_API_KEY }}"
+            add_missing: false
+            add_existing: false
+            upgrade_existing: false
+            monitor: true
+            availability: released
+            quality_profile: HD Bluray + WEB
+            root_folder_path: /data/haynestower/Media/Movies
+            search: false
+          sonarr:
+            url: http://sonarr.media.svc.cluster.local:8989
+            token: "{{ .SONARR_API_KEY }}"
+            add_missing: false
+            add_existing: false
+            upgrade_existing: false
+            monitor: all
+            quality_profile: WEB-1080p
+            root_folder_path: /data/haynestower/Media/TV Shows
+            series_type: standard
+            season_folder: true
+            search: false
+            cutoff_search: false
+  data:
+    - secretKey: TMDB_API_KEY
+      remoteRef:
+        key: media-stack
+        property: TMDB_API_KEY
+    - secretKey: MDBLIST_API_KEY
+      remoteRef:
+        key: media-stack
+        property: MDBList_API_KEY
+    - secretKey: RADARR_API_KEY
+      remoteRef:
+        key: media-stack
+        property: RADARR_API_KEY
+    - secretKey: SONARR_API_KEY
+      remoteRef:
+        key: media-stack
+        property: SONARR_API_KEY
+    - secretKey: PLEXOPS_TOKEN
+      remoteRef:
+        key: plexops
+        property: HAYNESKUBE_PLEX_API_KEY

--- a/kubernetes/main/apps/media/kometa/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/kometa/app/helmrelease.yaml
@@ -1,0 +1,129 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kometa
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    # Three cadences, one config: bounded runtimes instead of the old
+    # day-long monolith. Schedules are spaced so runs can't overlap
+    # (collections-only finishes well before the weekend jobs start).
+    controllers:
+      collections:
+        type: cronjob
+        cronjob:
+          schedule: "30 6 * * *"
+          timeZone: America/New_York
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 2
+        pod: &pod
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
+        initContainers:
+          seed-config: &seed
+            image: &busybox
+              repository: docker.io/library/busybox
+              tag: 1.38.0
+            command:
+              - /bin/sh
+              - -c
+              - '[ -f /config/config.yml ] && echo "config.yml present, keeping PVC copy" || { cp /seed/config.yml /config/config.yml && echo "seeded config.yml from git"; }'
+            securityContext: &sc
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
+        containers:
+          app: &app
+            image:
+              repository: docker.io/kometa/kometa
+              tag: v2.4.4
+            args: ["--run", "--collections-only"]
+            env:
+              TZ: America/New_York
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                cpu: 2000m
+                memory: 4Gi
+            securityContext: *sc
+      overlays:
+        type: cronjob
+        cronjob:
+          schedule: "0 1 * * 6"
+          timeZone: America/New_York
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 2
+        pod: *pod
+        initContainers:
+          seed-config: *seed
+        containers:
+          app:
+            <<: *app
+            args: ["--run", "--overlays-only"]
+      operations:
+        type: cronjob
+        cronjob:
+          schedule: "0 1 * * 0"
+          timeZone: America/New_York
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 2
+        pod: *pod
+        initContainers:
+          seed-config: *seed
+        containers:
+          app:
+            <<: *app
+            args: ["--run", "--operations-only"]
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    persistence:
+      config:
+        existingClaim: kometa
+        globalMounts:
+          - path: /config
+      # git-managed collection/overlay files — always live, never seeded
+      config-git:
+        type: configMap
+        name: kometa-config-files
+        globalMounts:
+          - path: /config/git
+            readOnly: true
+      # config.yml seed (rendered with secrets by external-secrets)
+      seed:
+        type: secret
+        name: kometa-secret
+        globalMounts:
+          - path: /seed
+            readOnly: true
+      tmp:
+        type: emptyDir

--- a/kubernetes/main/apps/media/kometa/app/kustomization.yaml
+++ b/kubernetes/main/apps/media/kometa/app/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: kometa-config-files
+    files:
+      - movies-charts.yml=./config/movies-charts.yml
+      - movies-collections.yml=./config/movies-collections.yml
+      - shows-collections.yml=./config/shows-collections.yml
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/main/apps/media/kometa/app/pvc.yaml
+++ b/kubernetes/main/apps/media/kometa/app/pvc.yaml
@@ -1,0 +1,18 @@
+---
+# Kometa state: self-written config.yml (trakt tokens if ever added), the
+# cache DB, and original-poster backups for overlays (can reach several GB at
+# 9.4k movies). Deliberately NOT VolSync'd — poster backups in restic would
+# recreate the k8plex artwork-bloat problem. Disaster recovery: PVC re-creates
+# empty, init container re-seeds config.yml, overlays re-apply on next run.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kometa
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: ceph-block

--- a/kubernetes/main/apps/media/kometa/ks.yaml
+++ b/kubernetes/main/apps/media/kometa/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kometa
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: plexops
+      namespace: media
+  path: ./kubernetes/main/apps/media/kometa/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/main/apps/media/kustomization.yaml
+++ b/kubernetes/main/apps/media/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   # Pre Flux-Kustomizations
   - ./namespace.yaml
   # Flux-Kustomizations
+  - ./kometa/ks.yaml
   - ./lidarr/ks.yaml
   - ./plexops/ks.yaml
   - ./plex/ks.yaml


### PR DESCRIPTION
Design informed by adversarially-verified deep research into current
kometa.wiki docs + the old config autopsy:

- ARR-SAFE: add_missing/search explicitly false (also Kometa's defaults) —
  the 2023 config had both TRUE, which auto-added international chart junk
  into radarr. Collections organize EXISTING items only; flip documented in
  the cutover checklist (recommendation: never).
- Curated via Defaults catalog: franchise/universe/studio/oscars/golden/
  seasonal + director/actor limited to data:{depth:5, limit:25}. Hand-curated
  keepers (family sets, Christmas HNet, Spatial Surround) ported from the old
  config, stripped of arr tags. Charts rebuilt on tmdb_discover with
  SERVER-SIDE with_original_language=en + vote_count.gte — no more
  international pulls, no slow client-side filters.
- OVERLAY SPEED: show-level only (the old episode+season-level overlays across
  ~100k episodes are the documented dominant cost of day-long runs); movies
  get resolution+ribbon; ratings overlays dropped (they redraw posters every
  time mass rating ops change a value).
- THREE CADENCES via CronJobs sharing one config PVC: collections daily
  06:30, overlays Sat 01:00, operations (mass ratings) Sun 01:00 — bounded
  runs, individually triggerable, no monolith.
- config.yml seeded from an ExternalSecret-rendered template only-if-absent
  (Kometa self-writes config.yml; trakt can be added later with its PIN
  flow); collection files stay pure-GitOps via ConfigMap at /config/git.
  20Gi PVC deliberately NOT VolSync'd (poster backups = artwork bloat).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CeNbTXarmoGUB4eN9EaEfy
