### PR TITLE
feat(upgrade-agent): Phase D pre-filter — LLM only when a ramp PR is open

### DIFF
--- a/.agents/runbooks/upgrade-shepherd.md
+++ b/.agents/runbooks/upgrade-shepherd.md
@@ -263,16 +263,45 @@ Scope are both green**. It cannot merge past a red/pending check, and `--admin`
 (skip-checks) fails for a non-admin. So `auto`/`remediate` are safe to allowlist `gh pr
 merge` — the Phase-B required checks are the boundary.
 
+### The scheduled-run pre-filter (cost control — LLM only when there's in-scope work)
+
+The scheduled `auto` run is deterministically pre-filtered so a **quiet day costs \$0**.
+Before any clone or LLM call, `run-shepherd.sh` (`prefilter_should_run`) lists open
+**Renovate** PRs and checks each one's changed files against
+`UPGRADE_AGENT_PREFILTER_GLOBS` — the ramp's repo path prefixes, set on the scheduled
+cronjob env in the shepherd HR. If **no** open Renovate PR touches a ramp path it logs
+`pre-filter: … skipping LLM ($0)` and exits `0` — no clone, no LLM, no spend record.
+Only when a ramp PR exists does it fall through to the (paid) survey+vet.
+
+- **It never decides mergeability.** The LLM still fully vets every in-scope PR (holds,
+  release notes, supporting-edit detection). The filter only decides *whether there is
+  work worth looking at* — the conservative split: deterministic gate on the *look*,
+  LLM owns the *judgement*.
+- **Fails OPEN.** Any `gh`/`jq` error → it returns "run the LLM" (never silently skips
+  real work); the identical old behaviour on error.
+- **The ramp is defined in TWO places that must stay in lockstep:**
+  `UPGRADE_AGENT_PREFILTER_GLOBS` (path prefixes — what the filter matches) and
+  `UPGRADE_AGENT_PROMPT` (component names — what the LLM is allowed to merge), both in
+  [`shepherd/app/helmrelease.yaml`](../../kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml).
+  **Widen the ramp by editing BOTH in the same commit** (add the component's path
+  prefix + its name), then re-run `/kyverno-verify`.
+- **Gating:** the filter runs only when `MODE=auto` **and** `UPGRADE_AGENT_PREFILTER_GLOBS`
+  is non-empty (i.e. the scheduled cronjob). A manual/targeted summon must **clear the
+  var** to bypass it (see the summon recipe's `UPGRADE_AGENT_PREFILTER_GLOBS:""`).
+
 ### Summon (manual, any mode)
 
 ```bash
 # dryrun (read-only, free-ish):
 kubectl -n upgrade-agent create job shep-$(date +%s) --from=cronjob/upgrade-shepherd
-# a specific mode (create-job can't set env; inject via jq):
+# a specific mode (create-job can't set env; inject via jq). NOTE: clear
+# UPGRADE_AGENT_PREFILTER_GLOBS so a TARGETED summon is never pre-filtered out (else a
+# PR outside the ramp — e.g. a cnpg negative-proof test — would be skipped before the LLM):
 kubectl -n upgrade-agent create job shep-$(date +%s) --from=cronjob/upgrade-shepherd \
   --dry-run=client -o json \
   | jq '.spec.template.spec.containers |= map(if .name=="app"
-        then .env |= (map(if .name=="UPGRADE_AGENT_MODE" then .value="auto" else . end)
+        then .env |= (map(if .name=="UPGRADE_AGENT_MODE" then .value="auto"
+                          elif .name=="UPGRADE_AGENT_PREFILTER_GLOBS" then .value="" else . end)
                       + [{name:"UPGRADE_AGENT_PROMPT",value:"<task>"}]) else . end)' \
   | kubectl apply -f -
 ```

--- a/docs/renovate/README.md
+++ b/docs/renovate/README.md
@@ -376,12 +376,24 @@ read+page, so it can ship on the Omni SA kubeconfig alone.
 
 The scheduled shepherd (CronJob `upgrade-shepherd`, daily 09:00 ET, `MODE=auto`) may
 **auto-merge pure version/chart/digest bumps only**, for the components listed here.
-The scope lives in the `UPGRADE_AGENT_PROMPT` env in
-[`shepherd/app/helmrelease.yaml`](../../kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml);
-widening it is a git edit (one component at a time, operator-approved), and every
-widening gets a fresh `/kyverno-verify`. Structural backstops regardless of prompt:
-diff-scope (bot PRs must be pure bumps in `kubernetes/**`), required checks, non-admin
-bot, Kyverno enforce, the $50/mo spend guard, and the health gate + guardrail alerts.
+The ramp is defined in **two lockstep env vars** in
+[`shepherd/app/helmrelease.yaml`](../../kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml):
+`UPGRADE_AGENT_PROMPT` (component names the LLM may merge) and
+`UPGRADE_AGENT_PREFILTER_GLOBS` (repo path prefixes the deterministic pre-filter
+matches). **Widen the ramp by editing BOTH in the same commit**, one component at a
+time, operator-approved, with a fresh `/kyverno-verify` after each.
+
+**Cost control — the pre-filter:** before the scheduled run spends a cent, a
+deterministic check (`prefilter_should_run` in `run-shepherd.sh`) lists open Renovate
+PRs and matches their changed files against the ramp path prefixes. **No in-scope PR ⇒
+it exits $0 with no clone and no LLM call** — most days cost nothing. It never decides
+mergeability (the LLM still fully vets every in-scope PR); it only gates *whether there
+is work worth looking at*, and fails open (runs the LLM) on any error. This is what
+keeps the daily cadence from burning ~$0.77/day surveying an empty-of-ramp queue.
+
+Structural backstops regardless of prompt: diff-scope (bot PRs must be pure bumps in
+`kubernetes/**`), required checks, non-admin bot, Kyverno enforce, the $50/mo spend
+guard, and the health gate + guardrail alerts.
 
 | Component | In ramp since | Notes |
 |---|---|---|
@@ -479,6 +491,19 @@ EMQX holds (operator + broker, [emqx/emqx#17600](https://github.com/emqx/emqx/is
   runbook for the failing component.
 
 ## Changelog
+
+- **2026-07-04** — **Phase D cost control: deterministic pre-filter (quiet day = $0).**
+  The first unattended 09:00 ET run behaved correctly (surveyed 11 PRs, none in the
+  ramp, auto-merged nothing) but cost ~$0.77 to conclude "nothing to do" — ~$23/mo of
+  no-op LLM surveys eating the $50 cap. Added `prefilter_should_run` to `run-shepherd.sh`:
+  a scheduled `auto` run now lists open Renovate PRs and matches their changed files
+  against the ramp path prefixes (`UPGRADE_AGENT_PREFILTER_GLOBS`, new HR env) **before**
+  cloning or calling the LLM — no in-scope PR ⇒ exit $0, no clone, no spend. It never
+  decides mergeability (the LLM still fully vets every in-scope PR) and fails open (runs
+  the LLM) on any `gh`/`jq` error. The ramp is now two lockstep env vars (prompt names +
+  filter globs) — widen both together. Matcher proven both ways against the live queue
+  (real ramp → skip; probe glob at #1921's path → summon). Targeted manual summons must
+  clear the globs var (documented in the summon recipe).
 
 - **2026-07-03** — **Tier-4 Phase D live: scheduled hands-off auto-merge (clean tier).**
   Proved the chain supervised first: shepherd dry-run E2E ($0.66, correct triage of 12

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
@@ -63,6 +63,22 @@ spec:
             env:
               UPGRADE_AGENT_MODE: auto     # Phase D: vet + `gh pr merge --auto` (server-side gated)
               UPGRADE_AGENT_MODEL: sonnet
+              # Deterministic PRE-FILTER (cost control): the scheduled run invokes the
+              # paid LLM ONLY when an open Renovate PR touches one of these ramp path
+              # prefixes; a quiet day exits $0 with no clone + no LLM. This is the
+              # SECOND half of the ramp definition — keep it in lockstep with the
+              # component names in UPGRADE_AGENT_PROMPT below (widen BOTH together).
+              # Manual/targeted summons must clear this var to bypass the filter.
+              UPGRADE_AGENT_PREFILTER_GLOBS: >-
+                kubernetes/main/apps/kube-system/coredns/
+                kubernetes/edge/apps/kube-system/coredns/
+                kubernetes/main/apps/network/traefik/
+                kubernetes/main/apps/network/multus/
+                kubernetes/main/apps/kube-system/generic-device-plugin/
+                kubernetes/main/apps/kube-system/intel-device-plugin/
+                kubernetes/main/apps/kube-system/nvidia-device-plugin/
+                kubernetes/main/flux/
+                kubernetes/edge/flux/
               # The auto-merge RAMP lives here: widen the component list one entry at a
               # time as each proves quiet (docs/renovate/README.md tracks the ramp), and
               # re-run /kyverno-verify after each widening.

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/run-shepherd.sh
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/run-shepherd.sh
@@ -73,6 +73,45 @@ record_spend() {
   fi
 }
 
+# ── Deterministic PRE-FILTER (Phase D cost control) ── On a SCHEDULED auto run, only
+# summon the (paid) LLM when an open Renovate PR actually touches a component in the
+# current auto-merge ramp. On a quiet day (no in-scope PR) this exits $0 with ZERO LLM
+# cost. It does NOT decide mergeability — the LLM still fully vets every in-scope PR
+# (holds, release notes, supporting edits). The filter only decides IF there is work
+# worth looking at, keeping the conservative posture: deterministic layer gates the
+# look, LLM owns the judgement.
+#
+# Gated by UPGRADE_AGENT_PREFILTER_GLOBS — a space-separated list of repo path prefixes
+# (one per ramp component), set ONLY on the scheduled cronjob. A manual/targeted summon
+# leaves it empty (or clears it) and is never filtered — it runs as asked. WIDEN THE
+# RAMP by adding the new component's path prefix HERE (via the HR env) AND naming it in
+# UPGRADE_AGENT_PROMPT, in the same commit. Fails OPEN (returns 0 = proceed to the LLM)
+# on any gh/jq error — never silently skips real work.
+#
+# Returns 0 = an in-scope PR exists (or we're unsure) -> run the LLM.
+# Returns 1 = definitively no in-scope open Renovate PR -> caller should exit $0.
+prefilter_should_run() {
+  local globs="$1" prs pr files g
+  prs="$(gh pr list --state open --limit 200 --json number,author \
+           --jq '.[] | select(.author.login|test("renovate")) | .number' 2>/dev/null)" || {
+    log "pre-filter: gh pr list failed — failing OPEN (running the LLM)."; return 0; }
+  [ -n "$prs" ] || { log "pre-filter: no open Renovate PRs — skipping LLM (\$0)."; return 1; }
+  local checked=0
+  for pr in $prs; do
+    files="$(gh pr view "$pr" --json files --jq '.files[].path' 2>/dev/null)" || {
+      log "pre-filter: gh pr view #$pr failed — failing OPEN (running the LLM)."; return 0; }
+    checked=$((checked + 1))
+    for g in $globs; do
+      if printf '%s\n' "$files" | grep -qF -- "$g"; then
+        log "pre-filter: Renovate PR #$pr touches ramp path '$g' — summoning the LLM."
+        return 0
+      fi
+    done
+  done
+  log "pre-filter: checked $checked open Renovate PR(s); none touch the ramp — skipping LLM (\$0). Ramp: $globs"
+  return 1
+}
+
 # Quiet claude-code's phone-home (the egress CNP would block it anyway).
 export DISABLE_TELEMETRY=1 CLAUDE_CODE_ENABLE_TELEMETRY=0 \
        DISABLE_ERROR_REPORTING=1 DISABLE_AUTOUPDATER=1 DISABLE_NON_ESSENTIAL_MODEL_CALLS=1
@@ -83,6 +122,16 @@ GH_TOKEN="$(cat /creds/gh_token)"; export GH_TOKEN
 # Assert the PEM did NOT leak into this (the LLM) container.
 if [ -n "${GITHUB_BOT_APP_PRIVATE_KEY:-}" ]; then
   log "FATAL: bot PEM present in the LLM container env — refusing to run."; exit 3
+fi
+
+# Pre-filter BEFORE the clone/LLM: a scheduled auto run with no in-scope PR exits here
+# at $0 (skips clone + LLM). Only when MODE=auto AND the ramp-globs var is set (i.e. the
+# scheduled cronjob). Manual/targeted summons leave it empty and are never filtered.
+if [ "$MODE" = "auto" ] && [ -n "${UPGRADE_AGENT_PREFILTER_GLOBS:-}" ]; then
+  if ! prefilter_should_run "${UPGRADE_AGENT_PREFILTER_GLOBS}"; then
+    log "run skipped by pre-filter (no in-scope open PR) — no clone, no LLM, \$0."
+    exit 0
+  fi
 fi
 
 git config --global user.name  "haynes-ops-bot[bot]"


### PR DESCRIPTION
## Why
The first unattended 09:00 ET run worked correctly but cost **~$0.77 to conclude 'nothing in scope'** — every quiet day pays the full LLM to survey the queue and find no ramp PR (~$23/mo against the $50 cap, shrinking headroom for the days that *do* have work + a regression summon).

## What
- `prefilter_should_run` in `run-shepherd.sh`: on a scheduled `auto` run, list open **Renovate** PRs and match their changed files against `UPGRADE_AGENT_PREFILTER_GLOBS` (new HR env = the ramp's repo path prefixes) **before any clone or LLM call**. No in-scope PR ⇒ `exit 0`, no clone, no spend record.
- **Never decides mergeability** — the LLM still fully vets every in-scope PR (holds, release notes, supporting edits). The filter only gates *whether there is work worth looking at*: deterministic gate on the look, LLM owns the judgement.
- **Fails open** (runs the LLM) on any `gh`/`jq` error — identical old behaviour on error, never silently skips real work.
- Ramp is now **two lockstep env vars** (`UPGRADE_AGENT_PROMPT` names + `UPGRADE_AGENT_PREFILTER_GLOBS` path prefixes) — widen both in one commit.

## Proof (live, no LLM spend)
- Matcher run against the current 11-PR queue with the real ramp → **all out-of-scope, rc=1 (skip)**.
- Same matcher with a probe glob at #1921's real path → **matched #1921, rc=0 (run)**.
- `bash -n` clean; HR YAML parses to 9 space-separated prefixes.

Post-merge I'll reconcile and run one scheduled-style job to confirm the integrated skip path (log `skipping LLM ($0)`, spend CM unchanged). Kill switch + targeted-summon override documented in the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)