### PR TITLE
fix(cilium): pin operator to control-plane + relax leader-election

### DIFF
--- a/kubernetes/main/apps/kube-system/cilium/app/helm-values.yaml
+++ b/kubernetes/main/apps/kube-system/cilium/app/helm-values.yaml
@@ -40,6 +40,24 @@ localRedirectPolicy: true
 operator:
   replicas: 1
   rollOutPods: true
+  # Pin the operator to control-plane nodes. WHY (verified 2026-07-04 via
+  # `talosctl get kubeprismendpoints`): worker KubePrism (127.0.0.1:7445) has ONLY the
+  # Omni SideroLink apiserver endpoint (fdae:41e4:649b:9303::1:10000), while CP nodes
+  # also have localhost:6443 + the direct apiserver IPs. So an operator on a worker
+  # reaches the apiserver over a single SideroLink tunnel; under heavy worker load (the
+  # *arr pipeline) that path congests, the operator's 5s leader-election lease renewal
+  # times out, and it self-terminates (`Leader election lost`) into a crash-loop. On a
+  # CP node it uses a LOCAL apiserver and carries no download load. CP nodes are
+  # untainted (allowSchedulingOnControlPlanes), so no tolerations are needed.
+  nodeSelector:
+    kubernetes.io/os: linux
+    node-role.kubernetes.io/control-plane: ""
+  # Defense-in-depth: relax leader-election (defaults 15s/10s/2s) so a transient
+  # apiserver/KubePrism blip doesn't kill the operator even on a CP node.
+  extraArgs:
+    - --leader-election-lease-duration=30s
+    - --leader-election-renew-deadline=20s
+    - --leader-election-retry-period=4s
 rollOutCiliumPods: true
 routingMode: native
 securityContext:


### PR DESCRIPTION
## Root cause (talosctl-confirmed)
The cilium-operator was crash-looping (~37 restarts, 2026-07-04), following the pod across both worker nodes. Not upgrade-related — it correlates with new worker load (the *arr media pipeline).

`talosctl get kubeprismendpoints` shows the mechanism:
- **Worker nodes:** KubePrism has exactly ONE apiserver backend — `fdae:41e4:649b:9303::1:10000` (the Omni **SideroLink** tunnel).
- **Control-plane nodes:** KubePrism has `localhost:6443` + all the direct apiserver IPs.

So a worker operator reaches the apiserver only through the SideroLink tunnel; heavy worker load congests it, the operator's **5s leader-election lease renewal** times out → `Leader election lost, shutting down` → crash-loop. The cilium *agents* (long-lived connections) tolerate the same congestion; the operator's tight loop does not.

## Fix
1. **Pin operator to control-plane nodes** (primary — structural): CP KubePrism talks to a local apiserver, no SideroLink dependency, no download load. CP nodes are untainted (`allowSchedulingOnControlPlanes`), so no tolerations needed. (onedr0p pins by default.)
2. **Relax leader-election** `30s/20s/4s` (defaults `15s/10s/2s`) — defense-in-depth so a transient blip can't kill it even on CP.

Operator-only values change — the agent DaemonSet / datapath is **not** touched (no networking disruption).

## Verify after merge
Operator reschedules onto a control-plane node, stops flapping (0 restarts), holds leadership cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)