### PR TITLE
feat(kometa): re-enable acquisition (add_missing+search) + Kometa-Added tags

### DIFF
--- a/kubernetes/main/apps/media/kometa/app/config/movies-charts.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/movies-charts.yml
@@ -10,7 +10,16 @@
 #     CLIENT-SIDE filters (original_language / tmdb_vote_count).
 #   * curated quality lists (IMDb Top 250) stay unfiltered — acclaimed foreign
 #     films belong there.
-# ARR-SAFE: display-only, no radarr flags; add_missing/search false globally.
+#
+# ACQUISITION ON: charts ADD missing titles to Radarr and SEARCH (add_missing/
+# search true globally). radarr_tag applies the umbrella "Kometa-Added" + a
+# per-chart tag. The language/vote filters above are what make chart acquisition
+# SANE (the un-filtered 2023 charts are exactly what flooded Radarr with foreign
+# junk). ⚠ CONTINUOUS ACQUISITION: "Popular Now", "In Theaters" and "IMDB
+# Popular" refresh with new releases, so they keep pulling new English-language
+# titles on every daily run — not a one-time wave. "Top Rated" / "Top Grossing" /
+# "IMDB Top 250" are effectively static (one-time fill). To make any chart
+# display-only again, add `radarr_add_missing: false` to its block.
 #
 # TRAKT GAP: Trakt charts are preserved but COMMENTED (no trakt block in
 # config.yml). Add trakt to the externalsecret to re-enable them.
@@ -25,6 +34,7 @@ collections:
     sort_title: "!020 Popular Now"
     summary: "Currently popular English-language movies (in this library)"
     url_poster: https://theposterdb.com/api/assets/241603
+    radarr_tag: "Kometa-Added,PopularNow"
     tmdb_discover:
       sort_by: popularity.desc
       with_original_language: en
@@ -36,6 +46,7 @@ collections:
     sort_title: "!021 Top Rated"
     summary: "All-time top-rated English-language movies (in this library)"
     url_poster: https://theposterdb.com/api/assets/241651
+    radarr_tag: "Kometa-Added,TopRated"
     tmdb_discover:
       sort_by: vote_average.desc
       with_original_language: en
@@ -47,6 +58,7 @@ collections:
     sort_title: "!022 Top Grossing"
     summary: "Highest-grossing English-language movies (in this library)"
     url_poster: https://theposterdb.com/api/assets/248186
+    radarr_tag: "Kometa-Added,TopGrossing"
     tmdb_discover:
       sort_by: revenue.desc
       with_original_language: en
@@ -58,6 +70,7 @@ collections:
     sort_title: "!023 In Theaters"
     summary: "English-language movies now playing in theaters (in this library)"
     url_poster: https://theposterdb.com/api/assets/213600
+    radarr_tag: "Kometa-Added,InTheaters"
     tmdb_now_playing: 100
     tmdb_region: US
     filters:
@@ -69,6 +82,7 @@ collections:
     sort_title: "!024 IMDB Popular"
     summary: "IMDb's most popular English-language movies (in this library)"
     url_poster: https://theposterdb.com/api/assets/231643
+    radarr_tag: "Kometa-Added,IMDBPopular"
     imdb_chart: popular_movies
     filters:
       - original_language: en
@@ -79,6 +93,7 @@ collections:
     sort_title: "!025 IMDB Top 250"
     summary: "IMDb's Top 250 movies of all time (in this library)"
     url_poster: https://theposterdb.com/api/assets/294454
+    radarr_tag: "Kometa-Added,IMDBTop250"
     imdb_chart: top_movies
 
   # ---- Trakt charts: need a trakt block in config.yml. Re-enable with the
@@ -87,6 +102,7 @@ collections:
   #   template: {name: Chart}
   #   sort_title: "!026 Trakt Trending"
   #   url_poster: https://theposterdb.com/api/assets/136357
+  #   radarr_tag: "Kometa-Added,TraktTrending"
   #   trakt_chart:
   #     chart: trending
   #     limit: 30
@@ -96,6 +112,7 @@ collections:
   #   template: {name: Chart}
   #   sort_title: "!027 Trakt Popular"
   #   url_poster: https://theposterdb.com/api/assets/241646
