### PR TITLE
feat(upgrade-agent): widen auto-merge ramp to first stateful leaf app (immich, backup-gated)

### DIFF
--- a/docs/renovate/README.md
+++ b/docs/renovate/README.md
@@ -395,18 +395,31 @@ Structural backstops regardless of prompt: diff-scope (bot PRs must be pure bump
 `kubernetes/**`), required checks, non-admin bot, Kyverno enforce, the $50/mo spend
 guard, and the health gate + guardrail alerts.
 
-| Component | In ramp since | Notes |
-|---|---|---|
-| `coredns` | 2026-07-03 | clean rollback |
-| `traefik` | 2026-07-03 | clean; internal→external order per playbook |
-| `multus` | 2026-07-03 | clean, node-wide blast on breakage (gate catches) |
-| `device-plugins` | 2026-07-03 | clean; Plex-unschedulable failure mode |
-| `flux` | 2026-07-03 | first proven auto-merge (#1917, v2.9.0, 2026-07-03) |
+| Component | Class | In ramp since | Notes |
+|---|---|---|---|
+| `coredns` | stateless | 2026-07-03 | clean rollback |
+| `traefik` | stateless | 2026-07-03 | clean; internal→external order per playbook |
+| `multus` | stateless | 2026-07-03 | clean, node-wide blast on breakage (gate catches) |
+| `device-plugins` | stateless | 2026-07-03 | clean; Plex-unschedulable failure mode |
+| `flux` | stateless | 2026-07-03 | first proven auto-merge (#1917, v2.9.0, 2026-07-03) |
+| `immich` | **stateful** | 2026-07-05 | first stateful add; minor/patch image bumps only, backup-gated on `postgres16-pgvecto` (@daily ScheduledBackup); **majors stay author-only** (one-way PG migration — v2→v3 was hand-run). Health-gate + auto-revert catch a bad minor. |
 
-Explicitly **excluded** (never in the ramp without a design change): all majors, the
-HA pod group, cnpg, rook-ceph/ceph-csi-drivers, cilium, authentik, emqx,
-dragonfly-operator. Supporting-edit upgrades arrive as shepherd-authored `shepherd/*`
-PRs for **human merge** (diff-scope structurally blocks the bot auto-merging those).
+**Two ramp classes.** *Stateless* clean-tier components auto-merge any pure bump. A
+*stateful* leaf app (durable DB/PVC) auto-merges only **minor/patch** pure image bumps,
+and only after the **backup gate** (`--append-system-prompt` in `run-shepherd.sh`)
+confirms a recent <24h successful backup of its data store — else the shepherd HOLDs and
+the CNPG/VolSync backup-failure alert pages. A stateful **major** (one-way migration) is
+always shepherd-authored for **human merge**. Widen the stateful class one leaf app at a
+time, verifying its data store has a working scheduled backup first (else the gate HOLDs
+it forever). Next candidates in this class: `paperless`, media leaf apps — **not** the
+`*arr` set while their Unraid→cluster migration is in flight, and **not** SSO (`authentik`).
+
+Explicitly **excluded** (never in the ramp without a design change): operator/DB-engine
+bumps (cnpg, rook-ceph/ceph-csi-drivers, dragonfly-operator, emqx), cilium, the HA pod
+group, authentik, and all majors except where a stateful leaf app's major is explicitly
+author-only above. Supporting-edit upgrades arrive as shepherd-authored `shepherd/*`
+PRs for **human merge** (diff-scope structurally blocks the bot auto-merging those —
+until the operator-gated diff-scope widening lands).
 
 Kill switch: `kubectl -n upgrade-agent patch cronjob upgrade-shepherd -p '{"spec":{"suspend":true}}'`.
 

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
@@ -14,7 +14,9 @@ spec:
       upgrade-shepherd:
         type: cronjob
         # PHASE D LIVE (2026-07-03): scheduled unattended auto-merge, ONE PR/day max,
-        # scope-constrained by UPGRADE_AGENT_PROMPT below to the clean-rollback tier.
+        # scope-constrained by UPGRADE_AGENT_PROMPT below — the stateless clean-rollback
+        # tier PLUS stateful leaf apps (immich, 2026-07-05) whose minor/patch bumps are
+        # gated by the backup check + health gate + auto-revert (majors stay author-only).
         # Server-side safety: the bot is non-admin/non-bypass — `gh pr merge --auto`
         # only queues; GitHub merges only when Flux Local AND Diff Scope are green.
         # Kill switch (instant, no git):
@@ -79,29 +81,40 @@ spec:
                 kubernetes/main/apps/kube-system/nvidia-device-plugin/
                 kubernetes/main/flux/
                 kubernetes/edge/flux/
+                kubernetes/main/apps/photos/immich/
               # The auto-merge RAMP lives here: widen the component list one entry at a
               # time as each proves quiet (docs/renovate/README.md tracks the ramp), and
               # re-run /kyverno-verify after each widening.
               UPGRADE_AGENT_PROMPT: >-
                 You are the Tier-4 upgrade shepherd in AUTO mode (scheduled, unattended).
                 Follow .agents/runbooks/upgrade-shepherd.md.
-                AUTO-MERGE SCOPE (current ramp): pure version/chart/digest bumps for
-                coredns, traefik, multus, device-plugins, and flux ONLY — no majors,
-                no other components, nothing that needs a supporting values edit.
+                AUTO-MERGE SCOPE (current ramp) — two classes:
+                (1) STATELESS clean-tier: coredns, traefik, multus, device-plugins, flux
+                — any pure version/chart/digest bump (incl. minor). No backup needed.
+                (2) STATEFUL leaf app: immich (kubernetes/main/apps/photos/immich). Only
+                MINOR or PATCH pure image bumps, and ONLY after the BACKUP GATE passes
+                (verify a recent <24h successful backup of its DB cluster
+                postgres16-pgvecto per the append-system-prompt rule; if none, HOLD). For
+                an immich MAJOR (one-way Postgres migration — v2->v3 was one), do NOT
+                auto-merge: author the PR on a NEW branch shepherd/immich-<version> with
+                the breaking-change + backup analysis for HUMAN merge.
+                In BOTH classes, nothing that needs a supporting values edit auto-merges.
                 Survey open Renovate PRs (gh pr list); pick the NEXT in-scope PR by the
                 runbook merge-order table. CONSULT .renovate/holds.json5 FIRST — skip
                 anything held. Read the release notes and the component playbook
-                (.agents/runbooks/tier4-component-playbooks.md). If it is a pure bump
-                needing NO supporting edit: enable auto-merge with
+                (.agents/runbooks/tier4-component-playbooks.md). If it is an in-scope pure
+                bump needing NO supporting edit (and, for immich, a minor/patch that
+                clears the backup gate): enable auto-merge with
                 gh pr merge <N> --auto --squash --delete-branch (GitHub merges only when
                 Flux Local AND Diff Scope are both green). If an IN-SCOPE component needs
-                a supporting edit: author it on a NEW branch shepherd/<pkg>-<version>,
-                open a PR for HUMAN merge, and do NOT enable auto-merge on it. Everything
-                out of scope (majors, cnpg, rook-ceph, ceph-csi-drivers, cilium,
-                authentik, emqx, dragonfly-operator, the home-assistant pod group): leave
-                untouched, just list it in your summary. NEVER merge immediately, NEVER
-                use --admin, NEVER push to main, stay inside kubernetes/**. AT MOST ONE
-                auto-merge per run, then stop and summarize.
+                a supporting edit, or is an immich major: author it on a NEW branch
+                shepherd/<pkg>-<version>, open a PR for HUMAN merge, and do NOT enable
+                auto-merge on it. Everything out of scope (other majors, cnpg, rook-ceph,
+                ceph-csi-drivers, cilium, authentik, emqx, dragonfly-operator, paperless,
+                the *arr apps, the home-assistant pod group): leave untouched, just list
+                it in your summary. NEVER merge immediately, NEVER use --admin, NEVER push
+                to main, stay inside kubernetes/**. AT MOST ONE auto-merge per run, then
+                stop and summarize.
               # ANTHROPIC_API_KEY comes from the LLM secret ONLY (never the bot secret).
               ANTHROPIC_API_KEY:
                 valueFrom:


### PR DESCRIPTION
## What

Widens the unattended auto-merge ramp to its **first stateful component**, per the operator's 2026-07-05 scope decision ("app images + safe chart patches that don't change an operator/DB-engine version"). First add: **immich** — the leaf app proven hands-off this session (the v3 shepherd test).

## Two ramp classes now

| Class | Auto-merge scope | Safety |
|---|---|---|
| **Stateless** (coredns, traefik, multus, device-plugins, flux) | any pure bump | health gate + auto-revert |
| **Stateful** (immich) | **minor/patch** image bumps only, **backup-gated** | backup gate (#1968) + health gate + auto-revert; **majors author-only** |

Both lockstep ramp vars in the shepherd HR are widened together:
- `UPGRADE_AGENT_PREFILTER_GLOBS` += `kubernetes/main/apps/photos/immich/`
- `UPGRADE_AGENT_PROMPT` gains the stateful class rules

## Why this is safe now (it wasn't before #1968)

- **Backup gate**: the shepherd verifies a recent `<24h` successful backup of immich's DB cluster `postgres16-pgvecto` before enabling auto-merge. Verified: that cluster runs an `@daily` `ScheduledBackup` with a completed restore point from today. No backup → the shepherd HOLDs and the `CNPGBackupStale` alert pages.
- **Majors stay author-only**: an immich major is a one-way Postgres migration (v2→v3 was hand-run). The shepherd authors the PR + backup analysis; a human merges. Only minor/patch pure bumps auto-merge.
- **Health gate + auto-revert**: a bad minor is caught post-merge and git-reverted; a one-way migration failure escalates to BREAK-GLASS (human paged for a restore from the gated backup).
- **No security-gate change**: pure bumps already pass diff-scope. A supporting-edit immich PR still can't auto-merge (diff-scope blocks it) — it becomes author-only.

## Ramp discipline

Widen the stateful class **one leaf app at a time**, verifying each app's data store has a working scheduled backup first (else the gate HOLDs it forever). Next candidates documented in the README: `paperless`, media leaf apps — **not** the `*arr` set (Unraid→cluster migration in flight), **not** SSO (`authentik`).

## Test plan
- [x] `kubectl kustomize` renders; both ramp vars carry immich; folded prompt intact
- [x] `postgres16-pgvecto` `@daily` ScheduledBackup confirmed (completed restore point today)
- [ ] flux-local (main + edge) green
- [ ] After merge + reconcile: next immich Renovate minor/patch → shepherd summoned by pre-filter → backup gate passes → auto-merge queued (health gate watches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
