### PR TITLE
feat(renovate): hands-off default — auto-merge all but cluster-breakers + PR disposition labeler

### DIFF
--- a/.github/workflows/pr-disposition.yml
+++ b/.github/workflows/pr-disposition.yml
@@ -1,0 +1,106 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# PR disposition labeler — makes the auto-merge board visible on the PR list itself,
+# so "which merges itself vs which is waiting for me" is readable at a glance (the
+# renovate/type labels don't tell you). Labels each OPEN Renovate PR with exactly one:
+#
+#   disposition:auto-merge  — GitHub auto-merge is enabled (Renovate Tier-0/2); it merges
+#                             itself when checks go green. Nothing for you to do.
+#   disposition:shepherd    — a shepherd-ramp component (coredns/traefik/multus/
+#                             device-plugins/flux, or an immich major); the daily
+#                             upgrade-shepherd run vets + auto-merges it. Nothing for you.
+#   disposition:stranded    — waiting for YOU: a cluster-breaker, a non-ramp major, or
+#                             anything else outside both auto paths.
+#
+# Read-only classification; only manipulates its own three labels. Runs on a schedule
+# (catches Renovate enabling auto-merge after it re-evaluates) + on demand.
+name: PR Disposition
+
+on:
+  schedule:
+    - cron: '17 */2 * * *'   # every 2h at :17
+  workflow_dispatch: {}
+
+concurrency:
+  group: pr-disposition
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label open Renovate PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const OWNER = context.repo.owner, REPO = context.repo.repo;
+            // ── policy mirrors (keep in sync with .renovate/autoMerge.json5 + the
+            //    shepherd HR UPGRADE_AGENT_PREFILTER_GLOBS) ────────────────────────────
+            // Renovate Tier-2 auto-merges minor/patch/digest in these leaf-app domains:
+            const TIER2_DOMAINS = ['media','ai','downloads','frontend','office','photos','observability','home-automation'];
+            // ...and these curated kube-system/network leaves (by <domain>/<app>):
+            const CURATED_LEAVES = ['kube-system/metrics-server','kube-system/reloader','kube-system/reflector','kube-system/k8tz','kube-system/spegel','network/cloudflare-ddns'];
+            // Shepherd-ramp clean-tier prefixes (shepherd auto-merges these, incl. minor):
+            const RAMP_CLEAN = [
+              'kubernetes/main/apps/kube-system/coredns/','kubernetes/edge/apps/kube-system/coredns/',
+              'kubernetes/main/apps/network/traefik/','kubernetes/main/apps/network/multus/',
+              'kubernetes/main/apps/kube-system/generic-device-plugin/','kubernetes/main/apps/kube-system/intel-device-plugin/',
+              'kubernetes/main/apps/kube-system/nvidia-device-plugin/','kubernetes/main/flux/','kubernetes/edge/flux/',
+            ];
+            const IMMICH = 'kubernetes/main/apps/photos/immich/';
+            const DISPOS = ['disposition:auto-merge', 'disposition:shepherd', 'disposition:stranded'];
+            const isRenovate = (l) => /renovate/i.test(l || '');
+            const tier2Path = (p) => {
+              const m = p.match(/^kubernetes\/[^/]+\/apps\/([^/]+)\/(.+)$/);
+              if (!m) return false;
+              if (TIER2_DOMAINS.includes(m[1])) return true;
+              return CURATED_LEAVES.includes(m[1] + '/' + m[2].split('/')[0]);
+            };
+
+            const prs = await github.paginate(github.rest.pulls.list, { owner: OWNER, repo: REPO, state: 'open', per_page: 100 });
+            let n = 0;
+            for (const pr of prs) {
+              if (!isRenovate(pr.user && pr.user.login)) continue;
+              n++;
+              const files = await github.paginate(github.rest.pulls.listFiles, { owner: OWNER, repo: REPO, pull_number: pr.number, per_page: 100 });
+              const paths = files.map(f => f.filename);
+              const labelNames = (pr.labels || []).map(l => l.name);
+              const brtitle = (pr.head.ref + ' ' + pr.title).toLowerCase();
+              const isMajor = labelNames.includes('type/major');
+              const isImmich = paths.some(p => p.startsWith(IMMICH));
+              const inCleanRamp = paths.some(p => RAMP_CLEAN.some(r => p.startsWith(r)));
+              // Tier-2 auto-merge PREDICTION (Renovate will enable GH auto-merge on its
+              // next run even if pr.auto_merge is not set yet): every changed file is
+              // Tier-2-eligible, it's not a major, and nothing is held.
+              const allTier2 = paths.length > 0 && paths.every(tier2Path);
+              const ownImage = /thaynes43/.test(brtitle) || /kube-prometheus-stack/.test(brtitle);
+              const ghActions = paths.length > 0 && paths.every(p => p.startsWith('.github/'));
+
+              let want;
+              if (pr.auto_merge) {
+                want = 'disposition:auto-merge';                       // ground truth
+              } else if (isImmich && isMajor) {
+                want = 'disposition:shepherd';                         // immich major → shepherd
+              } else if (!isMajor && (allTier2 || ownImage || ghActions)) {
+                want = 'disposition:auto-merge';                       // Renovate Tier-0/2 (pending its next run)
+              } else if (!isMajor && inCleanRamp) {
+                want = 'disposition:shepherd';                         // clean-tier ramp → shepherd
+              } else {
+                want = 'disposition:stranded';                         // cluster-breaker / non-ramp major / other → you
+              }
+
+              for (const d of DISPOS) {
+                if (d !== want && labelNames.includes(d)) {
+                  try { await github.rest.issues.removeLabel({ owner: OWNER, repo: REPO, issue_number: pr.number, name: d }); } catch (e) {}
+                }
+              }
+              if (!labelNames.includes(want)) {
+                await github.rest.issues.addLabels({ owner: OWNER, repo: REPO, issue_number: pr.number, labels: [want] });
+              }
+              core.info(`#${pr.number} ${pr.title.slice(0,60)} -> ${want}`);
+            }
+            core.info(`Classified ${n} open Renovate PR(s).`);

--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -76,6 +76,14 @@
         'kubernetes/*/apps/office/**',
         'kubernetes/*/apps/photos/**',
         'kubernetes/*/apps/observability/**',
+        // home-automation added 2026-07-05 (hands-off directive: only cluster-breakers
+        // stay manual). All leaf apps — HA, esphome, z2m, zwave, music-assistant,
+        // appdaemon, go2rtc, ha-mcp, music-assistant — plain Deployments, no operator/
+        // CRD/StatefulSet. HA + z2m are the highest-blast members (a bad bump degrades
+        // the smart home, not the cluster); the flux-local gate + the HA watchdogs +
+        // nightly HA backups are the safety net. appdaemon is ghcr.io/thaynes43/* (also
+        // Tier-2 by the "our own images" rule).
+        'kubernetes/*/apps/home-automation/**',
       ],
       // 'digest' (2026-06-28): SHA-pinned image refreshes on the SAME tag are at
       // least as safe as minor/patch for these stateless single-pod apps, yet the
@@ -116,14 +124,13 @@
       ignoreTests: false,
       minimumReleaseAge: '3 days',
     },
-    // Carve-out: Immich ships breaking schema/DB migrations even on minor and
-    // documents manual upgrade steps — keep it MANUAL despite living in photos/.
-    // (Scoped to immich-app/* so it does NOT catch our ghcr.io/thaynes43/hass-immich-addon.)
-    {
-      description: 'Immich: breaking migrations -> never auto-merge',
-      matchDatasources: ['docker'],
-      matchPackageNames: ['/immich-app//'],
-      automerge: false,
-    },
+    // Immich carve-out REMOVED 2026-07-05 (hands-off directive). Immich minor/patch/
+    // digest now auto-merge via the photos leaf-app rule above — it is not cluster-
+    // breaking, and the safety net (flux-local + health gate + auto-revert + the daily
+    // postgres16-pgvecto backup + the CNPG backup-failure alerts) covers a bad minor
+    // migration. Immich MAJORS still never auto-merge here (the leaf rule is minor/
+    // patch/digest only) — the upgrade-shepherd owns immich majors (reads the release
+    // notes, backup-gates, and auto-merges a pure major or authors a supporting-edit PR
+    // for review). See kubernetes/main/apps/upgrade-agent/shepherd + docs/renovate/README.md.
   ],
 }

--- a/docs/renovate/README.md
+++ b/docs/renovate/README.md
@@ -402,24 +402,25 @@ guard, and the health gate + guardrail alerts.
 | `multus` | stateless | 2026-07-03 | clean, node-wide blast on breakage (gate catches) |
 | `device-plugins` | stateless | 2026-07-03 | clean; Plex-unschedulable failure mode |
 | `flux` | stateless | 2026-07-03 | first proven auto-merge (#1917, v2.9.0, 2026-07-03) |
-| `immich` | **stateful** | 2026-07-05 | first stateful add; minor/patch image bumps only, backup-gated on `postgres16-pgvecto` (@daily ScheduledBackup); **majors stay author-only** (one-way PG migration — v2→v3 was hand-run). Health-gate + auto-revert catch a bad minor. |
+| `immich` majors | **stateful** | 2026-07-05 | shepherd owns immich MAJORS only — backup-gated on `postgres16-pgvecto` (@daily ScheduledBackup), auto-merge a pure major / author-only if it needs a supporting edit. immich minor/patch auto-merge via **Renovate Tier-2** (the old "immich=manual" carve-out was removed 2026-07-05). |
 
-**Two ramp classes.** *Stateless* clean-tier components auto-merge any pure bump. A
-*stateful* leaf app (durable DB/PVC) auto-merges only **minor/patch** pure image bumps,
-and only after the **backup gate** (`--append-system-prompt` in `run-shepherd.sh`)
-confirms a recent <24h successful backup of its data store — else the shepherd HOLDs and
-the CNPG/VolSync backup-failure alert pages. A stateful **major** (one-way migration) is
-always shepherd-authored for **human merge**. Widen the stateful class one leaf app at a
-time, verifying its data store has a working scheduled backup first (else the gate HOLDs
-it forever). Next candidates in this class: `paperless`, media leaf apps — **not** the
-`*arr` set while their Unraid→cluster migration is in flight, and **not** SSO (`authentik`).
+**Operating principle (2026-07-05): auto-merge is the DEFAULT; only cluster-breakers are
+non-auto.** The shepherd (LLM vetting + backup gate + health gate + auto-revert) is the
+safety net, so every non-cluster-breaker bump auto-merges. Two mechanisms:
+- **Renovate Tier-2** auto-merges minor/patch/digest for all safe leaf-app domains
+  (`media, ai, downloads, frontend, office, photos, observability, home-automation`) +
+  curated kube-system/network utilities — flux-local-gated, no shepherd needed.
+- **The shepherd ramp (this table)** owns the cluster-adjacent components that need
+  careful vetting: the stateless clean-tier (coredns/traefik/multus/device-plugins/flux)
+  and immich majors. It also catches **majors** of ramp components.
 
-Explicitly **excluded** (never in the ramp without a design change): operator/DB-engine
-bumps (cnpg, rook-ceph/ceph-csi-drivers, dragonfly-operator, emqx), cilium, the HA pod
-group, authentik, and all majors except where a stateful leaf app's major is explicitly
-author-only above. Supporting-edit upgrades arrive as shepherd-authored `shepherd/*`
-PRs for **human merge** (diff-scope structurally blocks the bot auto-merging those —
-until the operator-gated diff-scope widening lands).
+**Cluster-breakers = the only non-auto set** (shepherd where possible, human last resort):
+cilium, coredns, flux, rook-ceph/ceph-csi (storage), the DB operators (cnpg,
+dragonfly-operator, emqx-operator), cert-manager, external-secrets, authentik (SSO),
+Talos/node. Plus: **majors** of anything get shepherd/human review, and **supporting-edit
+PRs** stay human-merge (the diff-scope security gate — the one accepted human-in-loop;
+see the diff-scope adversarial suite `scripts/diff-scope-test.sh` for why widening it is
+unsafe). Everything else auto-merges.
 
 Kill switch: `kubectl -n upgrade-agent patch cronjob upgrade-shepherd -p '{"spec":{"suspend":true}}'`.
 

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
@@ -15,8 +15,9 @@ spec:
         type: cronjob
         # PHASE D LIVE (2026-07-03): scheduled unattended auto-merge, ONE PR/day max,
         # scope-constrained by UPGRADE_AGENT_PROMPT below — the stateless clean-rollback
-        # tier PLUS stateful leaf apps (immich, 2026-07-05) whose minor/patch bumps are
-        # gated by the backup check + health gate + auto-revert (majors stay author-only).
+        # tier PLUS immich MAJORS (2026-07-05; backup-gated auto-merge for a pure major,
+        # author-only if it needs a supporting edit). Non-cluster-breaker LEAF apps
+        # (incl. immich minor/patch) auto-merge via Renovate Tier-2, not here.
         # Server-side safety: the bot is non-admin/non-bypass — `gh pr merge --auto`
         # only queues; GitHub merges only when Flux Local AND Diff Scope are green.
         # Kill switch (instant, no git):
@@ -91,30 +92,30 @@ spec:
                 AUTO-MERGE SCOPE (current ramp) — two classes:
                 (1) STATELESS clean-tier: coredns, traefik, multus, device-plugins, flux
                 — any pure version/chart/digest bump (incl. minor). No backup needed.
-                (2) STATEFUL leaf app: immich (kubernetes/main/apps/photos/immich). Only
-                MINOR or PATCH pure image bumps, and ONLY after the BACKUP GATE passes
-                (verify a recent <24h successful backup of its DB cluster
-                postgres16-pgvecto per the append-system-prompt rule; if none, HOLD). For
-                an immich MAJOR (one-way Postgres migration — v2->v3 was one), do NOT
-                auto-merge: author the PR on a NEW branch shepherd/immich-<version> with
-                the breaking-change + backup analysis for HUMAN merge.
-                In BOTH classes, nothing that needs a supporting values edit auto-merges.
+                (2) STATEFUL — immich MAJORS (kubernetes/main/apps/photos/immich).
+                Renovate auto-merges immich MINOR/PATCH itself now — if the only in-scope
+                immich PR is a minor/patch, LEAVE it (Renovate owns it, do not act). You
+                own immich MAJORS: after the BACKUP GATE passes (recent <24h backup of its
+                DB cluster postgres16-pgvecto per the append-system-prompt rule; if none,
+                HOLD), a major that is a PURE image bump needing NO supporting edit is
+                treated like class (1) and auto-merged; a major needing a supporting
+                values edit is authored for review (diff-scope holds it for a human).
                 Survey open Renovate PRs (gh pr list); pick the NEXT in-scope PR by the
                 runbook merge-order table. CONSULT .renovate/holds.json5 FIRST — skip
                 anything held. Read the release notes and the component playbook
                 (.agents/runbooks/tier4-component-playbooks.md). If it is an in-scope pure
-                bump needing NO supporting edit (and, for immich, a minor/patch that
-                clears the backup gate): enable auto-merge with
+                bump needing NO supporting edit (immich majors: one that clears the backup
+                gate): enable auto-merge with
                 gh pr merge <N> --auto --squash --delete-branch (GitHub merges only when
-                Flux Local AND Diff Scope are both green). If an IN-SCOPE component needs
-                a supporting edit, or is an immich major: author it on a NEW branch
-                shepherd/<pkg>-<version>, open a PR for HUMAN merge, and do NOT enable
-                auto-merge on it. Everything out of scope (other majors, cnpg, rook-ceph,
-                ceph-csi-drivers, cilium, authentik, emqx, dragonfly-operator, paperless,
-                the *arr apps, the home-assistant pod group): leave untouched, just list
-                it in your summary. NEVER merge immediately, NEVER use --admin, NEVER push
-                to main, stay inside kubernetes/**. AT MOST ONE auto-merge per run, then
-                stop and summarize.
+                Flux Local AND Diff Scope are both green). If it needs a supporting edit:
+                author it on a NEW branch shepherd/<pkg>-<version>, open a PR (diff-scope
+                holds it for human review), do NOT enable auto-merge. Everything out of
+                scope — the cluster-breakers (cnpg, rook-ceph, ceph-csi-drivers, cilium,
+                authentik, emqx, dragonfly-operator, cert-manager, external-secrets) and
+                any non-ramp component's major: leave untouched, just list it in your
+                summary. NEVER merge immediately, NEVER use --admin, NEVER push to main,
+                stay inside kubernetes/**. AT MOST ONE auto-merge per run, then stop and
+                summarize.
               # ANTHROPIC_API_KEY comes from the LLM secret ONLY (never the bot secret).
               ANTHROPIC_API_KEY:
                 valueFrom:


### PR DESCRIPTION
## Operating principle (your call, 2026-07-05)

**Auto-merge is the default. Only cluster-breakers stay non-auto.** The shepherd (LLM vetting + backup gate + health gate + auto-revert) is the safety net, so every non-cluster-breaker bump merges hands-off.

**Cluster-breakers (the only non-auto set):** cilium, coredns, flux, rook-ceph/ceph-csi, the DB operators (cnpg/dragonfly-operator/emqx-operator), cert-manager, external-secrets, authentik, Talos/node. Plus **majors** of anything get shepherd/human review, and **supporting-edit PRs** stay human-merge (the diff-scope security gate). Everything else auto-merges.

## Changes

**`.renovate/autoMerge.json5`**
- **Removed the "immich = manual" carve-out.** immich isn't cluster-breaking; minor/patch/digest now auto-merge via the `photos` leaf rule, covered by flux-local + health gate + auto-revert + the daily `postgres16-pgvecto` backup + the CNPG backup-failure alerts. Majors still don't auto-merge here.
- **Added `home-automation`** to the Tier-2 leaf-app domains (all leaf Deployments — HA, esphome, z2m, zwave, music-assistant, appdaemon, go2rtc, ha-mcp; verified no operator/CRD/StatefulSet). This clears the currently-stranded esphome / music-assistant / code-server PRs.

**Shepherd HR** — immich **majors** are now shepherd-owned: backup-gated auto-merge for a pure major, author-only (diff-scope holds for review) if a major needs a supporting edit. Renovate owns immich minor/patch.

**`docs/renovate/README.md`** — documents the principle, the cluster-breaker set, and the two auto-merge mechanisms.

**`.github/workflows/pr-disposition.yml` (new)** — the disposition labeler you asked for. Tags every open Renovate PR with exactly one label so the board is visible in the GitHub PR list:
- `disposition:auto-merge` — merges itself on green (Renovate Tier-0/2). Nothing for you.
- `disposition:shepherd` — the daily shepherd run handles it (clean-tier ramp / immich major). Nothing for you.
- `disposition:stranded` — waiting for **you** (cluster-breaker, non-ramp major, or other).

It *predicts* the disposition (mirrors the Tier-2 domain + ramp rules), so a Tier-2-eligible PR reads `auto-merge` immediately rather than `stranded` until Renovate re-runs. Runs every 2h + on demand; only touches its own three labels.

## Effect on the current 7 stranded PRs (once this lands + Renovate re-evaluates)
- #1908 esphome, #1936 code-server, #1922 music-assistant → **auto-merge** (home-automation now Tier-2)
- #1938 recyclarr v8, #1918 node v24 → **stranded** (majors — need review; node is the shepherd's own build image)
- #1921 ceph-csi, #1963 restic → **stranded** (storage cluster-breaker / the backup engine)

## Test plan
- [x] `autoMerge.json5` valid JSON5; shepherd HR renders; immich prefilter glob intact
- [ ] flux-local (main + edge) green
- [ ] After merge: run the labeler (`workflow_dispatch`) and confirm the 7 PRs get the labels above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
