### PR TITLE
feat(haynesnetwork): v0.2.0 — media ledger, fix flow, sync CronJobs

### DIFF
--- a/kubernetes/main/apps/frontend/haynesnetwork/app/externalsecret.yaml
+++ b/kubernetes/main/apps/frontend/haynesnetwork/app/externalsecret.yaml
@@ -35,8 +35,25 @@ spec:
         INIT_POSTGRES_USER: "{{ .HAYNESNETWORK_POSTGRESQL__USER }}"
         INIT_POSTGRES_PASS: "{{ .HAYNESNETWORK_POSTGRESQL__PASSWORD }}"
         INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+
+        # Media stack (Phase 2 ledger sync + fix flow) — DESIGN-005 D-18.
+        # URLs are omitted: @hnet/arr defaults to the in-cluster service DNS.
+        SONARR_API_KEY: "{{ .SONARR_API_KEY }}"
+        RADARR_API_KEY: "{{ .RADARR_API_KEY }}"
+        LIDARR_API_KEY: "{{ .LIDARR_API_KEY }}"
+        SEERR_API_KEY: "{{ .SEERR_API_KEY }}"
+  data:
+    # lidarr pre-dates the media-stack item; its key lives in its own item
+    # (same targeted fetch the homepage ExternalSecret uses).
+    - secretKey: LIDARR_API_KEY
+      remoteRef:
+        key: lidarr
+        property: LIDARR_API_KEY
   dataFrom:
     - extract:
         key: haynesnetwork
     - extract:
         key: cloudnative-pg
+    # Shared media-pipeline keys (unique <APP>_API_KEY names — collision-safe merge)
+    - extract:
+        key: media-stack

--- a/kubernetes/main/apps/frontend/haynesnetwork/app/helmrelease.yaml
+++ b/kubernetes/main/apps/frontend/haynesnetwork/app/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
           migrate:
             image: &mainImage
               repository: ghcr.io/thaynes43/haynesnetwork
-              tag: v0.1.1
+              tag: v0.2.0
               pullPolicy: IfNotPresent
             command:
               - tsx
@@ -99,6 +99,61 @@ spec:
                   periodSeconds: 5
                   timeoutSeconds: 3
                   failureThreshold: 24
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+      # Ledger sync (DESIGN-005 D-14): same image, flattened /sync subtree.
+      # Incremental = *arr history cursors + Seerr requests, cheap and frequent.
+      sync-incremental:
+        type: cronjob
+        pod:
+          restartPolicy: Never
+        cronjob:
+          schedule: "*/15 * * * *"
+          backoffLimit: 1
+          concurrencyPolicy: Forbid
+          failedJobsHistory: 2
+          successfulJobsHistory: 1
+        containers:
+          main:
+            image: *mainImage
+            command:
+              - tsx
+              - /sync/src/scripts/sync.ts
+              - --mode=incremental
+            envFrom:
+              - secretRef:
+                  name: haynesnetwork-secret
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+      # Full reconcile nightly: upserts everything + tombstones (guarded).
+      sync-full:
+        type: cronjob
+        pod:
+          restartPolicy: Never
+        cronjob:
+          schedule: "30 4 * * *"
+          backoffLimit: 1
+          concurrencyPolicy: Forbid
+          failedJobsHistory: 2
+          successfulJobsHistory: 1
+        containers:
+          main:
+            image: *mainImage
+            command:
+              - tsx
+              - /sync/src/scripts/sync.ts
+              - --mode=full
+            envFrom:
+              - secretRef:
+                  name: haynesnetwork-secret
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/main/apps/frontend/haynesnetwork/app/helmrelease.yaml
+++ b/kubernetes/main/apps/frontend/haynesnetwork/app/helmrelease.yaml
@@ -162,6 +162,7 @@ spec:
                 memory: 1Gi
     service:
       main:
+        controller: main
         ports:
           http:
             port: 3000


### PR DESCRIPTION
New identity + /library + fix/restore surfaces; adds *arr/Seerr API keys
to the ExternalSecret (media-stack + lidarr items) and two sync CronJobs
(incremental */15, full nightly 04:30) running the image's /sync subtree.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
