### PR TITLE
feat(upgrade-agent): shepherd autonomy hardening — self-authored PRs, backup gate, unattended-run rules

### DIFF
--- a/.agents/runbooks/upgrade-shepherd.md
+++ b/.agents/runbooks/upgrade-shepherd.md
@@ -84,6 +84,36 @@ run on the read-only **Omni Reader** SA kubeconfig
 - **One PR at a time** for the manual tier. Merge, reconcile, verify *green*, then
   the next. Lowest blast radius first; must-move-together pairs together (below).
 
+### Operating rules injected into every run (`--append-system-prompt`)
+
+`run-shepherd.sh` composes a `SAFETY_PROMPT` that is appended to **every** mode's
+system prompt — so these hold even under the scheduled-ramp `UPGRADE_AGENT_PROMPT`
+override in the HR env. Three rules beyond the cluster-read-only / merge-safety line:
+
+1. **PR authoring — body as a FILE, never a heredoc.** The shepherd authors the PR
+   body with the `Write` tool to `/tmp/pr-body.md`, then
+   `gh pr create --title "…" --body-file /tmp/pr-body.md`. A `--body "$(cat <<EOF…)"`
+   heredoc is a compound command that the `dontAsk` allowlist auto-denies — it silently
+   blocked the shepherd from opening immich #1966 (a human had to open it). The
+   file-then-`--body-file` shape stays inside the allowlisted `Write` + `gh pr create`
+   tools.
+2. **Backup gate (stateful upgrades).** Before merging / auto-merging / forward-fixing
+   any component with durable state (cnpg·postgres, rook-ceph, dragonfly, emqx, immich,
+   authentik, paperless, the `*arr` apps…), the shepherd first confirms a **recent
+   successful backup** exists — read-only, within its SA: `kubectl get backup -n database`
+   (newest `.status.phase=completed` <24h, or the Cluster `.status.lastSuccessfulBackup`)
+   for cnpg; `kubectl get replicationsource -A` (`.status.lastSyncTime` within schedule)
+   for volsync-backed apps. No healthy backup <24h → it **HOLDs** (`HOLD: backup safety
+   net compromised for <component>`) rather than proceeding, and the existing
+   `CNPGBackupFailed`/`CNPGBackupStale`/VolSync backup-failure alerts page the human. This
+   is the in-code version of *"see a backup within 24h and move forward, else a human is
+   needed"* — it keeps the SA read-only (verify, don't trigger) and pages only when the
+   safety net is actually broken.
+3. **Autonomy.** The Job runs unattended on a schedule — no human answers a mid-task
+   question. The shepherd finishes the allowlisted work or bails with **one** structured
+   line (`BREAK-GLASS: …` or `HOLD: …`); it never ends a turn with an un-executed plan or
+   an "I'll open the PR next" that then never happens.
+
 ---
 
 ## Mode 3 — breaking-change shepherd (the core loop)

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/run-shepherd.sh
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/run-shepherd.sh
@@ -201,6 +201,22 @@ if [ "$guard_rc" -ne 0 ]; then
   esac
 fi
 
+# ── Cross-cutting operating rules, injected into EVERY mode's system prompt so they hold
+# regardless of which task PROMPT is active (incl. the scheduled-ramp override in the HR
+# env). Built up on their OWN lines — apostrophes and braces inside a ${VAR:-default}
+# break bash quote parsing, and $( ) must be escaped as \$( ) so it isn't run here.
+SAFETY_PROMPT="SAFETY: read-only cluster default; ALL cluster changes go via a PR to kubernetes/**; NEVER kubectl apply/exec/delete; ${SAFETY_MERGE}; stay inside kubernetes/**."
+# (1) PR AUTHORING — the fix for the heredoc dontAsk denial that blocked the shepherd from
+# opening its own PRs (immich #1966): author the body as a FILE, never a command-sub.
+SAFETY_PROMPT="${SAFETY_PROMPT} PR AUTHORING: to open a PR, FIRST write the body to a file with the Write tool (e.g. /tmp/pr-body.md), THEN run 'gh pr create --title \"...\" --body-file /tmp/pr-body.md'. NEVER build the body with a heredoc or \$(cat ...) command substitution — that compound form is auto-denied and the PR will silently fail to open."
+# (2) BACKUP GATE — before touching anything with durable state, confirm the auto-backup
+# safety net is intact (read-only; the shepherd has kubectl get). A stale/failed backup
+# means a human is needed (the CNPG/VolSync backup-failure alerts already page), so HOLD.
+SAFETY_PROMPT="${SAFETY_PROMPT} BACKUP GATE: before you merge, enable auto-merge on, or forward-fix any component backed by a database or persistent volume (cnpg/postgres, rook-ceph, dragonfly, emqx, immich, authentik, paperless, the *arr apps, etc.), FIRST verify a recent SUCCESSFUL backup exists — for cnpg: 'kubectl get backup -n database' (newest .status.phase=completed within 24h) or the Cluster .status.lastSuccessfulBackup; for volsync-backed apps: 'kubectl get replicationsource -A' (.status.lastSyncTime within its schedule). If no healthy backup within 24h exists, do NOT proceed — stop with one line 'HOLD: backup safety net compromised for <component>'. Stateless components need no backup check."
+# (3) AUTONOMY — this Job runs unattended on a schedule; there is no human to answer a
+# mid-task question. Finish the allowlisted work or bail with ONE structured line.
+SAFETY_PROMPT="${SAFETY_PROMPT} AUTONOMY: you run UNATTENDED — no human is watching this run. For reversible, in-scope actions proceed without asking. NEVER end your turn with a question, a plan, or an 'I will…' you have not executed — either complete the allowlisted work now, or stop with a single 'BREAK-GLASS: <reason>' or 'HOLD: <reason>' line."
+
 log "MODE=$MODE model=$MODEL max_turns=$MAX_TURNS budget=\$$MAX_BUDGET cap=\$$MONTHLY_CAP"
 set +e
 OUT_FILE="$(mktemp 2>/dev/null || echo /tmp/claude-out.json)"