+  #   radarr_tag: "Kometa-Added,TraktPopular"
   #   trakt_chart:
   #     chart: popular
   #     limit: 30
@@ -105,6 +122,7 @@ collections:
   #   template: {name: Chart}
   #   sort_title: "!028 Trakt Recommended"
   #   url_poster: https://theposterdb.com/api/assets/204194
+  #   radarr_tag: "Kometa-Added,TraktRecommended"
   #   trakt_chart:
   #     chart: recommended
   #     limit: 30

--- a/kubernetes/main/apps/media/kometa/app/config/movies-collections.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/movies-collections.yml
@@ -1,6 +1,13 @@
 # Custom movie collections — the survivors of the 2023 config cleanup.
 # Franchises/universes/studios/directors/actors/awards now come from Kometa
 # Defaults (see config.yml); only genuinely custom things live here.
+#
+# Christmas HNet keeps radarr_add_missing:false (tag-only) exactly as the old
+# MovieSeasonal.yml did — it's an IMDb list of every Christmas movie, so we do
+# NOT auto-acquire it; the `seasonal` Default in config.yml is the acquiring
+# seasonal source. The audio collections are plex_all filters over EXISTING,
+# already-analyzed media — there is nothing "missing" to add, so add_missing is
+# a no-op for them; radarr_tag is present only for traceability parity.
 collections:
   Christmas HNet:
     sort_title: "!001 Christmas HNet"
@@ -10,6 +17,8 @@ collections:
     url_poster: https://theposterdb.com/api/assets/48897
     # display-only during the Nov-Jan window; items persist year-round
     schedule: range(11/01-01/07)
+    radarr_add_missing: false
+    radarr_tag: "Kometa-Added,ChristmasHNet"
 
   # Audio-metadata regex collections (Spatial Surround / Dolby Atmos / DTS X),
   # restored verbatim from the LIVE old Kometa config (an earlier port read a
@@ -23,6 +32,7 @@ collections:
     url_poster: https://haynesnetwork.com/wp-content/uploads/2023/11/SurroundTestCollection.png
     collection_order: release.desc
     schedule: weekly(saturday)
+    radarr_tag: "Kometa-Added,SpacialSurround"
     filters:
       - filepath.regex: '(?i)^(?=.*\btrue[ ._-]?hd(\b|\d))(?=.*\batmos(\b|\d))'
       - audio_track_title.regex: '(?i)^(?=.*\btrue[ ._-]?hd(\b|\d))(?=.*\batmos(\b|\d))'
@@ -39,6 +49,7 @@ collections:
     url_poster: https://haynesnetwork.com/wp-content/uploads/2023/11/SurroundTestCollection.png
     collection_order: release.desc
     schedule: weekly(saturday)
+    radarr_tag: "Kometa-Added,Atmos"
     filters:
       - filepath.regex: '(?i)^(?=.*\btrue[ ._-]?hd(\b|\d))(?=.*\batmos(\b|\d))'
       - audio_track_title.regex: '(?i)^(?=.*\btrue[ ._-]?hd(\b|\d))(?=.*\batmos(\b|\d))'
@@ -53,6 +64,7 @@ collections:
     url_poster: https://haynesnetwork.com/wp-content/uploads/2023/11/SurroundTestCollection.png
     collection_order: release.desc
     schedule: weekly(saturday)
+    radarr_tag: "Kometa-Added,DTSX"
     filters:
       - filepath.regex: '(?i)\bdts[ ._-]?x\b'
       - audio_track_title.regex: '(?i)\bdts[ ._-]?x\b'

--- a/kubernetes/main/apps/media/kometa/app/config/movies-franchises.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/movies-franchises.yml
@@ -4,8 +4,11 @@
 # summary). These are COMPLEMENTS to the `universe` Default (kept in config.yml),
 # not replacements — the user curated these 145 by hand and they stay.
 #
