### PR TITLE
feat(appdaemon): 1.4.0 — escalation gate, repair hold, per-checker mute

### DIFF
--- a/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
+++ b/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/thaynes43/appdaemon
-              tag: 1.3.1
+              tag: 1.4.0
             env:
               TZ: America/New_York
             envFrom:


### PR DESCRIPTION
Deploys hass-sandbox v1.4.0 (thaynes43/hass-sandbox#89): health-check paging overhaul — severity escalations gated by for-duration, critical pages held while auto-repair runs, per-checker mute from the dashboard card.

Image `ghcr.io/thaynes43/appdaemon:1.4.0` is built by hass-sandbox CI on merge to its main (in flight; will verify tag exists before merging this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuMSAu2NVfs5owDjiPiWoR