### PR TITLE
feat(media): tautulli x2 — watch-history for plexops + k8plex

### DIFF
--- a/kubernetes/main/apps/media/kustomization.yaml
+++ b/kubernetes/main/apps/media/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - ./recyclarr/ks.yaml
   - ./seerr/ks.yaml
   - ./sonarr/ks.yaml
+  - ./tautulli/ks.yaml

--- a/kubernetes/main/apps/media/tautulli/k8plex/externalsecret.yaml
+++ b/kubernetes/main/apps/media/tautulli/k8plex/externalsecret.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Seeds Tautulli's config.ini (init container copies only-if-absent, kometa
+# pattern): binds the Plex server + skips the first-run wizard. Tautulli
+# owns the live copy afterward; its self-generated API key gets harvested
+# to media-stack for the homepage widget.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tautulli-k8plex
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: tautulli-k8plex-secret
+    template:
+      engineVersion: v2
+      data:
+        config.ini: |
+          [General]
+          first_run_complete = 1
+          launch_browser = 0
+          check_github = 0
+          [PMS]
+          pms_ip = plex.media.svc.cluster.local
+          pms_port = 32400
+          pms_is_remote = 0
+          pms_ssl = 0
+          pms_token = {{ .PLEXOPS_TOKEN }}
+          pms_identifier = c1b23d688afea4a39ec2c214776832c16be6504d
+          pms_name = K8Plex
+          pms_url = http://plex.media.svc.cluster.local:32400
+          pms_url_manual = 1
+  data:
+    - secretKey: PLEXOPS_TOKEN
+      remoteRef:
+        key: homepage
+        property: HAYNESKUBE_PLEX_API_KEY

--- a/kubernetes/main/apps/media/tautulli/k8plex/helmrelease.yaml
+++ b/kubernetes/main/apps/media/tautulli/k8plex/helmrelease.yaml
@@ -1,0 +1,124 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tautulli-k8plex
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      tautulli-k8plex:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
+        initContainers:
+          seed-config:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.38.0
+            command:
+              - /bin/sh
+              - -c
+              - '[ -f /config/config.ini ] && echo "config present" || { cp /seed/config.ini /config/config.ini && echo "seeded"; }'
+            securityContext: &sc
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/tautulli
+              tag: 2.17.2
+            env:
+              TZ: America/New_York
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /status
+                    port: &port 8181
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+            securityContext: *sc
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        forceRename: "{{ .Release.Name }}"
+        primary: true
+        ports:
+          http:
+            port: *port
+    ingress:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: internal.haynesops
+          gethomepage.dev/href: &url "https://tautulli-k8plex.haynesops.com"
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Media
+          gethomepage.dev/name: Tautulli (K8Plex)
+          gethomepage.dev/description: K8Plex watch stats
+          gethomepage.dev/icon: tautulli
+          gethomepage.dev/app: tautulli-k8plex
+          gethomepage.dev/siteMonitor: *url
+        className: traefik-internal
+        hosts:
+          - host: tautulli-k8plex.haynesops.com
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      config:
+        existingClaim: tautulli-k8plex
+      seed:
+        type: secret
+        name: tautulli-k8plex-secret
+        globalMounts:
+          - path: /seed
+            readOnly: true
+      tmp:
+        type: emptyDir

--- a/kubernetes/main/apps/media/tautulli/k8plex/kustomization.yaml
+++ b/kubernetes/main/apps/media/tautulli/k8plex/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/gatus/gaurded
+  - ../../../../../shared/components/volsync/aws
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/main/apps/media/tautulli/ks.yaml
+++ b/kubernetes/main/apps/media/tautulli/ks.yaml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# Two Tautulli instances — one per cluster Plex (the Unraid Tautulli stays
+# paired to the Unraid Plex). Watch-history from these feeds the future
+# Maintainerr auto-deletion rules, so the sooner they run the better.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tautulli
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+    - name: plexops
+      namespace: media
+  path: ./kubernetes/main/apps/media/tautulli/plexops
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: tautulli
+      GATUS_PATH: /status
+      VOLSYNC_CAPACITY: 10Gi
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tautulli-k8plex
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+    - name: plex
+      namespace: media
+  path: ./kubernetes/main/apps/media/tautulli/k8plex
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: tautulli-k8plex
+      GATUS_PATH: /status
+      VOLSYNC_CAPACITY: 10Gi