-# ARR-SAFE: radarr_tag stripped from the template. add_missing/search are false
-# globally, so these only ever organize EXISTING library items.
+# ACQUISITION ON: these franchises ADD missing entries to Radarr and SEARCH
+# (add_missing/search are true globally in config.yml). radarr_tag applies the
+# umbrella "Kometa-Added" + the "MovieCollection" category tag (the old
+# HaynesTower Movies-template tag, PMM-Added -> Kometa-Added) to every ADDED
+# item so Kometa's franchise acquisitions are traceable.
 #
 # NOTE: collection names are preserved verbatim, including the source typos
 # ("Teanage Mutant Ninja Turtles", "Wrreck-It Ralf", "Mama Mia!") — rename in
@@ -23,6 +26,7 @@ templates:
     tmdb_list: <<tmdb_list>>
     imdb_list: <<imdb_list>>
     collection_order: release
+    radarr_tag: "Kometa-Added,MovieCollection"
 
 collections:
   28 Days/Weeks Later:

--- a/kubernetes/main/apps/media/kometa/app/config/movies-lists.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/movies-lists.yml
@@ -1,16 +1,22 @@
 # Studio + special-genre list collections — restored from the LIVE 2023 config
-# (MovieLists.yml). radarr_tag / radarr_add_missing stripped (ARR-SAFE).
+# (MovieLists.yml). TAG-ONLY (no acquisition): the old stack set
+# radarr_add_missing:false on both templates so, e.g., every A24 / Disney
+# Animation film isn't dumped into Radarr. We restore that opt-out and only TAG
+# (umbrella "Kometa-Added" + a per-collection tag). radarr_tag is inert while
+# add_missing is false — kept for parity + easy future enable.
 #
 # TRAKT GAP: the deployed config.yml has no trakt block, so every trakt_list
-# collection is preserved but COMMENTED below. Add a trakt block to the kometa
-# externalsecret to re-enable them. imdb_search / imdb_list need no auth and are
-# active.
+# collection is preserved but COMMENTED below (with its old tag, PMM->Kometa,
+# ready for re-enable). Add a trakt block to the kometa externalsecret to
+# re-enable them. imdb_search / imdb_list need no auth and are active.
 templates:
   Studio:
     sort_title: "!C <<collection_name>>"
+    radarr_add_missing: false
   Special Genre:
     sort_title: "!D <<collection_name>>"
     collection_order: alpha
+    radarr_add_missing: false
 
 collections:
 #####################################
@@ -27,6 +33,7 @@ collections:
     collection_order: custom
     sync_mode: sync
     url_poster: https://theposterdb.com/api/assets/11845
+    radarr_tag: "Kometa-Added,DisneyAnimation"
   # Pixar Animation — needs trakt (trakt_list). Alternative: imdb_search company co0086397.
   # Pixar Animation:
   #   template: {name: Studio}
@@ -34,6 +41,7 @@ collections:
   #   summary: "A collection of Pixar Animation movies."
   #   collection_order: release
   #   url_poster: https://theposterdb.com/api/assets/2190
+  #   radarr_tag: "Kometa-Added,PixarAnimation"
   Dreamworks Pictures:
     template: {name: Studio}
     imdb_search:
@@ -45,6 +53,7 @@ collections:
     collection_order: custom
     sync_mode: sync
     url_poster: https://theposterdb.com/api/assets/57647
+    radarr_tag: "Kometa-Added,DreamworksPictures"
   A24:
     template: {name: Studio}
     imdb_search:
@@ -56,12 +65,14 @@ collections:
     collection_order: custom
     sync_mode: sync
     url_poster: https://theposterdb.com/api/assets/139297
+    radarr_tag: "Kometa-Added,A24"
   Roald Dahl:
     template: {name: Studio}
     imdb_list: https://www.imdb.com/list/ls046555751/
     summary: "A collection of movies based off of the works of Roald Dahl."
     collection_order: release
     url_poster: https://theposterdb.com/api/assets/557888
+    radarr_tag: "Kometa-Added,RoaldDahl"
 #####################################
 #      Special Genre Collections    #
 #####################################
@@ -71,33 +82,39 @@ collections:
   #   trakt_list: https://trakt.tv/users/hdlists/lists/top-ten-pirated-movies-of-the-week-torrent-freak-com
   #   summary: "A collection of movies that are the top downloaed of the week! Check back every week for what is popular."
   #   url_poster: https://theposterdb.com/api/assets/374490
