### PR TITLE
feat(haynesnetwork): staged internal deployment of the SSO front door

### DIFF
--- a/kubernetes/main/apps/frontend/haynesnetwork/app/externalsecret.yaml
+++ b/kubernetes/main/apps/frontend/haynesnetwork/app/externalsecret.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: haynesnetwork
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: haynesnetwork-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # App — Better Auth (Authentik OIDC only; see haynesnetwork repo
+        # docs/ops/001-authentik-provisioning.md for the provider of record)
+        BETTER_AUTH_SECRET: "{{ .BETTER_AUTH_SECRET }}"
+        # STAGED ROLLOUT (PRD R-64): internal hostname first. At root-domain
+        # cutover change this to https://haynesnetwork.com and swap the
+        # IngressRoute — the Authentik redirect URIs already cover both.
+        BETTER_AUTH_URL: "https://haynesnetwork.haynesops.com"
+        OIDC_CLIENT_ID: "{{ .OIDC_CLIENT_ID }}"
+        OIDC_CLIENT_SECRET: "{{ .OIDC_CLIENT_SECRET }}"
+
+        # App — bootstrap admins (comma-separated allowlist, ADR-002)
+        BOOTSTRAP_ADMIN_EMAILS: "{{ .BOOTSTRAP_ADMIN_EMAILS }}"
+
+        # Database connection — composed from cnpg creds
+        DATABASE_URL: "postgres://{{ .HAYNESNETWORK_POSTGRESQL__USER }}:{{ .HAYNESNETWORK_POSTGRESQL__PASSWORD }}@postgres16-rw.database.svc.cluster.local:5432/haynesnetwork"
+
+        # postgres-init bootstrap (idempotent DB + role creation on pod start)
+        INIT_POSTGRES_DBNAME: haynesnetwork
+        INIT_POSTGRES_HOST: postgres16-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .HAYNESNETWORK_POSTGRESQL__USER }}"
+        INIT_POSTGRES_PASS: "{{ .HAYNESNETWORK_POSTGRESQL__PASSWORD }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: haynesnetwork
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/main/apps/frontend/haynesnetwork/app/helmrelease.yaml
+++ b/kubernetes/main/apps/frontend/haynesnetwork/app/helmrelease.yaml
@@ -1,0 +1,112 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app haynesnetwork
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      main:
+        replicas: 1
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # 1. Create the app's database + role inside cluster16 if missing.
+          #    Idempotent; same pattern as todos-for-dues/authentik/paperless.
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: "18.4"
+              pullPolicy: IfNotPresent
+            envFrom:
+              - secretRef:
+                  name: haynesnetwork-secret
+          # 2. Apply Drizzle migrations (+ idempotent app_catalog seed) from
+          #    the flattened migrator subtree baked into the app image.
+          migrate:
+            image: &mainImage
+              repository: ghcr.io/thaynes43/haynesnetwork
+              tag: v0.1.0
+              pullPolicy: IfNotPresent
+            command:
+              - tsx
+              - /migrator/src/scripts/migrate.ts
+            envFrom:
+              - secretRef:
+                  name: haynesnetwork-secret
+        containers:
+          app:
+            image: *mainImage
+            env:
+              NODE_ENV: production
+              PORT: "3000"
+              HOSTNAME: "0.0.0.0"
+              # No IPv6 egress in this cluster; Authentik's public endpoints
+              # (Cloudflare) return AAAA + A. Same undici Happy-Eyeballs
+              # timeout todos-for-dues hit with Google OIDC — force IPv4.
+              NODE_OPTIONS: --dns-result-order=ipv4first
+            envFrom:
+              - secretRef:
+                  name: haynesnetwork-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: 3000
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: 3000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: 3000
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 3
+                  failureThreshold: 24
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    service:
+      main:
+        ports:
+          http:
+            port: 3000

--- a/kubernetes/main/apps/frontend/haynesnetwork/app/ingressroute.yaml
+++ b/kubernetes/main/apps/frontend/haynesnetwork/app/ingressroute.yaml
@@ -1,0 +1,25 @@
+---
+# STAGED ROLLOUT (haynesnetwork PRD R-64): internal ingress for cluster
+# validation. At cutover this route is replaced by the traefik-external
+# root-domain route (haynesnetwork.com + www, certificate-haynesnetwork,
+# external-dns target ingress-ext.haynesnetwork.com) and BETTER_AUTH_URL
+# flips in the ExternalSecret. Authentik redirect URIs already cover both.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: haynesnetwork
+  annotations:
+    external-dns.alpha.kubernetes.io/target: internal.haynesops
+    kubernetes.io/ingress.class: traefik-internal
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`haynesnetwork.haynesops.com`) && PathPrefix(`/`)
+      services:
+        - kind: Service
+          name: haynesnetwork
+          port: 3000
+  tls:
+    secretName: certificate-haynesops

--- a/kubernetes/main/apps/frontend/haynesnetwork/app/kustomization.yaml
+++ b/kubernetes/main/apps/frontend/haynesnetwork/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ingressroute.yaml

--- a/kubernetes/main/apps/frontend/haynesnetwork/ks.yaml
+++ b/kubernetes/main/apps/frontend/haynesnetwork/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app haynesnetwork
+  namespace: &namespace frontend
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: cloudnative-pg-cluster
+      namespace: database
+  path: ./kubernetes/main/apps/frontend/haynesnetwork/app
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  prune: true
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/main/apps/frontend/kustomization.yaml
+++ b/kubernetes/main/apps/frontend/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - ./headlamp/ks.yaml
   - ./omni/ks.yaml
   - ./todos-for-dues/ks.yaml
+  - ./haynesnetwork/ks.yaml


### PR DESCRIPTION
Deploys the haynesnetwork web app (Phase 1: Authentik SSO + permissioned dashboard) to the frontend namespace, following the todos-for-dues pattern:

- `ghcr.io/thaynes43/haynesnetwork:v0.1.0` (public GHCR package; multi-stage Next standalone + flattened migrator subtree)
- postgres-init + Drizzle-migrate initContainers against `postgres16-rw` (composes DATABASE_URL from the new 1Password `haynesnetwork` item — verified present in HaynesKube with all six fields)
- **Staged rollout (haynesnetwork repo PRD R-64):** internal `haynesnetwork.haynesops.com` only for cluster validation; the traefik-external root-domain route + BETTER_AUTH_URL flip happen at go-live (backlogged with the apex-through-tunnel work)
- NODE_OPTIONS ipv4first carried over from todos-for-dues (no IPv6 egress; Authentik token exchange is behind Cloudflare)
- Health probes on /api/health (process-only by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaTKVZ36hc3jmsW1z6CrJG