### PR TITLE
feat(immich)!: immich-server + immich-machine-learning to v3.0.1 (MAJOR, shepherd-authored)

### DIFF
--- a/kubernetes/main/apps/photos/immich/machine-learning/helmrelease.yaml
+++ b/kubernetes/main/apps/photos/immich/machine-learning/helmrelease.yaml
@@ -47,7 +47,7 @@ spec:
           app:
             image:
               repository: ghcr.io/immich-app/immich-machine-learning
-              tag: v2.7.5@sha256:a2501141440f10516d329fdfba2c68082e19eb9ba6016c061ac80d23beadf7f3
+              tag: v3.0.1@sha256:cb2128c5cbc554fdaa2a036fb4419c808a9f3e0f27170e569dd9e727243da909
             env:
               TZ: America/New_York
               IMMICH_MEDIA_LOCATION: /usr/src/app/upload

--- a/kubernetes/main/apps/photos/immich/server/helmrelease.yaml
+++ b/kubernetes/main/apps/photos/immich/server/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
           app:
             image:
               repository: ghcr.io/immich-app/immich-server
-              tag: v2.7.5@sha256:c15bff75068effb03f4355997d03dc7e0fc58720c2b54ad6f7f10d1bc57efaa5
+              tag: v3.0.1@sha256:46dedfc5848f7313bd6b584ea9f2648057430307aad6de56de968f6710a72cae
             env:
               TZ: America/New_York
             envFrom:


### PR DESCRIPTION
**Shepherd-authored** (Tier-4 upgrade shepherd, mode-3), opened by the operator — the shepherd pushed the branch + analysis but `gh pr create` with a heredoc body tripped its dontAsk allowlist (a tooling quirk, not a scope issue).

## Summary

Shepherds Renovate PR #1939 (`ghcr.io/immich-app/immich-server` and `ghcr.io/immich-app/immich-machine-learning`: `v2.7.5` → `v3.0.1`, a **MAJOR**). This app runs as bjw-s `app-template` (not the official Immich Helm chart) under `kubernetes/main/apps/photos/immich/`, against the external CNPG `postgres16-pgvecto` cluster (VectorChord). Tag+digest values are copied verbatim from Renovate's already-resolved #1939 diff.

## Breaking changes audited (v3.0.0 + v3.0.1 release notes / linked `!` PRs)

Every `!`-marked breaking PR was cross-referenced against our `configmap.yaml`, `externalsecret.yaml`, and both `helmrelease.yaml` env blocks. The majority are API/mobile-client changes that don't affect this env-based server deployment. Items touching server/env/DB behavior:

1. **Removed env `IMMICH_MACHINE_LEARNING_PING_TIMEOUT`** (immich#27802) — not set anywhere here. No action.
2. **Removed ML fallback envs** `MACHINE_LEARNING_PRELOAD__*`, `MAX_BATCH_SIZE__TEXT_RECOGNITION` (immich#28326) — none set. No action.
3. **pgvecto.rs support dropped** (immich#28159) — the key one. We're already on **VectorChord** (`vchord` extension 1.1.1, within v3's required `>=0.3 <2`), don't set `DB_VECTOR_EXTENSION` (auto-detects), and the init container does `CREATE EXTENSION IF NOT EXISTS vchord CASCADE`. We are **not** on pgvecto.rs, so the removed migration path doesn't apply. No action.
4. **OAuth insecure requests disallowed by default** (immich#27844) — no `OAUTH_*` env vars in Git; OAuth (if configured) lives in Immich's DB-stored admin settings. **Unverifiable from the repo** — flagged as residual risk.
5. **`libopus` → `opus` transcode enum rename** (immich#28325) — DB-stored admin config, not in Git. Low risk (rename with internal remap).
6. **Schema migrations** (e.g. album owner → `album_user`, immich#27467) — Immich runs these automatically on `immich-server` startup. Standard Immich upgrade risk.

**Conclusion: no supporting config/manifest edits are required beyond the two image bumps.** `grep -rniE "PING_TIMEOUT|MACHINE_LEARNING_PRELOAD|MAX_BATCH_SIZE|DB_VECTOR_EXTENSION|libopus|OAUTH_" kubernetes/main/apps/photos/` → no matches.

## DB migration behavior / backup recommendation

Immich runs its Postgres migrations automatically on server startup — no manual step. Since this is a MAJOR with schema changes, **take a CNPG backup/snapshot of `postgres16-pgvecto` immediately before reconciling**. Rollback means reverting this commit **and** restoring the DB (Immich migrations don't run backwards).

## What could NOT be verified (residual risk for the reviewer)

- **DB-stored admin settings** (OAuth issuer/insecure-request, audio codec/`libopus`) live in the Postgres `system_config` table, not Git — if OAuth uses a non-HTTPS issuer, item 4 could break login.
- **Runtime behavior** — the shepherd only edits Git (read-only cluster SA); pod health, migration success, OAuth/audio are verified after a human merges + reconciles.

## Test plan

- [ ] flux-local passes (main + edge)
- [ ] Reviewer takes a CNPG snapshot of `postgres16-pgvecto` before reconciling
- [ ] After merge: reconcile `immich-server` then `immich-machine-learning`; check `immich-server` logs for clean migrations + no vector-extension startup errors
- [ ] Confirm login (esp. OAuth) + photo search/ML work