+  #   radarr_tag: "Kometa-Added,TopTenArrThisWeek"
   # Mind Fuck Movies — needs trakt (trakt_list).
   # Mind Fuck Movies:
   #   template: {name: Special Genre}
   #   trakt_list: https://trakt.tv/users/hdlists/lists/mindfuck-movies
   #   summary: "A collection of movies that will mess with your mind!"
   #   url_poster: https://haynesnetwork.com/wp-content/uploads/2023/09/mindfuck.png
+  #   radarr_tag: "Kometa-Added,MindFuck"
   # Outer Space & Exploration Movies — needs trakt (trakt_list).
   # Outer Space & Exploration Movies:
   #   template: {name: Special Genre}
   #   trakt_list: https://trakt.tv/users/hdlists/lists/outer-space-space-exploration-movies
   #   summary: "Movies that feature outer space and exploration."
   #   url_poster: https://haynesnetwork.com/wp-content/uploads/2023/09/Space-3.jpg
+  #   radarr_tag: "Kometa-Added,OuterSpace"
   # Superhero Movies — needs trakt (trakt_list).
   # Superhero Movies:
   #   template: {name: Special Genre}
   #   trakt_list: https://trakt.tv/users/hdlists/lists/superhero-movies-from-1980-to-today
   #   summary: "Superhero movies released from 1980 until today."
   #   url_poster: https://haynesnetwork.com/wp-content/uploads/2023/09/Super-Hero-3.jpg
+  #   radarr_tag: "Kometa-Added,SuperHeroMovie"
   # Standup Comedy — needs trakt (trakt_list).
   # Standup Comedy:
   #   template: {name: Special Genre}
   #   trakt_list: https://trakt.tv/users/diverzija/lists/standup-comedy
   #   summary: "A standup comedy collection from Trakt that looked pretty good!"
   #   url_poster: https://haynesnetwork.com/wp-content/uploads/2023/09/Stand-Up.png
+  #   radarr_tag: "Kometa-Added,StandupComedy"
   J-Horror:
     template: {name: Special Genre}
     imdb_list: https://www.imdb.com/list/ls023154794/
     summary: "The best J-Horror movies around."
     collection_order: release
     url_poster: https://theposterdb.com/api/assets/51475
+    radarr_tag: "Kometa-Added,JHorror"

--- a/kubernetes/main/apps/media/kometa/app/config/movies-people.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/movies-people.yml
@@ -10,9 +10,12 @@
 # person (the intent of the old *_details keys). sort_by popularity.desc + a
 # generous limit ensures the person's library titles are captured.
 #
-# ARR-SAFE: radarr_tag / radarr_add_missing stripped. add_missing/search false
-# globally, so these organize EXISTING library items only (missing titles are
-# never sent to Radarr).
+# TAG-ONLY (no acquisition), exactly as the old HaynesTower stack did: both
+# templates carried radarr_add_missing:false so a director's/actor's ENTIRE
+# filmography is never dumped into Radarr. We restore that opt-out here and only
+# TAG (umbrella "Kometa-Added" + DirectorCollection/ActorCollection) so these
+# people collections are traceable without driving acquisition. (radarr_tag is
+# inert while add_missing is false — kept for parity + easy future enable.)
 #
 # Commented-out people below are preserved exactly as the user disabled them.
 # Multi-ID people (Coen Brothers) use comma = AND on with_crew (their joint films).
@@ -26,6 +29,8 @@ templates:
       limit: 250
     tmdb_profile: <<tmdb>>
     tmdb_biography: <<tmdb>>
+    radarr_add_missing: false
+    radarr_tag: "Kometa-Added,DirectorCollection"
   Actor:
     sort_title: "!Z <<collection_name>>"
     collection_order: release.desc
@@ -35,6 +40,8 @@ templates:
       limit: 250
     tmdb_profile: <<tmdb>>
     tmdb_biography: <<tmdb>>
+    radarr_add_missing: false
+    radarr_tag: "Kometa-Added,ActorCollection"
 
 collections:
 ######################################################

