### PR TITLE
feat(upgrade-agent): Phase D — enable triage auto-summon (*/30)

### DIFF
--- a/docs/renovate/README.md
+++ b/docs/renovate/README.md
@@ -491,8 +491,15 @@ EMQX holds (operator + broker, [emqx/emqx#17600](https://github.com/emqx/emqx/is
   (see "Phase-D auto-merge ramp"). Spend guard verified recording ($1.84/$50 MTD).
   One backlog artifact handled: PRs opened before Phase B lack the now-required
   `Diff Scope - Success` on their head SHA — close/reopen re-fires it (new PRs get it
-  automatically). Triage auto-summon (`upgrade-shepherd-triage`) enabled separately
-  after soak.
+  automatically). Triage auto-summon (`upgrade-shepherd-triage`) enabled the same day
+  on `*/30` after validating both paths with one-off jobs: healthy path exits pre-LLM
+  at $0 (recent merges + green cluster), and an induced benign regression (throwaway-ns
+  ImagePullBackOff persisted >10m right after a merge) correctly summoned
+  `MODE=remediate`. During the flux upgrade a REAL wedge surfaced — the cluster's
+  image.toolkit CRDs still stored `v1beta2` (etcd bookkeeping, invisible to repo-side
+  vetting) — the flux ks failed Ready **fail-safe** (nothing applied), remediated with
+  the official `flux migrate` (operator-approved break-glass); pre-flight check added
+  to the flux playbook.
 
 - **2026-07-02** — **Tier-4 Phase C: all three Kyverno policies now ENFORCE.**
   After building the exception set to audit-clean (registry rewrite for normalized

--- a/docs/renovate/README.md
+++ b/docs/renovate/README.md
@@ -491,15 +491,29 @@ EMQX holds (operator + broker, [emqx/emqx#17600](https://github.com/emqx/emqx/is
   (see "Phase-D auto-merge ramp"). Spend guard verified recording ($1.84/$50 MTD).
   One backlog artifact handled: PRs opened before Phase B lack the now-required
   `Diff Scope - Success` on their head SHA — close/reopen re-fires it (new PRs get it
-  automatically). Triage auto-summon (`upgrade-shepherd-triage`) enabled the same day
-  on `*/30` after validating both paths with one-off jobs: healthy path exits pre-LLM
-  at $0 (recent merges + green cluster), and an induced benign regression (throwaway-ns
-  ImagePullBackOff persisted >10m right after a merge) correctly summoned
-  `MODE=remediate`. During the flux upgrade a REAL wedge surfaced — the cluster's
-  image.toolkit CRDs still stored `v1beta2` (etcd bookkeeping, invisible to repo-side
-  vetting) — the flux ks failed Ready **fail-safe** (nothing applied), remediated with
-  the official `flux migrate` (operator-approved break-glass); pre-flight check added
-  to the flux playbook.
+  automatically). Triage auto-summon (`upgrade-shepherd-triage`) enabled on `*/30`
+  after validating both paths with one-off jobs: healthy path exits pre-LLM at $0
+  (recent merges + green cluster), and an induced benign regression (throwaway-ns
+  ImagePullBackOff persisted >10m right after a merge) summons `MODE=remediate`.
+  During the flux upgrade a REAL wedge surfaced — the cluster's image.toolkit CRDs
+  still stored `v1beta2` (etcd bookkeeping, invisible to repo-side vetting) — the flux
+  ks failed Ready **fail-safe** (nothing applied), remediated with the official
+  `flux migrate` (operator-approved break-glass); pre-flight check added to the flux
+  playbook.
+
+  **The induced-regression drill caught two REAL monitoring bugs** (both fixed in the
+  same PR, both of the "silent false-negative" class): (1) the persisted-pods PromQL
+  in gate.sh/triage.sh used `(expr) offset 10m` — a **parse error**; Prometheus 400'd,
+  `curl -sf` returned empty, and the check read as healthy forever (offset must follow
+  a selector). (2) Worse: the agents' CiliumNetworkPolicy DNS allowlist
+  (`*.cluster.local`) never matched multi-label service FQDNs (Cilium `*` doesn't
+  cross dots), so **the live health gate's Prometheus (pods/ESO/alerts/Ceph) and HA
+  checks had been silently blind since deploy** — it was effectively a 2-check
+  (Flux-only) gate. Fixed with exact `matchName` entries (keeps DNS-exfil closed) +
+  "blind is NOT green" warnings whenever Prometheus/HA are unreachable or a query
+  fails. Lesson (same class as the Phase-C `result==error` miss): **a monitoring
+  check must be proven able to FIRE, not just observed quiet** — the drill exists for
+  exactly this.
 
 - **2026-07-02** — **Tier-4 Phase C: all three Kyverno policies now ENFORCE.**
   After building the exception set to audit-clean (registry rewrite for normalized

--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/networkpolicy.yaml
@@ -26,8 +26,15 @@ spec:
               protocol: ANY
           rules:
             dns:
+              # Cilium `*` does NOT cross label boundaries: "*.cluster.local" matches
+              # only single-label names under it, so multi-label service FQDNs were
+              # silently unresolvable (proven live 2026-07-04 — the gate's Prometheus
+              # + HA checks were BLIND since deploy). Exact matchNames for the two
+              # services keep the DNS-tunnel-exfil surface closed.
               - matchPattern: "*.cluster.local"
               - matchPattern: "*.svc"
+              - matchName: "kube-prometheus-stack-prometheus.observability.svc.cluster.local"
+              - matchName: "home-assistant.home-automation.svc.cluster.local"
               - matchName: "api.pushover.net"
     # 2. Kube API server — the ONLY cluster read path (Flux CRs via kubectl).
     - toEntities: [kube-apiserver]

--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/resources/gate.sh
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/resources/gate.sh
@@ -59,14 +59,28 @@ fi
 
 if [ "$PROM_OK" -eq 0 ]; then
   # ---- Check 2: pods bad NOW and at offset (persisted past a cycle) => regression. ----
-  waiting='kube_pod_container_status_waiting_reason{reason=~"CrashLoopBackOff|ImagePullBackOff|ErrImagePull|CreateContainerError|CreateContainerConfigError"} == 1'
-  phase='kube_pod_status_phase{phase=~"Pending|Failed|Unknown"} == 1'
-  q_pods="( (${waiting}) or (${phase}) ) and ( (${waiting}) or (${phase}) ) offset ${OFFSET}"
-  gt0 "$(prom_count "$q_pods")" && page critical pods "$(prom_names "$q_pods" pod)" "Pod(s) unhealthy now AND ${OFFSET} ago (persisted): $(prom_names "$q_pods" pod)"
+  # PromQL gotcha (bit us 2026-07-04): `offset` must directly follow a SELECTOR —
+  # `(expr) offset 10m` is a parse error, Prometheus 400s, `curl -sf` returns empty,
+  # and the check silently read as green. Keep offset per-selector, and treat an
+  # empty (failed) query as BLIND (warn), never as healthy.
+  waiting_sel='kube_pod_container_status_waiting_reason{reason=~"CrashLoopBackOff|ImagePullBackOff|ErrImagePull|CreateContainerError|CreateContainerConfigError"}'
+  phase_sel='kube_pod_status_phase{phase=~"Pending|Failed|Unknown"}'
+  q_pods="( (${waiting_sel} == 1) or (${phase_sel} == 1) ) and ( (${waiting_sel} offset ${OFFSET} == 1) or (${phase_sel} offset ${OFFSET} == 1) )"
+  c_pods="$(prom_count "$q_pods")"
+  if [ -z "$c_pods" ]; then
+    page warning gate-blind pods "Pods persisted-unhealthy query failed (parse/timeout) — pods dimension is blind."
+  elif gt0 "$c_pods"; then
+    page critical pods "$(prom_names "$q_pods" pod)" "Pod(s) unhealthy now AND ${OFFSET} ago (persisted): $(prom_names "$q_pods" pod)"
+  fi
 
   # ---- Check 3: ExternalSecret Ready=False persisted past a cycle. ----
   q_eso='(externalsecret_status_condition{condition="Ready",status="False"} == 1) and (externalsecret_status_condition{condition="Ready",status="False"} offset '"$OFFSET"' == 1)'
-  gt0 "$(prom_count "$q_eso")" && page critical eso "$(prom_names "$q_eso" name)" "ExternalSecret(s) Ready=False, persisted ${OFFSET}: $(prom_names "$q_eso" name)"
+  c_eso="$(prom_count "$q_eso")"
+  if [ -z "$c_eso" ]; then
+    page warning gate-blind eso "ExternalSecret persisted query failed (parse/timeout) — ESO dimension is blind."
+  elif gt0 "$c_eso"; then
+    page critical eso "$(prom_names "$q_eso" name)" "ExternalSecret(s) Ready=False, persisted ${OFFSET}: $(prom_names "$q_eso" name)"
+  fi
 
   # ---- Check 4: any firing severity=critical (already 'for:'-debounced by the rules). ----
   q_crit='ALERTS{alertstate="firing",severity="critical"}'
@@ -79,11 +93,21 @@ if [ "$PROM_OK" -eq 0 ]; then
   elif [ "$ceph" = "1" ]; then
     log "note: ceph HEALTH_WARN (==1) — benign unless a NEW OSD/PG/mon fault (see runbook allowlist)."
   fi
+else
+  # Prometheus alone unreachable => checks 2-5 are dark. Blind is NOT green — warn.
+  # (Bit us 2026-07-04: a CNP DNS gap made Prometheus unresolvable since deploy and
+  # the gate quietly ran as a 2-check gate.)
+  page warning gate-blind prometheus "Prometheus unreachable — pods/ESO/alerts/Ceph dimensions are blind this cycle."
 fi
 
 # ---- Check 6: Home Assistant availability (only if HASS_TOKEN is set). ----
 if [ -n "${HASS_TOKEN:-}" ]; then
   hastate() { curl -sf --max-time 10 -H "Authorization: Bearer $HASS_TOKEN" "$HA/api/states/$1" 2>/dev/null | jq -r '.state // "ERR"' 2>/dev/null; }
+  # Blind is NOT green: if the HA API itself is unreachable, warn instead of silently
+  # skipping (hastate returns ""/ERR on curl failure, which pages nothing).
+  if ! curl -sf --max-time 10 -H "Authorization: Bearer $HASS_TOKEN" "$HA/api/" >/dev/null 2>&1; then
+    page warning gate-blind home-assistant "HA API unreachable — Zigbee/lock dimensions are blind this cycle."
+  else
   z2m="$(hastate binary_sensor.zigbee2mqtt_bridge_connection_state)"
   [ "$z2m" = "off" ] && page critical ha zigbee2mqtt "Zigbee2MQTT bridge connection == off (mesh down / Z2M-HA restart race)."
   for lk in front_door_lock side_door_lock bulkhead_lock mudroom_door_lock; do
@@ -91,6 +115,7 @@ if [ -n "${HASS_TOKEN:-}" ]; then
     case "$st" in unavailable|unknown) page critical ha "lock.$lk" "Door lock lock.$lk == $st." ;; esac
   done
   # Spa (Gecko in.touch3) is chronically flaky over RF — benign, deliberately NOT paged.
+  fi
 fi
 
 # ---- Dead-man's-switch: a successful cycle pings the heartbeat (if configured). ----

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
@@ -103,15 +103,17 @@ spec:
               readOnlyRootFilesystem: true
               capabilities:
                 drop: ["ALL"]
-      # ── Phase 4b.3 auto-summon (SUSPENDED groundwork) ──────────────────────────
-      # Deterministic (no-LLM) triage: on a schedule, summon MODE=remediate ONLY when a
-      # regression correlates with a recent merge to main. Inert until unsuspended +
-      # scheduled (the Tom-gated final flip). Reuses the shared SA/secrets/CNP/volumes.
+      # ── Phase 4b.3 auto-summon (LIVE 2026-07-03) ───────────────────────────────
+      # Deterministic (no-LLM) triage: every 30 min, summon MODE=remediate ONLY when a
+      # regression correlates with a recent merge to main (healthy path = $0, proven).
+      # Reuses the shared SA/secrets/CNP/volumes; spend-guarded in run-shepherd.sh.
+      # Kill switch (instant, no git):
+      #   kubectl -n upgrade-agent patch cronjob upgrade-shepherd-triage -p '{"spec":{"suspend":true}}'
       triage:
         type: cronjob
         cronjob:
-          suspend: true
-          schedule: "0 0 31 2 *"        # 31 Feb — never fires until the final flip
+          suspend: false
+          schedule: "*/30 * * * *"
           concurrencyPolicy: Forbid
           backoffLimit: 0
           successfulJobsHistory: 3

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/networkpolicy.yaml
@@ -25,8 +25,13 @@ spec:
               protocol: ANY
           rules:
             dns:
+              # Cilium `*` does NOT cross label boundaries — "*.cluster.local" never
+              # matched the multi-label Prometheus FQDN, so triage's Prometheus checks
+              # were silently blind (proven live 2026-07-04). Exact matchName fixes it
+              # without widening the DNS-tunnel-exfil surface.
               - matchPattern: "*.cluster.local"
               - matchPattern: "*.svc"
+              - matchName: "kube-prometheus-stack-prometheus.observability.svc.cluster.local"
               - matchName: "github.com"          # apex — *.github.com does NOT match it
               - matchPattern: "*.github.com"
               - matchPattern: "*.githubusercontent.com"

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/triage.sh
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/triage.sh
@@ -49,9 +49,19 @@ crit="$(curl -sf --max-time 15 "$PROM/api/v1/query" --data-urlencode 'query=ALER
   | jq -r '[.data.result[].metric.alertname] | unique | join(",")' 2>/dev/null)"
 [ -n "$crit" ] && REG="${REG:+$REG; }Critical alerts: ${crit}"
 # Pods crashlooping/failed now AND 10m ago (persisted past a cycle).
-q='( (kube_pod_container_status_waiting_reason{reason=~"CrashLoopBackOff|ImagePullBackOff|CreateContainerError"}==1) or (kube_pod_status_phase{phase=~"Failed|Unknown"}==1) ) and ( (kube_pod_container_status_waiting_reason{reason=~"CrashLoopBackOff|ImagePullBackOff|CreateContainerError"}==1) or (kube_pod_status_phase{phase=~"Failed|Unknown"}==1) ) offset 10m'
-pods="$(curl -sf --max-time 15 "$PROM/api/v1/query" --data-urlencode "query=$q" 2>/dev/null | jq -r '[.data.result[].metric.pod] | unique | join(",")' 2>/dev/null)"
-[ -n "$pods" ] && REG="${REG:+$REG; }Pods unhealthy (persisted): ${pods}"
+# PromQL gotcha (bit us 2026-07-04): `offset` must directly follow a SELECTOR —
+# `(expr) offset 10m` is a parse error → Prometheus 400 → `curl -sf` empty → the
+# check silently read as healthy. Keep offset per-selector; log if the query fails.
+w='kube_pod_container_status_waiting_reason{reason=~"CrashLoopBackOff|ImagePullBackOff|CreateContainerError"}'
+p='kube_pod_status_phase{phase=~"Failed|Unknown"}'
+q="( (${w} == 1) or (${p} == 1) ) and ( (${w} offset 10m == 1) or (${p} offset 10m == 1) )"
+pods_json="$(curl -sf --max-time 15 "$PROM/api/v1/query" --data-urlencode "query=$q" 2>/dev/null)"
+if [ -z "$pods_json" ]; then
+  log "WARN: persisted-pods query failed (parse/timeout) — pods dimension blind this run."
+else
+  pods="$(echo "$pods_json" | jq -r '[.data.result[].metric.pod] | unique | join(",")' 2>/dev/null)"
+  [ -n "$pods" ] && REG="${REG:+$REG; }Pods unhealthy (persisted): ${pods}"
+fi
 
 if [ -z "$REG" ]; then
   log "recent merge but cluster is healthy — no regression. exit."


### PR DESCRIPTION
Final Phase-D piece: unsuspends `upgrade-shepherd-triage` on `*/30`.

- Deterministic, LLM-free on the healthy path (proven $0: recent merges + green cluster → exit before any LLM call)
- Summons `MODE=remediate` only when a regression correlates with a recent merge to main; spend-guarded ($5/run, $50/mo), merge safety server-side
- Kill switch: `kubectl -n upgrade-agent patch cronjob upgrade-shepherd-triage -p '{"spec":{"suspend":true}}'`
- Also amends the README changelog with the validated results (incl. the flux CRD storedVersions wedge + `flux migrate` remediation)

Merging after the induced-regression validation completes (in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)