### PR TITLE
feat(upgrade-agent): alert-responder — read-only critical-alert diagnosis paged to Pushover (Track B1)

### DIFF
--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/externalsecret.yaml
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Responder secret: the Anthropic key + the Pushover page channel. NO github-bot PEM,
+# NO repo-write credential of any kind — the responder's repo clone is anonymous
+# read-only, which is exactly what keeps its blast radius at "pages + read".
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alert-responder
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: alert-responder-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: ANTHROPIC_API_KEY
+      remoteRef: { key: anthropic, property: ANTHROPIC_API_KEY }
+    - secretKey: PUSHOVER_TOKEN
+      remoteRef: { key: upgrade-gate, property: PUSHOVER_TOKEN }
+    - secretKey: PUSHOVER_USER_KEY
+      remoteRef: { key: upgrade-gate, property: PUSHOVER_USER_KEY }

--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/helmrelease.yaml
@@ -1,0 +1,84 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alert-responder
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  values:
+    controllers:
+      alert-responder:
+        type: cronjob
+        # Track-B1 (2026-07-06): ENRICH, DON'T ACT. Polls Alertmanager every 10 min;
+        # for each NEW critical-alert incident it runs ONE read-only Claude Code
+        # diagnosis and pages the result to Pushover (priority 0 — the original
+        # critical already paged at 1). The human stays the actuator. Healthy path =
+        # one curl, $0. At-most-once per incident; separate $15/mo spend envelope.
+        # Kill switch (instant, no git):
+        #   kubectl -n upgrade-agent patch cronjob alert-responder -p '{"spec":{"suspend":true}}'
+        cronjob:
+          suspend: false
+          schedule: "*/10 * * * *"
+          concurrencyPolicy: Forbid
+          startingDeadlineSeconds: 300
+          backoffLimit: 0
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+        pod:
+          restartPolicy: Never
+        containers:
+          app:
+            image:
+              # The shepherd image (claude + kubectl + flux + git + jq); no bot
+              # initContainer here — the responder holds NO repo-write credential.
+              repository: ghcr.io/thaynes43/upgrade-shepherd
+              tag: 0.1.0@sha256:8b8bc5e2ab9d5cb81ca4f90115f17881c83e68504fd569280d1588a62177a7df
+            command: ["/bin/bash", "/opt/responder/respond.sh"]
+            env:
+              ALERTMANAGER_URL: http://kube-prometheus-stack-alertmanager.observability.svc.cluster.local:9093
+              PROMETHEUS_URL: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+              LOKI_URL: http://loki-gateway.observability.svc.cluster.local:80
+              RESPONDER_MODEL: sonnet
+              RESPONDER_MAX_PER_RUN: "1"
+              RESPONDER_MAX_BUDGET_USD: "2.00"
+              RESPONDER_MONTHLY_CAP_USD: "15"
+            envFrom:
+              - secretRef:
+                  name: alert-responder-secret
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+    defaultPodOptions:
+      automountServiceAccountToken: true   # read-only cluster diagnosis via the SA
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+    serviceAccount:
+      alert-responder: {}
+    persistence:
+      responder-scripts:
+        type: configMap
+        name: alert-responder-scripts
+        defaultMode: 0555
+        globalMounts:
+          - path: /opt/responder
+      # HOME + CLAUDE_CONFIG_DIR + the anonymous shallow clone (readOnlyRootFilesystem).
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/kustomization.yaml
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/common/repos/app-template
+resources:
+  - ./externalsecret.yaml
+  - ./rbac.yaml
+  - ./networkpolicy.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: alert-responder-scripts
+    files:
+      - resources/respond.sh
+      - resources/prom-query.sh
+      - resources/loki-query.sh
+generatorOptions:
+  # Stable name so the HelmRelease can mount it by name.
+  disableNameSuffixHash: true
+  labels:
+    app.kubernetes.io/name: alert-responder

