### PR TITLE
feat(media): bazarr 1.5.6 — subtitle automation (post-cutover addition)

### DIFF
--- a/kubernetes/main/apps/media/bazarr/app/externalsecret.yaml
+++ b/kubernetes/main/apps/media/bazarr/app/externalsecret.yaml
@@ -19,3 +19,14 @@ spec:
       remoteRef:
         key: media-stack
         property: SONARR_API_KEY
+    # Provider creds: 1Password is the durable source; the post-deploy config
+    # script pushes them into bazarr's config.yaml via its API (bazarr has no
+    # native env-var support for providers).
+    - secretKey: OPENSUBTITLES_USERNAME
+      remoteRef:
+        key: media-stack
+        property: OPENSUBTITLES_USERNAME
+    - secretKey: OPENSUBTITLES_PASSWORD
+      remoteRef:
+        key: media-stack
+        property: OPENSUBTITLES_PASSWORD

--- a/kubernetes/main/apps/media/bazarr/app/externalsecret.yaml
+++ b/kubernetes/main/apps/media/bazarr/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: bazarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: bazarr-secret
+  data:
+    - secretKey: RADARR_API_KEY
+      remoteRef:
+        key: media-stack
+        property: RADARR_API_KEY
+    - secretKey: SONARR_API_KEY
+      remoteRef:
+        key: media-stack
+        property: SONARR_API_KEY

--- a/kubernetes/main/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/bazarr/app/helmrelease.yaml
@@ -1,0 +1,123 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bazarr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      bazarr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          # Keep off the control-plane nodes (critical smart-home stack).
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/bazarr
+              tag: 1.5.6
+            env:
+              TZ: America/New_York
+            envFrom:
+              - secretRef:
+                  name: bazarr-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/system/ping
+                    port: &port 6767
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 200m
+                memory: 512Mi
+              limits:
+                cpu: 2000m
+                memory: 4Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        forceRename: "{{ .Release.Name }}"
+        primary: true
+        ports:
+          http:
+            port: *port
+    ingress:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: internal.haynesops
+          gethomepage.dev/href: &url "https://bazarr.haynesops.com"
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Media
+          gethomepage.dev/name: Bazarr
+          gethomepage.dev/description: Subtitle automation
+          gethomepage.dev/icon: bazarr
+          gethomepage.dev/app: bazarr
+          gethomepage.dev/siteMonitor: *url
+        className: traefik-internal
+        hosts:
+          - host: bazarr.haynesops.com
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      config:
+        existingClaim: bazarr
+      # Same mount convention as qbittorrent/sabnzbd so download-client paths
+      # resolve identically here — hardlinks/atomic moves stay on-filesystem.
+      data-tower:
+        type: nfs
+        server: haynestower.haynesnetwork
+        path: /mnt/user/data
+        advancedMounts:
+          bazarr:
+            app:
+              - path: /data/haynestower
+                readOnly: false
+      tmp:
+        type: emptyDir

--- a/kubernetes/main/apps/media/bazarr/app/kustomization.yaml
+++ b/kubernetes/main/apps/media/bazarr/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/gatus/gaurded
+  - ../../../../../shared/components/volsync/aws
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/main/apps/media/bazarr/ks.yaml
+++ b/kubernetes/main/apps/media/bazarr/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bazarr
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/main/apps/media/bazarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: bazarr
+      GATUS_PATH: /api/system/status
+      VOLSYNC_CAPACITY: 5Gi

--- a/kubernetes/main/apps/media/kustomization.yaml
+++ b/kubernetes/main/apps/media/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   # Pre Flux-Kustomizations
   - ./namespace.yaml
   # Flux-Kustomizations
+  - ./bazarr/ks.yaml
   - ./kometa/ks.yaml
   - ./lidarr/ks.yaml
   - ./plexops/ks.yaml


### PR DESCRIPTION
Fresh install per cutover doctrine; the user's OpenSubtitles.com provider,
subzero mods, scoring and upgrade tuning get applied via API post-deploy
from the harvested old config. Mounts tower at the same /data/haynestower
path as the arrs, so the old container's path mappings are unnecessary.
No exportarr (unsupported app).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CeNbTXarmoGUB4eN9EaEfy