@@ -208,7 +224,7 @@ timeout "$RUN_TIMEOUT" claude -p "$PROMPT" \
   --permission-mode dontAsk \
   --allowedTools "${ALLOWED[@]}" \
   --disallowedTools "WebFetch" "WebSearch" \
-  --append-system-prompt "SAFETY: read-only cluster default; ALL cluster changes go via a PR to kubernetes/**; NEVER kubectl apply/exec/delete; ${SAFETY_MERGE}; stay inside kubernetes/**." \
+  --append-system-prompt "$SAFETY_PROMPT" \
   --max-turns "$MAX_TURNS" \
   --max-budget-usd "$MAX_BUDGET" \
   --model "$MODEL" \


### PR DESCRIPTION
## What

Three cross-cutting operating rules injected into **every** shepherd mode's `--append-system-prompt` (so they hold under the scheduled-ramp prompt override too), plus runbook docs. This is the "make the shepherd truly hands-off" hardening — it closes the gaps that forced a human step in the immich v3 run.

### 1. PR authoring via `--body-file` (bug fix)
The shepherd authored the immich #1966 branch + analysis but **could not open its own PR** — `gh pr create --body "$(cat <<EOF…)"` is a compound command the `dontAsk` allowlist auto-denies, so a human had to open it. Now: `Write` the body to `/tmp/pr-body.md`, then `gh pr create --body-file` (both already allowlisted). No allowlist change needed.

### 2. Backup gate (stateful upgrades)
Before merging / auto-merging / forward-fixing any component with durable state (cnpg·postgres, rook-ceph, dragonfly, emqx, immich, authentik, paperless, `*arr`…), the shepherd first verifies a **recent (<24h) successful backup** exists — read-only, within its SA:
- cnpg: `kubectl get backup -n database` (newest `.status.phase=completed`) / Cluster `.status.lastSuccessfulBackup`
- volsync: `kubectl get replicationsource -A` (`.status.lastSyncTime`)

No healthy backup <24h → **HOLD** (`HOLD: backup safety net compromised for <component>`); the existing `CNPGBackupFailed`/`CNPGBackupStale`/VolSync alerts page the human. This is the in-code form of *"see a backup within 24h and move forward, else a human is needed"* — it **keeps the SA read-only** (verify, don't trigger a backup) and pages only when the safety net is actually broken.

### 3. Autonomy
The Job runs unattended on a schedule — no human answers a mid-task question. Finish the allowlisted work or bail with **one** structured line (`BREAK-GLASS:`/`HOLD:`); never end a turn with an un-executed plan.

## Safety envelope — unchanged
No scope or security widening. Read-only cluster SA, egress CiliumNetworkPolicy, diff-scope author-gate, push-protection rulesets, Kyverno enforce, and the $50/mo spend guard are all untouched. `gh pr merge` remains blocked in shepherd mode. This PR only makes the shepherd better at its existing, already-bounded job.

## Test plan
- [x] `bash -n` clean; `\$(cat ...)` verified to render as literal text (not executed)
- [x] `kubectl kustomize` renders; ConfigMap carries the new rules
- [ ] flux-local (main + edge) green
- [ ] After merge + reconcile: next scheduled run's `--append-system-prompt` carries the three rules (visible in the pod's rendered prompt / CM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