--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/networkpolicy.yaml
@@ -1,0 +1,89 @@
+---
+# CiliumNetworkPolicy for the responder pod: the exfil boundary for a prompt-injectable
+# LLM that reads ALERT CONTENT (labels/annotations can carry attacker-influenced text).
+# Egress ONLY to: DNS, apiserver (read-only SA), observability (Alertmanager/Prometheus/
+# Loki), GitHub (anonymous read-only runbook clone), Anthropic, Pushover. No ingress.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: alert-responder
+  namespace: upgrade-agent
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: alert-responder
+  egress:
+    # 1. DNS via CoreDNS. Cilium `*` does NOT cross label boundaries (proven live
+    #    2026-07-04: "*.cluster.local" never matched multi-label service FQDNs and
+    #    silently blinded the gate) — so every multi-label service name the responder
+    #    uses gets an exact matchName.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*.cluster.local"
+              - matchPattern: "*.svc"
+              - matchName: "kube-prometheus-stack-alertmanager.observability.svc.cluster.local"
+              - matchName: "kube-prometheus-stack-prometheus.observability.svc.cluster.local"
+              - matchName: "loki-gateway.observability.svc.cluster.local"
+              - matchName: "github.com"          # apex — *.github.com does NOT match it
+              - matchPattern: "*.github.com"
+              - matchPattern: "*.githubusercontent.com"
+              - matchName: "api.anthropic.com"
+              - matchName: "api.pushover.net"
+    # 2. Kube API server — read-only diagnosis (kubectl get/describe, flux get).
+    - toEntities: [kube-apiserver]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "6443"
+              protocol: TCP
+    # 3. Observability plane: Alertmanager (9093), Prometheus (9090), Loki gateway (80/8080)
+    #    + loki direct (3100) in case the gateway svc changes.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "9093"
+              protocol: TCP
+            - port: "9090"
+              protocol: TCP
+            - port: "3100"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+            - port: "8080"
+              protocol: TCP
+    # 4. GitHub — ANONYMOUS read-only shallow clone (runbook context). No credential
+    #    exists in this pod, so this cannot become a push path.
+    - toFQDNs:
+        - matchName: "github.com"
+        - matchPattern: "*.github.com"
+        - matchPattern: "*.githubusercontent.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # 5. Anthropic — the LLM API.
+    - toFQDNs:
+        - matchName: api.anthropic.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # 6. Pushover — the page channel (the whole point of the responder).
+    - toFQDNs:
+        - matchName: api.pushover.net
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+  # No ingress rules -> all ingress denied.

