### PR TITLE
feat(cutover): flip overseerr.haynesnetwork.com to in-cluster Seerr + re-enable upgrades

### DIFF
--- a/kubernetes/main/apps/media/recyclarr/app/recyclarr.yml
+++ b/kubernetes/main/apps/media/recyclarr/app/recyclarr.yml
@@ -10,15 +10,6 @@ radarr:
       - template: radarr-quality-definition-movie
       - template: radarr-quality-profile-hd-bluray-web
       - template: radarr-custom-formats-hd-bluray-web
-    # VETTING POSTURE — REVERT AT CUTOVER: upgrades disabled so the new stack
-    # never replaces files in the tower library while the Unraid arrs still
-    # own it. Remove this override (restoring the template's upgrade-until
-    # behavior) in the cutover PR.
-    quality_profiles:
-      - name: HD Bluray + WEB
-        upgrade:
-          allowed: false
-
 sonarr:
   sonarr:
     base_url: http://sonarr.media.svc.cluster.local:8989
@@ -27,8 +18,3 @@ sonarr:
       - template: sonarr-quality-definition-series
       - template: sonarr-v4-quality-profile-web-1080p
       - template: sonarr-v4-custom-formats-web-1080p
-    # VETTING POSTURE — REVERT AT CUTOVER (see radarr note above).
-    quality_profiles:
-      - name: WEB-1080p
-        upgrade:
-          allowed: false

--- a/kubernetes/main/apps/network/traefik/config/ingress-routes/traefik-external/ingressroute-overseerr.yaml
+++ b/kubernetes/main/apps/network/traefik/config/ingress-routes/traefik-external/ingressroute-overseerr.yaml
@@ -5,12 +5,9 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/target: ingress-ext.haynesnetwork.com
     kubernetes.io/ingress.class: traefik-external
-    gethomepage.dev/href: "https://overseerr.haynesnetwork.com"
-    gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Unraid
-    gethomepage.dev/name: Overseerr
-    gethomepage.dev/description: Media requests (retires at cutover)
-    gethomepage.dev/icon: overseerr
+    # Homepage tile intentionally disabled: this URL now fronts the in-cluster
+    # Seerr, which already has its own Media tile (seerr.haynesops.com).
+    gethomepage.dev/enabled: "false"
 spec:
   entryPoints:
     - websecure
@@ -18,8 +15,11 @@ spec:
     - kind: Rule
       match: Host(`overseerr.haynesnetwork.com`) && PathPrefix(`/`)
       services:
+        # CUTOVER (2026-07-03): family-facing URL flipped from the Unraid
+        # overseerr (haynestower ExternalName) to the in-cluster Seerr.
         - kind: Service
-          name: haynestower
+          name: seerr
+          namespace: media
           port: 5055
       middlewares:
         - name: default-headers


### PR DESCRIPTION
THE cutover commit — merge only once the Unraid arr/download containers are
stopped:
- ingressroute-overseerr: haynestower ExternalName -> media/seerr:5055
  (public URL unchanged; family re-links Plex on first visit). Homepage tile
  disabled (Seerr's own Media tile remains).
- recyclarr: vetting quality_profiles overrides removed -> TRaSH
  upgrade-until behavior goes live on the next sync.

Post-merge API steps (not in git): sonarr monitor-all, arr->Plex notify
connections, empty-folder sweep.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CeNbTXarmoGUB4eN9EaEfy