--- a/kubernetes/main/apps/media/kometa/app/config/shows-collections.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/shows-collections.yml
@@ -1,10 +1,14 @@
-# Family curated TV collections — ported verbatim from the 2023 PMM config
-# (sonarr_tag/add_missing stripped: Kometa builds from EXISTING items only;
-# see the cutover checklist before ever re-enabling arr integration flags).
+# Family curated TV collections — ported from the 2023 PMM config (Shows.yml).
+# ACQUISITION ON: each is a curated list of specific series (tmdb_show/tvdb_show
+# IDs); with add_missing/search true globally, any listed show not in the library
+# is sent to Sonarr and searched. sonarr_tag applies the umbrella "Kometa-Added"
+# + the old per-collection tag (PMM-Added -> Kometa-Added) so each family list's
+# acquisitions are traceable.
 collections:
   Curated for Jackson:
     sort_title: "!010AA Curated for Jackson"
     url_poster: https://theposterdb.com/api/assets/82398
+    sonarr_tag: "Kometa-Added,ForJackson"
     tmdb_show:
       - 15260  # Adventure Time
       - 37606  # The Amazing World of Gumball
@@ -51,6 +55,7 @@ collections:
   Curated for Kellie:
     sort_title: "!010AA Curated for Kellie"
     url_poster: https://theposterdb.com/api/assets/411741
+    sonarr_tag: "Kometa-Added,ForKellie"
     tmdb_show:
       - 1418   # The Big Bang Theory
       - 2327   # Dawson's Creek
@@ -83,6 +88,7 @@ collections:
   Curated for Penelope:
     sort_title: "!010AA Curated for Penelope"
     url_poster: https://theposterdb.com/api/assets/243003
+    sonarr_tag: "Kometa-Added,ForPenelope"
     tmdb_show:
       - 39107  # Bubble Guppies
       - 100088 # The Last of Us
@@ -107,6 +113,7 @@ collections:
   Big Kid Cartoons:
     sort_title: "!010AB Big Kid Cartoons"
     url_poster: https://theposterdb.com/api/assets/342075
+    sonarr_tag: "Kometa-Added,BigKidCartoons"
     tvdb_show:
       - 371028 # Arcane
       - 110381 # Archer
@@ -123,6 +130,7 @@ collections:
   Kid Cartoons:
     sort_title: "!010AB Kid Cartoons"
     url_poster: https://theposterdb.com/api/assets/316188
+    sonarr_tag: "Kometa-Added,KidCartoons"
     tmdb_show:
       - 15260  # Adventure Time
       - 37606  # The Amazing World of Gumball
@@ -182,6 +190,7 @@ collections:
   Earth & Space Wonders:
     sort_title: "!010AC Earth & Space Wonders"
     url_poster: https://theposterdb.com/api/assets/121577
+    sonarr_tag: "Kometa-Added,EarthAndSpace"
     tvdb_show:
       - 417835 # Our Great National Parks
       - 74372  # The Blue Planet

--- a/kubernetes/main/apps/media/kometa/app/config/shows-franchises.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/shows-franchises.yml
@@ -1,8 +1,11 @@
 # TV franchise / list collections — restored from the LIVE 2023 config (Shows.yml).
-# sonarr_tag stripped (ARR-SAFE). TVDb list builders need no auth (Kometa ships a
-# bundled TVDb key) and are active. The trakt-based ones (Adventure Time, the
-# Trakt charts) are preserved but COMMENTED — add a trakt block to config.yml to
-# re-enable.
+# ACQUISITION ON: these ADD missing series to Sonarr and SEARCH (add_missing/
+# search true globally in config.yml). sonarr_tag applies the umbrella
+# "Kometa-Added" + the "ShowCollection" category tag (the old HaynesTower
+# Shows-template tag, PMM-Added -> Kometa-Added) to every ADDED series. TVDb list
+# builders need no auth (Kometa ships a bundled TVDb key) and are active. The
+# trakt-based ones (Adventure Time, the Trakt charts) are preserved but COMMENTED
+# (with their old tag renamed) — add a trakt block to config.yml to re-enable.
 templates:
   Shows:
     sort_title: "!010B <<collection_name>>"