--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/rbac.yaml
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/rbac.yaml
@@ -1,0 +1,54 @@
+---
+# The responder diagnoses READ-ONLY — it reuses the gate's read-only ClusterRole
+# `upgrade-health-gate` (get/list/watch only; no secrets/exec/log/write) via its own
+# binding, exactly like the shepherd does. It holds NO repo-write credential at all
+# (its repo clone is anonymous read-only), so its total write surface is Pushover
+# pages + the two runtime ConfigMaps below.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app alert-responder
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: upgrade-health-gate # the shared read-only role (defined by the gate)
+subjects:
+  - kind: ServiceAccount
+    name: *app
+    namespace: upgrade-agent
+---
+# Runtime state, both confined to this namespace (same rationale as the shepherd's
+# spend Role — `create` cannot be name-restricted):
+#   * alert-responder-state — at-most-once incident ledger (fingerprint+startsAt)
+#   * alert-responder-spend — the monthly spend counter (separate envelope from the
+#     shepherd so an alert storm can't eat the upgrade budget)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: alert-responder-state
+  namespace: upgrade-agent
+  labels:
+    app.kubernetes.io/name: alert-responder
+rules:
+  - apiGroups: [""]
+    resources: [configmaps]
+    verbs: [get, list, create, update, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: alert-responder-state
+  namespace: upgrade-agent
+  labels:
+    app.kubernetes.io/name: alert-responder
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: alert-responder-state
+subjects:
+  - kind: ServiceAccount
+    name: alert-responder
+    namespace: upgrade-agent

--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/resources/loki-query.sh
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/resources/loki-query.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# loki-query.sh — deterministic LogQL wrapper for the responder's LLM (pod logs come
+# from Loki, NOT kubectl logs — the read-only ClusterRole deliberately denies pods/log).
+# Usage: loki-query.sh '<logql>' [lookback-minutes=60] [limit=100]
+set -uo pipefail
+LOKI="${LOKI_URL:-http://loki-gateway.observability.svc.cluster.local:80}"
+q="${1:?usage: loki-query.sh '<logql>' [minutes] [limit]}"
+mins="${2:-60}"; limit="${3:-100}"
+start="$(date -u -d "-${mins} minutes" +%s)000000000"
+end="$(date -u +%s)000000000"
+curl -sf --max-time 20 -G "$LOKI/loki/api/v1/query_range" \
+    --data-urlencode "query=$q" \
+    --data-urlencode "start=$start" \
+    --data-urlencode "end=$end" \
+    --data-urlencode "limit=$limit" \
+    --data-urlencode "direction=backward" 2>/dev/null \
+  | jq -r '.data.result[]?.values[]? | .[1]' 2>/dev/null | head -n "$limit" \
+  || { echo "QUERY FAILED (LogQL parse error or Loki unreachable)"; exit 1; }

--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/resources/prom-query.sh
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/resources/prom-query.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# prom-query.sh — deterministic PromQL wrapper for the responder's LLM.
+# The ONLY http the LLM can drive toward Prometheus (raw curl is not allowlisted).
+# Usage: prom-query.sh '<promql instant query>'
+set -uo pipefail
+PROM="${PROMETHEUS_URL:-http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090}"
+q="${1:?usage: prom-query.sh '<promql>'}"
+curl -sf --max-time 15 "$PROM/api/v1/query" --data-urlencode "query=$q" 2>/dev/null \
+  | jq -c '.data.result[:25] | map({metric, value: .value[1]})' 2>/dev/null \
+  || { echo "QUERY FAILED (parse error or Prometheus unreachable)"; exit 1; }

--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/resources/respond.sh
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/resources/respond.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# alert-responder — Track-B1 of the 2026-07-06 agent-ops plan: ENRICH, DON'T ACT.
+#
+# Every RESPONDER_INTERVAL the CronJob polls Alertmanager for active critical alerts.
+# For a NEW alert incident (fingerprint+startsAt never handled) it summons a READ-ONLY
+# Claude Code diagnosis — kubectl get/describe, flux get, PromQL/LogQL via the two
+# deterministic wrappers, the repo's committed runbooks — and pages the result to
+# Pushover as a FOLLOW-UP to the page Alertmanager already sent. The human stays the
+# actuator; the 2am page just arrives pre-investigated.
+#
+# COST DISCIPLINE (the shepherd/triage pattern):
+#   - Healthy path = $0: one curl to Alertmanager, exit.
+#   - AT MOST ONCE per alert INCIDENT (fingerprint+startsAt; a resolve+refire is a new
+#     incident), claim-before-summon (crash-proof), FAIL CLOSED if the claim can't be
+#     durably recorded.
+#   - At most RESPONDER_MAX_PER_RUN (1) diagnosis per run; its own monthly spend CM
+#     (separate envelope from the shepherd — an alert storm can't eat the upgrade
+#     budget) + per-run --max-budget-usd.
+# CONTAINMENT: read-only cluster SA (the shared upgrade-health-gate ClusterRole), NO
+# git/gh write credential AT ALL (the repo clone is anonymous read-only), egress CNP =
+# DNS/apiserver/observability/Anthropic/Pushover/GitHub only, dontAsk + allowlist.
+set -uo pipefail
+
+AM="${ALERTMANAGER_URL:-http://kube-prometheus-stack-alertmanager.observability.svc.cluster.local:9093}"
+SEVERITY="${RESPONDER_SEVERITY:-critical}"
+ALLOWLIST="${RESPONDER_ALERT_ALLOWLIST:-.*}"
+DENYLIST="${RESPONDER_ALERT_DENYLIST:-^(Watchdog|InfoInhibitor|AlertmanagerReceiversNotConfigured)$}"
+MAX_PER_RUN="${RESPONDER_MAX_PER_RUN:-1}"
+MAX_AGE_HOURS="${RESPONDER_MAX_AGE_HOURS:-24}"
+STATE_TTL_HOURS="${RESPONDER_STATE_TTL_HOURS:-168}"
+MODEL="${RESPONDER_MODEL:-sonnet}"
+MAX_TURNS="${RESPONDER_MAX_TURNS:-25}"
+MAX_BUDGET="${RESPONDER_MAX_BUDGET_USD:-2.00}"
+MONTHLY_CAP="${RESPONDER_MONTHLY_CAP_USD:-15}"
+RUN_TIMEOUT="${RESPONDER_TIMEOUT:-12m}"
+DRY="${RESPONDER_DRY:-0}"
+NS="${RESPONDER_NAMESPACE:-upgrade-agent}"
+STATE_CM="alert-responder-state"
+SPEND_CM="alert-responder-spend"
+REPO_URL="${RESPONDER_REPO_URL:-https://github.com/thaynes43/haynes-ops.git}"
+WORKDIR="${HOME}/repo"
+NOW="$(date -u +%s)"
+
+log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" >&2; }
+
+page() {  # $1=title-suffix $2=message ; priority 0 (the ORIGINAL critical already
+          # paged at prio 1 via Alertmanager — this is the follow-up diagnosis).
+  if [ "$DRY" = "1" ]; then log "DRY: would page '[responder] $1' :: $2"; return 0; fi
+  : "${PUSHOVER_TOKEN:?}" ; : "${PUSHOVER_USER_KEY:?}"
+  curl -sf --max-time 10 https://api.pushover.net/1/messages.json \
+    --form-string "token=${PUSHOVER_TOKEN}" \
+    --form-string "user=${PUSHOVER_USER_KEY}" \
+    --form-string "title=[responder] $1" \
+    --form-string "message=$2" \
+    --form-string "priority=0" >/dev/null \
+    && log "paged: [responder] $1" \
+    || log "PAGE FAILED: [responder] $1"
+}
+
+# ── spend guard (same shape as the shepherd's, SEPARATE envelope) ──
+SPEND_MONTH="$(date -u +%Y-%m)"; SPEND_PRIOR="0"
+spend_guard() {
+  local cm m
+  cm="$(kubectl -n "$NS" get configmap "$SPEND_CM" -o json 2>/dev/null)" || {
+    log "spend-guard: cannot read $SPEND_CM (proceeding; account balance is the backstop)"; return 0; }
+  m="$(printf '%s' "$cm" | jq -r '.data.month // ""')"
+  SPEND_PRIOR="$(printf '%s' "$cm" | jq -r '.data.spent_usd // "0"')"
+  [ "$m" = "$SPEND_MONTH" ] || SPEND_PRIOR="0"
+  if awk -v s="$SPEND_PRIOR" -v b="$MAX_BUDGET" -v c="$MONTHLY_CAP" 'BEGIN{exit !(s + b > c)}'; then
+    log "spend-guard: MTD \$$SPEND_PRIOR + run cap \$$MAX_BUDGET would exceed \$$MONTHLY_CAP — SKIPPING (responder is always unattended)."
+    return 1
+  fi
+  return 0
+}
+record_spend() {
+  local cost new
+  cost="$(jq -r '.total_cost_usd // .cost_usd // 0' "$1" 2>/dev/null)"; [ -n "$cost" ] && [ "$cost" != "null" ] || cost=0
+  new="$(awk -v a="${SPEND_PRIOR:-0}" -v b="$cost" 'BEGIN{printf "%.4f", a + b}')"
+  kubectl -n "$NS" create configmap "$SPEND_CM" \
+    --from-literal=month="$SPEND_MONTH" --from-literal=spent_usd="$new" \
+    --dry-run=client -o yaml | kubectl -n "$NS" apply -f - >/dev/null 2>&1 \
+    && log "spend: +\$$cost => MTD \$$new / \$$MONTHLY_CAP" \
+    || log "spend: WARN could not record \$$cost"
+}
+
+# ── incident state (at-most-once per fingerprint+startsAt, TTL-pruned) ──
+sig_of() { printf '%s' "$1" | sha256sum | grep -oE '[0-9a-f]{64}' | head -1 | cut -c1-12; }
+state_has() {  # $1=key ; rc0 = already handled. Any read ERROR => treat as handled
+               # (FAIL CLOSED — protect spend; Alertmanager already paged the human).
+  local out rc
+  out="$(kubectl -n "$NS" get configmap "$STATE_CM" -o json 2>&1)"; rc=$?
+  if [ $rc -ne 0 ]; then
+    case "$out" in
+      *NotFound*|*"not found"*) return 1 ;;  # verifiably no prior state
+      *) log "state: UNREADABLE ($out) — failing CLOSED (skip)"; return 0 ;;
+    esac
+  fi
+  printf '%s' "$out" | jq -e --arg k "$1" '.data[$k] // empty' >/dev/null 2>&1
+}
+state_claim() {  # $1=key $2=alertname ; claim BEFORE the summon; rc!=0 => do NOT summon.
+  local ttl=$(( STATE_TTL_HOURS * 3600 ))
+  if kubectl -n "$NS" get configmap "$STATE_CM" >/dev/null 2>&1; then
+    kubectl -n "$NS" get configmap "$STATE_CM" -o json 2>/dev/null \
+      | jq --arg k "$1" --arg a "$2" --argjson now "$NOW" --argjson ttl "$ttl" '
+          .data = (.data // {})
+          | .data[$k] = ({alertname:$a, attempted:"1", first_seen:($now|tostring)} | tojson)
+          | .data |= with_entries(
+                select(.key == $k
+                       or ((((.value | (fromjson? // {}) | (.first_seen // "0") | tonumber?) // 0)) > ($now - $ttl))))
+        ' 2>/dev/null | kubectl -n "$NS" replace -f - >/dev/null 2>&1
+  else
+    kubectl -n "$NS" create configmap "$STATE_CM" \
+      --from-literal="$1"="{\"alertname\":\"$2\",\"attempted\":\"1\",\"first_seen\":\"$NOW\"}" >/dev/null 2>&1
+  fi
+}
+
+# ── 1. Poll Alertmanager (the $0 path). ──
+alerts="$(curl -sf --max-time 15 "$AM/api/v2/alerts?active=true&silenced=false&inhibited=false" 2>/dev/null)"
+if [ -z "$alerts" ]; then
+  log "Alertmanager unreachable/empty response — nothing to do (Alertmanager pages independently; the gate covers blind spots)."
+  exit 0
+fi
+candidates="$(printf '%s' "$alerts" | jq -c --arg sev "$SEVERITY" --arg allow "$ALLOWLIST" --arg deny "$DENYLIST" --argjson now "$NOW" --argjson maxage "$(( MAX_AGE_HOURS * 3600 ))" '
+  [ .[]
+    | select(.labels.severity == $sev)
+    | select(.labels.alertname | test($allow))
+    | select(.labels.alertname | test($deny) | not)
+    | select(((.startsAt | sub("\\.[0-9]+";"") | fromdateiso8601? ) // $now) > ($now - $maxage))
+  ] | sort_by(.startsAt) | reverse' 2>/dev/null)"
+count="$(printf '%s' "$candidates" | jq 'length' 2>/dev/null)" || count=0
+if [ "${count:-0}" -eq 0 ] 2>/dev/null; then
+  log "no active ${SEVERITY} alerts in scope — exit \$0."
+  exit 0
+fi
+log "${count} in-scope ${SEVERITY} alert(s) active."
+
+# ── 2. Pick new incidents (newest first), at most MAX_PER_RUN. ──
+handled=0
+i=0
+while [ "$i" -lt "$count" ] && [ "$handled" -lt "$MAX_PER_RUN" ]; do
+  alert="$(printf '%s' "$candidates" | jq -c ".[$i]")"
+  i=$((i + 1))
+  aname="$(printf '%s' "$alert" | jq -r '.labels.alertname // "unknown"')"
+  ans="$(printf '%s' "$alert" | jq -r '.labels.namespace // .labels.exported_namespace // ""')"
+  fp="$(printf '%s' "$alert" | jq -r '.fingerprint // ""')"
+  sat="$(printf '%s' "$alert" | jq -r '.startsAt // ""')"
+  key="$(sig_of "${fp}|${sat}")"
+  if state_has "$key"; then
+    log "incident $key ($aname) already handled — skip."
+    continue
+  fi
+  spend_guard || exit 0
+  if ! state_claim "$key" "$aname"; then
+    log "incident $key ($aname): could NOT durably claim — FAIL CLOSED, not summoning (Alertmanager already paged the human)."
+    continue
+  fi
+  log "incident $key ($aname ns=$ans): claimed — summoning read-only diagnosis."
+
+  # ── 3. Anonymous read-only clone for the committed runbooks (repo is public; NO
+  #      credential exists in this pod). Best-effort — diagnosis proceeds without it. ──
+  rm -rf "$WORKDIR"
+  git clone --depth 1 --quiet "$REPO_URL" "$WORKDIR" >/dev/null 2>&1 || log "clone failed — continuing without repo context."
+  cd "$WORKDIR" 2>/dev/null || cd /tmp
+
+  ALERT_JSON="$(printf '%s' "$alert" | jq -c '{labels, annotations, startsAt}')"
+  PROMPT="You are the on-call ALERT RESPONDER for this Kubernetes homelab (GitOps/Flux, Talos). A critical alert is firing; Alertmanager already paged the human — your ONLY job is a fast, read-only diagnosis they read on their phone. Alert: ${ALERT_JSON}. Investigate with the allowlisted tools: kubectl get/describe, flux get, /opt/responder/prom-query.sh '<promql>' for metrics, /opt/responder/loki-query.sh '<logql>' [minutes] [limit] for logs (e.g. loki-query.sh '{namespace=\"x\",pod=~\"y.*\"}' 60). If a repo checkout is present, check .agents/runbooks/ and docs/ for a matching runbook and the recent git log for a plausible culprit change. Then STOP and output EXACTLY this report, under 900 characters total, no markdown headers: CAUSE: <most likely root cause, one or two sentences, state confidence> | EVIDENCE: <the two or three concrete observations that support it> | FIX: <the suggested action for the human — you must NOT perform it> | RUNBOOK: <repo path of the matching runbook, or none>."
+  SAFETY="SAFETY: you are STRICTLY READ-ONLY — never kubectl apply/delete/edit/exec/patch, never git push, never install anything; do not retry a denied command. Never include secret VALUES in output. You run UNATTENDED: no human answers questions; produce the report and stop. If the alert looks already resolved or you cannot diagnose it, still output the report with CAUSE: inconclusive."
+
+  export DISABLE_TELEMETRY=1 CLAUDE_CODE_ENABLE_TELEMETRY=0 \
+         DISABLE_ERROR_REPORTING=1 DISABLE_AUTOUPDATER=1 DISABLE_NON_ESSENTIAL_MODEL_CALLS=1
+  : "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY unset}"
+  OUT_FILE="$(mktemp 2>/dev/null || echo /tmp/responder-out.json)"
+  timeout "$RUN_TIMEOUT" claude -p "$PROMPT" \
+    --permission-mode dontAsk \
+    --allowedTools Read Grep Glob \
+      "Bash(kubectl get:*)" "Bash(kubectl describe:*)" "Bash(flux get:*)" \
+      "Bash(grep:*)" "Bash(cat:*)" "Bash(git log:*)" "Bash(git show:*)" \
+      "Bash(/opt/responder/prom-query.sh:*)" "Bash(/opt/responder/loki-query.sh:*)" \
+    --disallowedTools "WebFetch" "WebSearch" \
+    --append-system-prompt "$SAFETY" \
+    --max-turns "$MAX_TURNS" \
+    --max-budget-usd "$MAX_BUDGET" \
+    --model "$MODEL" \
+    --output-format json > "$OUT_FILE" 2>/dev/null
+  rc=$?
+  record_spend "$OUT_FILE"
+  REPORT="$(jq -r '.result // empty' "$OUT_FILE" 2>/dev/null | tr '\n\r' '  ' | cut -c1-950)"
+  if [ -n "$REPORT" ]; then
+    log "diagnosis ($aname): $REPORT"
+    page "${aname}${ans:+ (${ans})}" "${REPORT} [auto-diagnosis — verify before acting]"
+  else
+    log "diagnosis produced no report (rc=$rc) — silent (the original Alertmanager page stands)."
+  fi
+  handled=$((handled + 1))
+done
+log "responder cycle complete: handled=$handled"
+exit 0

--- a/kubernetes/main/apps/upgrade-agent/alert-responder/ks.yaml
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app alert-responder
+  namespace: upgrade-agent
+spec:
+  targetNamespace: upgrade-agent
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: upgrade-health-gate # reuse its read-only ClusterRole
+      namespace: upgrade-agent
+  path: ./kubernetes/main/apps/upgrade-agent/alert-responder/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  # NO postBuild.substitute: Flux envsubst would rewrite the shell `${VAR:-default}`
+  # forms in respond.sh (same trap as the gate/shepherd — keep it substitution-free).

--- a/kubernetes/main/apps/upgrade-agent/kustomization.yaml
+++ b/kubernetes/main/apps/upgrade-agent/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   # Flux-Kustomizations
   - ./health-gate/ks.yaml
   - ./shepherd/ks.yaml
+  - ./alert-responder/ks.yaml


### PR DESCRIPTION
Track B1 of the 2026-07-06 agent-ops plan: the **alert-responder** — the first step toward in-cluster agentic response to the Pushover pages, built as a second tenant on the shepherd chassis. Phase 1 is deliberately **enrich, don't act**: the human stays the actuator; the 2am critical page just arrives pre-investigated.

## How it works

- CronJob (`*/10`) polls Alertmanager for active, unsilenced, uninhibited `severity=critical` alerts (denylist: Watchdog-class). Healthy path = one curl, **$0**.
- A **new incident** (fingerprint + startsAt — a resolve+refire is a new incident) gets ONE read-only Claude Code diagnosis: `kubectl get/describe`, `flux get`, PromQL/LogQL via two deterministic wrapper scripts (raw curl is NOT allowlisted), plus the committed runbooks from an **anonymous** shallow clone (repo is public — no credential exists in the pod).
- The structured report (`CAUSE | EVIDENCE | FIX | RUNBOOK`, ≤950 chars) is paged to Pushover at **priority 0** — a follow-up under the priority-1 page Alertmanager already sent.

## Containment (shepherd pattern minus ALL write credentials)

- Read-only shared ClusterRole (`upgrade-health-gate`) — no secrets/exec/log/write; pod logs come via Loki instead.
- Egress CNP: DNS (exact matchNames for every multi-label service FQDN — the 2026-07-04 lesson), apiserver, observability (9090/9093/3100/80/8080), GitHub, Anthropic, Pushover. Nothing else; no ingress.
- No bot PEM, no ghs_ token, no git/gh write path anywhere in the pod. Total write surface: Pushover pages + two runtime CMs in its own namespace.
- `dontAsk` + explicit allowlist; WebFetch/WebSearch disabled.

## Cost discipline

At-most-once per incident (claim-before-summon, crash-proof, fail-closed on unverifiable state — triage's rules); max 1 diagnosis/run; own spend envelope (`alert-responder-spend`, **$15/mo**, $2/run) so an alert storm can't eat the shepherd's $50 budget.

Kill switch: `kubectl -n upgrade-agent patch cronjob alert-responder -p '{"spec":{"suspend":true}}'`

## Validation

- `bash -n` all scripts; kustomize renders (8 docs).
- jq filter harness: severity/allow/deny/max-age selection correct against synthetic alerts; refire produces a distinct incident key.
- Post-merge: E2E drill planned — synthetic warning-severity alert POSTed to Alertmanager + a one-off Job with `RESPONDER_SEVERITY=warning`, proving pickup → claim → diagnosis → page without touching the real critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLJgCzmxxtqjqfikkpRFpC
