### PR TITLE
chore(haynesnetwork): deploy v0.4.0

### DIFF
--- a/kubernetes/main/apps/frontend/haynesnetwork/app/helmrelease.yaml
+++ b/kubernetes/main/apps/frontend/haynesnetwork/app/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
           migrate:
             image: &mainImage
               repository: ghcr.io/thaynes43/haynesnetwork
-              tag: v0.3.1
+              tag: v0.4.0
               pullPolicy: IfNotPresent
             command:
               - tsx


### PR DESCRIPTION
Bump `ghcr.io/thaynes43/haynesnetwork` → **v0.4.0** (unified roles, arbitrary catalog URLs, inline confirm + drag-drop reorder, library sub-tabs). Testing against live *arr APIs on the cluster.

> Note: v0.4.0 includes a clean-cut role migration (0007) — the app DB will re-seed roles on rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)