@@ -13,6 +16,7 @@ templates:
     tvdb_show: <<tvdb_show>>
     collection_order: custom
     sync_mode: sync
+    sonarr_tag: "Kometa-Added,ShowCollection"
 
 collections:
 #####################################
@@ -67,11 +71,14 @@ collections:
   #   sort_title: "!010C Trakt Trending"
   #   trakt_chart: {chart: trending, limit: 18}
   #   url_poster: https://theposterdb.com/api/assets/136358
+  #   sonarr_tag: "Kometa-Added,TraktTrending"
   # Trakt Popular:
   #   sort_title: "!010C Trakt Popular"
   #   trakt_chart: {chart: popular, limit: 18}
   #   url_poster: https://theposterdb.com/api/assets/241646
+  #   sonarr_tag: "Kometa-Added,TraktPopular"
   # Trakt Recommended:
   #   sort_title: "!010C Trakt Recommended"
   #   trakt_chart: {chart: recommended, limit: 18}
   #   url_poster: https://theposterdb.com/api/assets/204278
+  #   sonarr_tag: "Kometa-Added,TraktRecommended"

--- a/kubernetes/main/apps/media/kometa/app/externalsecret.yaml
+++ b/kubernetes/main/apps/media/kometa/app/externalsecret.yaml
@@ -30,10 +30,40 @@ spec:
               # REMOVED — those are now the user's own explicit files below, not
               # generic auto-generated Defaults.
               collection_files:
+                # Acquisition-ON Defaults — parity with the old HaynesTower stack,
+                # which acquired from universe/seasonal/oscars/golden (they had no
+                # radarr_add_missing override, so they inherited the global true).
+                # radarr_add_missing + radarr_search send missing titles to Radarr
+                # and trigger a search; radarr_tag marks every ADDED item with the
+                # umbrella ("Kometa-Added") + a per-Default tag for source
+                # traceability. (radarr_tag = tag-on-ADD, chosen over item_radarr_tag
+                # so "Kometa-Added" stays a pure "acquired-by-Kometa" marker for the
+                # Maintainerr flow-out side, rather than also tagging pre-existing
+                # library items — this matches what the old config used on these
+                # exact Defaults. Flip to item_radarr_tag if existing items should
+                # also be tagged.) NOTE: oscars/golden/seasonal are the largest
+                # one-time-wave contributors (decades of award films / every
+                # seasonal title on the Default lists not yet in the library).
                 - default: universe
+                  template_variables:
+                    radarr_add_missing: true
+                    radarr_search: true
+                    radarr_tag: "Kometa-Added,UniverseCollection"
                 - default: seasonal
+                  template_variables:
+                    radarr_add_missing: true
+                    radarr_search: true
+                    radarr_tag: "Kometa-Added,SeasonalCollection"
                 - default: oscars
+                  template_variables:
+                    radarr_add_missing: true
+                    radarr_search: true
+                    radarr_tag: "Kometa-Added,OscarsCollection"
                 - default: golden
+                  template_variables:
+                    radarr_add_missing: true
+                    radarr_search: true
+                    radarr_tag: "Kometa-Added,GoldenGlobeCollection"
                 # franchise Default = COMPLEMENT to the hand-curated
                 # movies-franchises.yml, NOT a replacement. It auto-discovers a
                 # collection per TMDb Collection present in the library (type:
@@ -57,6 +87,15 @@ spec:
                 - default: franchise
                   template_variables:
                     minimum_items: 2
+                    # ACQUISITION-OFF for the franchise Default: it auto-discovers
+                    # ~168 TMDb Collections already present in the library; with
+                    # add_missing it would try to COMPLETE every one (thousands of
+                    # movies) — a net-new amplifier the old HaynesTower stack never
+                    # had. The hand-curated movies-franchises.yml already drives
+                    # franchise acquisition. Tag-only here so Kometa-managed
+                    # franchise items stay traceable without a runaway wave.
+                    radarr_add_missing: false
+                    radarr_tag: "Kometa-Added,FranchiseCollection"
                 - file: config/git/movies-franchises.yml
                 - file: config/git/movies-people.yml
                 - file: config/git/movies-lists.yml
