### PR TITLE
feat(media): deploy maintainerr

### DIFF
--- a/kubernetes/main/apps/media/kustomization.yaml
+++ b/kubernetes/main/apps/media/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./bazarr/ks.yaml
   - ./kometa/ks.yaml
   - ./lidarr/ks.yaml
+  - ./maintainerr/ks.yaml
   - ./plexops/ks.yaml
   - ./plex/ks.yaml
   - ./radarr/ks.yaml

--- a/kubernetes/main/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/maintainerr/app/helmrelease.yaml
@@ -1,0 +1,140 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: maintainerr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      maintainerr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          # Keep off the control-plane nodes (critical smart-home stack).
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
+        containers:
+          app:
+            # Upstream moved from jorenn92/* to the maintainerr org. GHCR
+            # container tags drop the `v` prefix used by the git release tags
+            # (git v3.17.0 -> image 3.17.0); `vX.Y.Z` here 404s on pull.
+            image:
+              repository: ghcr.io/maintainerr/maintainerr
+              tag: 3.17.0
+            env:
+              TZ: America/New_York
+              # Defaults are fine (UI_HOSTNAME=0.0.0.0, UI_PORT=6246). BASE_PATH
+              # is intentionally unset — served at the domain root, not a subpath.
+              UI_PORT: &port 6246
+            probes:
+              # Liveness pings /live (process-only, no DB) so a transient SQLite
+              # blip never triggers a restart loop.
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health/live
+                    port: *port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              # Readiness pings /ready (checks the DB) -> pod leaves rotation if
+              # the DB is unreachable, without a restart.
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health/ready
+                    port: *port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health/live
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              # Maintainerr bundles a Next.js UI that writes inside /opt/app at
+              # runtime; the config PVC covers durable state but the rootfs can't
+              # be locked down like the *arrs (same posture as seerr).
+              readOnlyRootFilesystem: false
+    defaultPodOptions:
+      securityContext:
+        # Image runs as `node` (UID/GID 1000); /opt/data must be 1000:1000-writable.
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        forceRename: "{{ .Release.Name }}"
+        primary: true
+        ports:
+          http:
+            port: *port
+    ingress:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: internal.haynesops
+          gethomepage.dev/href: &url "https://maintainerr.haynesops.com"
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Media
+          gethomepage.dev/name: Maintainerr
+          gethomepage.dev/description: Media cleanup rules
+          gethomepage.dev/icon: maintainerr
+          gethomepage.dev/app: maintainerr
+          gethomepage.dev/siteMonitor: *url
+        className: traefik-internal
+        hosts:
+          - host: maintainerr.haynesops.com
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+    persistence:
+      # SQLite DB + settings + logs live under /opt/data (DATA_DIR). Backed up
+      # by the volsync ReplicationSource (claim provisioned by volsync/aws).
+      config:
+        existingClaim: maintainerr
+        globalMounts:
+          - path: /opt/data
+      tmp:
+        type: emptyDir

--- a/kubernetes/main/apps/media/maintainerr/app/kustomization.yaml
+++ b/kubernetes/main/apps/media/maintainerr/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/gatus/gaurded
+  - ../../../../../shared/components/volsync/aws
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/main/apps/media/maintainerr/ks.yaml
+++ b/kubernetes/main/apps/media/maintainerr/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app maintainerr
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/main/apps/media/maintainerr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: maintainerr
+      # /api/health mirrors the readiness probe (200 when the SQLite DB is
+      # reachable, 503 otherwise) — a truthful external "is it up" signal.
+      GATUS_PATH: /api/health
+      # SQLite DB + config + logs only — small config.
+      VOLSYNC_CAPACITY: 5Gi


### PR DESCRIPTION
## What

Deploy **Maintainerr** (media lifecycle / "leaving soon" cleanup, https://github.com/maintainerr/Maintainerr) as a new app under `apps/media/`, mirroring the existing stateful media-app pattern.

## How

- **Chart/pattern:** bjw-s `app-template` OCIRepository + `volsync/aws` (PVC + restic backup) + `gatus/gaurded`, identical structure to `seerr`/`bazarr`.
- **Image:** `ghcr.io/maintainerr/maintainerr:3.17.0` — the org moved from `jorenn92/*` to `maintainerr/*`, and GHCR container tags drop the git `v` prefix (`v3.17.0` 404s; `3.17.0` is the pullable tag). Renovate will manage bumps.
- **Networking:** `maintainerr.haynesops.com` on `traefik-internal`, external-dns + Homepage annotations.
- **Persistence:** SQLite DB + config + logs at `/opt/data` on a volsync-provisioned 5Gi PVC; runs as UID/GID 1000 (`USER node`).
- **Probes:** liveness `GET /api/health/live` (process only, no DB), readiness `GET /api/health/ready` (pings DB), gatus monitors `/api/health`.
- **No ExternalSecret:** Maintainerr generates its own API key in-app; the owner retrieves it from the UI and wires integrations (Plex, Tautulli, the three *arrs, Seerr) afterward.

## Safety

A fresh Maintainerr install ships with **zero deletion rules → it deletes nothing** until the owner configures rules/integrations via the UI. This PR only adds the new `maintainerr/` directory and one line to `apps/media/kustomization.yaml`; no other app is touched.

## Validation

`kubectl kustomize` renders both the app path and the parent `apps/media` kustomization with rc=0.