--- a/kubernetes/main/apps/media/tautulli/plexops/externalsecret.yaml
+++ b/kubernetes/main/apps/media/tautulli/plexops/externalsecret.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Seeds Tautulli's config.ini (init container copies only-if-absent, kometa
+# pattern): binds the Plex server + skips the first-run wizard. Tautulli
+# owns the live copy afterward; its self-generated API key gets harvested
+# to media-stack for the homepage widget.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tautulli
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: tautulli-secret
+    template:
+      engineVersion: v2
+      data:
+        config.ini: |
+          [General]
+          first_run_complete = 1
+          launch_browser = 0
+          check_github = 0
+          [PMS]
+          pms_ip = plexops.media.svc.cluster.local
+          pms_port = 32400
+          pms_is_remote = 0
+          pms_ssl = 0
+          pms_token = {{ .PLEXOPS_TOKEN }}
+          pms_identifier = 80b33acb1d207508990637ec151fe9abad8d3d7a
+          pms_name = PlexOps
+          pms_url = http://plexops.media.svc.cluster.local:32400
+          pms_url_manual = 1
+  data:
+    - secretKey: PLEXOPS_TOKEN
+      remoteRef:
+        key: plexops
+        property: HAYNESKUBE_PLEX_API_KEY

--- a/kubernetes/main/apps/media/tautulli/plexops/helmrelease.yaml
+++ b/kubernetes/main/apps/media/tautulli/plexops/helmrelease.yaml
@@ -1,0 +1,124 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tautulli
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      tautulli:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
+        initContainers:
+          seed-config:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.38.0
+            command:
+              - /bin/sh
+              - -c
+              - '[ -f /config/config.ini ] && echo "config present" || { cp /seed/config.ini /config/config.ini && echo "seeded"; }'
+            securityContext: &sc
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/tautulli
+              tag: 2.17.2
+            env:
+              TZ: America/New_York
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /status
+                    port: &port 8181
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+            securityContext: *sc
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        forceRename: "{{ .Release.Name }}"
+        primary: true
+        ports:
+          http:
+            port: *port
+    ingress:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: internal.haynesops
+          gethomepage.dev/href: &url "https://tautulli.haynesops.com"
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Media
+          gethomepage.dev/name: Tautulli (PlexOps)
+          gethomepage.dev/description: PlexOps watch stats
+          gethomepage.dev/icon: tautulli
+          gethomepage.dev/app: tautulli
+          gethomepage.dev/siteMonitor: *url
+        className: traefik-internal
+        hosts:
+          - host: tautulli.haynesops.com
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      config:
+        existingClaim: tautulli
+      seed:
+        type: secret
+        name: tautulli-secret
+        globalMounts:
+          - path: /seed
+            readOnly: true
+      tmp:
+        type: emptyDir

--- a/kubernetes/main/apps/media/tautulli/plexops/kustomization.yaml
+++ b/kubernetes/main/apps/media/tautulli/plexops/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/gatus/gaurded
+  - ../../../../../shared/components/volsync/aws
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml


### PR DESCRIPTION
One per cluster Plex (Unraid Tautulli stays paired to the Unraid Plex).
Headless: config.ini seeded only-if-absent from an ES-rendered template
(server binding + token + wizard skip); self-generated API keys harvested
to media-stack afterward. Watch stats feed the future Maintainerr
auto-deletion rules — the sooner these run, the more history exists.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CeNbTXarmoGUB4eN9EaEfy