@@ -140,25 +179,33 @@ spec:
           mdblist:
             apikey: "{{ .MDBLIST_API_KEY }}"
             cache_expiration: 60
-          # CUTOVER FLIP-LIST: add_missing/search stay FALSE (also the Kometa
-          # defaults) so collections only ever organize EXISTING library items.
-          # The 2023 config had both true — that's what auto-added chart junk.
-          # Recommendation: leave false permanently even after cutover.
+          # ACQUISITION ON (post-cutover): restores the old HaynesTower behavior —
+          # collections send MISSING titles to Radarr/Sonarr (add_missing) and
+          # trigger a SEARCH. `tag: Kometa-Added` is the GLOBAL UMBRELLA applied to
+          # every ADDED item (the old "PMM-Added" role, renamed) so the Maintainerr
+          # flow-out side can find ALL Kometa acquisitions by one tag. Per-collection
+          # files additionally set "Kometa-Added,<Collection>" (umbrella first) for
+          # source traceability. Chart over-acquisition is held off by the
+          # original_language:en / vote_count filters in movies-charts.yml; the
+          # people / studio / hand-seasonal collections keep radarr_add_missing:false
+          # (tag-only) exactly as the old stack did — acquiring every actor's or
+          # studio's full filmography is deliberately NOT enabled.
           radarr:
             url: http://radarr.media.svc.cluster.local:7878
             token: "{{ .RADARR_API_KEY }}"
-            add_missing: false
+            add_missing: true
             add_existing: false
             upgrade_existing: false
             monitor: true
             availability: released
             quality_profile: HD Bluray + WEB
             root_folder_path: /data/haynestower/Media/Movies
-            search: false
+            search: true
+            tag: Kometa-Added
           sonarr:
             url: http://sonarr.media.svc.cluster.local:8989
             token: "{{ .SONARR_API_KEY }}"
-            add_missing: false
+            add_missing: true
             add_existing: false
             upgrade_existing: false
             monitor: all
@@ -166,8 +213,9 @@ spec:
             root_folder_path: /data/haynestower/Media/TV Shows
             series_type: standard
             season_folder: true
-            search: false
+            search: true
             cutoff_search: false
+            tag: Kometa-Added
   data:
     - secretKey: TMDB_API_KEY
       remoteRef:


### PR DESCRIPTION
## What this does

Re-enables Kometa's **acquisition** behavior now that the plexops cutover is done. Kometa stops being display-only and once again **DRIVES acquisition** like the old HaynesTower stack: collections **ADD** missing items to Radarr/Sonarr, **SEARCH** for them, and **TAG** every addition so the source is traceable.

> ⚠️ **DO NOT MERGE until the active A-list backfill drains.** First run is a **large one-time download wave** (see estimate below). Merge timing is the main agent's call.

## Changes

### 1. Global acquisition flip + umbrella tag (`externalsecret.yaml` seed)
- `radarr` and `sonarr`: `add_missing: true`, `search: true`.
- Added global **`tag: Kometa-Added`** to both — the umbrella applied to **every ADDED item** (the old `PMM-Added` role, renamed). This is the single tag the Maintainerr flow-out side can use to find **all** Kometa acquisitions.
- `quality_profile` / `root_folder_path` / `monitor` **unchanged** (verified: radarr `= /data/haynestower/Media/Movies`, sonarr `= /data/haynestower/Media/TV Shows` — both correct & present). FHD/UHD setup untouched.

### 2. Per-collection tags (`Kometa-Added,<Collection>`, umbrella first)
Renamed prefix `PMM-Added → Kometa-Added` throughout. Mapping matches the authoritative old config where one existed, else derived:

| File | Tag scheme (radarr_tag / sonarr_tag) | Acquires? |
|---|---|---|
| `movies-franchises.yml` (145) | template `Kometa-Added,MovieCollection` | ✅ yes |
| `movies-charts.yml` (6) | per-chart: `PopularNow / TopRated / TopGrossing / InTheaters / IMDBPopular / IMDBTop250` | ✅ yes (⚠ continuous) |
| `shows-franchises.yml` (16) | template `Kometa-Added,ShowCollection` | ✅ yes |
| `shows-collections.yml` (6) | per-collection: `ForJackson / ForKellie / ForPenelope / BigKidCartoons / KidCartoons / EarthAndSpace` | ✅ yes |
| `movies-people.yml` (directors+actors) | template `DirectorCollection` / `ActorCollection` | ❌ **tag-only** |
| `movies-lists.yml` (studios/genre) | `DisneyAnimation / DreamworksPictures / A24 / RoaldDahl / JHorror` | ❌ **tag-only** |
| `movies-collections.yml` | `ChristmasHNet` (imdb list), `SpacialSurround / Atmos / DTSX` (plex_all filters) | ❌ **tag-only** |

Commented (trakt-gap) collections also carry their renamed tag, ready for when a trakt block is added.

### 3. Defaults (`universe / seasonal / oscars / golden / franchise`)
Verified against the Kometa v2 Defaults shared template-variables (deployed image is `v2.4.4`). Every Default **can** be tagged.
- **universe / seasonal / oscars / golden** → `radarr_add_missing: true` + `radarr_search: true` + `radarr_tag: "Kometa-Added,<Name>Collection"` (parity: the old stack acquired from these).
- **franchise** → `radarr_add_missing: false` + `radarr_tag` (**tag-only**). This Default auto-discovers ~168 TMDb collections already in the library; with add_missing it would try to *complete every one* (thousands of movies) — a net-new amplifier the old stack never had. The hand-curated `movies-franchises.yml` already drives franchise acquisition.
- **Tag-variable choice:** used `radarr_tag` (tag-on-**ADD**) rather than `item_radarr_tag`. Both are valid on Defaults; `item_radarr_tag` also tags **pre-existing** library items, which would pollute the "Kometa-Added = acquired-by-Kometa" umbrella and risk Maintainerr flowing out movies the user already owned. `radarr_tag` matches what the old config used on these exact Defaults. Flip to `item_radarr_tag` if tagging existing items too is desired.

### Fidelity note (deliberate)
People / studios / special-genre / hand-Christmas collections keep `radarr_add_missing: false` **exactly as the old HaynesTower config did** — auto-acquiring every film by an actor/director or every A24/Disney title is intentionally NOT enabled. Global `add_missing: true` is set per the task; these opt out individually, same as the old stack.

## Acquisition-wave estimate (first run)
Rough, not exact (would need Radarr/Plex queries to pin down):
- **Movies:** 145 franchises fill gaps (~150–450) + universe/seasonal/oscars/golden Defaults (oscars/golden/seasonal are the big ones — decades of award/holiday films not in the library, potentially several hundred each) + charts (bounded by limits: 60+100+100+100+250 ≈ up to a few hundred). **Order of magnitude ~1,000–3,000 movies.**
- **TV:** 16 franchise lists + 6 curated family lists (specific series) → a few hundred series at most.
- Numbers are gross; Radarr/Sonarr dedupe titles already present, so net adds are lower.

## Risks / flags
- 🔴 **One-time wave** on first `--collections-only` run (daily 06:30 ET). Gate merge on backfill drain.
- 🟠 **Continuous acquisition:** `Popular Now`, `In Theaters`, `IMDB Popular` refresh with new releases and keep pulling new English titles every daily run — not one-time. `original_language:en` + `vote_count` filters keep it sane. Add `radarr_add_missing: false` to any chart block to make it display-only.
- 🟠 **oscars/golden/seasonal Defaults** are the largest one-time contributors.
- 🟢 `franchise` Default and people/studio collections are tag-only (no wave).
- Music (`music.yml`) is untagged — no radarr/sonarr for music and the library is disabled; can't be tagged here.

## Validation
- `kubectl kustomize kubernetes/main/apps/media/kometa/app` builds clean (1865 lines).
- All 8 config files + the embedded seed `config.yml` parse as valid YAML; asserted the flag flips, umbrella tag, root folders, and Default template-variables.
- No Kometa job triggered (that would start the wave prematurely).
