### PR TITLE
feat(diff-scope): typed supporting-edit allowlist — pattern 1: app-template automount restore

### DIFF
--- a/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
+++ b/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/thaynes43/appdaemon
-              tag: 1.3.1
+              tag: 1.4.0
             env:
               TZ: America/New_York
             envFrom:

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
@@ -101,7 +101,12 @@ spec:
                 gh pr merge <N> --auto --squash --delete-branch (GitHub merges only when
                 Flux Local AND Diff Scope are both green). If it needs a supporting edit:
                 author it on a NEW branch shepherd/<pkg>-<version>, open a PR (diff-scope
-                holds it for human review), do NOT enable auto-merge. Everything out of
+                holds it for human review), do NOT enable auto-merge — EXCEPT the one
+                TYPED shape diff-scope now admits (pattern 1): when the ONLY supporting
+                edit is restoring automountServiceAccountToken: true (plus its bare
+                defaultPodOptions: parent if absent) in a helmrelease.yaml that ALREADY
+                declares serviceAccount:, author bump+edit on one branch and DO enable
+                auto-merge; any other shape stays human-review. Everything out of
                 scope — the cluster-breakers (cnpg, rook-ceph, ceph-csi-drivers, cilium,
                 authentik, emqx, dragonfly-operator, cert-manager, external-secrets) and
                 any non-ramp component's major: leave untouched, just list it in your

--- a/scripts/diff-scope-test.sh
+++ b/scripts/diff-scope-test.sh
@@ -92,6 +92,48 @@ h_crole()    { new_kind 'kind: ClusterRole'; }
 h_crd()      { new_kind 'kind: CustomResourceDefinition'; }
 h_es()       { new_kind 'kind: ExternalSecret'; }
 
+# ── TYPED PATTERN 1 fixtures (2026-07-06): app-template automount restore ──
+# An HR that ALREADY declares serviceAccount: in its BASE version qualifies for the
+# typed allowlist; everything else about the automount edit must still be exact.
+SAHR=kubernetes/main/apps/network/multus/app/helmrelease.yaml
+sa_hr() { # $1=tag-char $2=extra-lines (appended verbatim, may be empty)
+  w "$SAHR" "apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: multus
+spec:
+  values:
+    controllers:
+      multus:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/k8snetworkplumbingwg/multus-cni
+              tag: v4.1.$1
+    serviceAccount:
+      create: true${2:+
+$2}"; }
+base_sa_hr()        { sa_hr 0 ''; }
+head_sa_bump_auto() { sa_hr 1 '    defaultPodOptions:
+      automountServiceAccountToken: true'; }
+head_sa_auto_only() { sa_hr 0 '    defaultPodOptions:
+      automountServiceAccountToken: true'; }
+head_sa_auto_sneak(){ sa_hr 1 '    defaultPodOptions:
+      automountServiceAccountToken: true
+      hostNetwork: true'; }
+base_sa_false()     { sa_hr 0 '    defaultPodOptions:
+      automountServiceAccountToken: false'; }
+head_sa_flip()      { sa_hr 0 '    defaultPodOptions:
+      automountServiceAccountToken: true'; }
+SANOTHR=kubernetes/main/apps/network/multus/app/extra.yaml
+base_sa_nothr() { w "$SANOTHR" 'spec:
+  serviceAccount:
+    create: true'; }
+head_sa_nothr() { w "$SANOTHR" 'spec:
+  serviceAccount:
+    create: true
+  automountServiceAccountToken: true'; }
+
 # The REAL supporting edits (the crux):
 head_apptmpl() { # app-template v5: must keep automountServiceAccountToken TRUE
   w "$IMMICH" 'apiVersion: helm.toolkit.fluxcd.io/v2
@@ -176,12 +218,23 @@ run_case "bump + unrelated replicas change" 1 base_hr head_repl "allowed shape"
 run_case "registry swap (no version change)" 1 base_hr head_repo "allowed shape"
 
 echo ""
-echo "── PROOF: the REAL manual-tier supporting edits ARE the sensitive shapes ──"
-echo "   (what a diff-scope 'widening' would have to admit — each collides with GATE A"
-echo "    by design; admitting them re-opens the hole the gate exists to close. Expected"
-echo "    verdict: REVIEW, not auto-merge.)"
-run_case "app-template v5 supporting edit"  1 base_hr   head_apptmpl "security-sensitive"
-run_case "rook CSI supporting edit"         1 base_rook head_rook    "security-sensitive"
+echo "── TYPED PATTERN 1 (2026-07-06): app-template automount restore ──"
+echo "   The ONLY admitted supporting-edit shape: add automountServiceAccountToken:true"
+echo "   (+ bare defaultPodOptions:) to a kubernetes/** helmrelease.yaml whose BASE"
+echo "   already declares serviceAccount:. Everything adjacent must still gate."
+run_case "typed: bump + automount restore (SA pre-exists)"  0 base_sa_hr    head_sa_bump_auto
+run_case "typed: automount restore alone (SA pre-exists)"   0 base_sa_hr    head_sa_auto_only
+run_case "typed: automount + sneaky hostNetwork"            1 base_sa_hr    head_sa_auto_sneak "security-sensitive"
+run_case "typed: explicit false->true flip still gates"     1 base_sa_false head_sa_flip       "allowed shape"
+run_case "typed: automount in a non-HR file still gates"    1 base_sa_nothr head_sa_nothr      "security-sensitive"
+
+echo ""
+echo "── PROOF: the OTHER manual-tier supporting edits stay the sensitive shapes ──"
+echo "   (the UNQUALIFIED automount shape — no serviceAccount in the base HR — and the"
+echo "    rook CSI SA edit still collide with GATE A by design. Only typed pattern 1"
+echo "    above is admitted; everything else stays REVIEW.)"
+run_case "app-template edit WITHOUT pre-existing SA" 1 base_hr   head_apptmpl "security-sensitive"
+run_case "rook CSI supporting edit"                  1 base_rook head_rook    "security-sensitive"
 
 echo ""
 echo "════════════════════════════════════════════════════════════════════"

--- a/scripts/diff-scope.sh
+++ b/scripts/diff-scope.sh
@@ -14,6 +14,14 @@
 # never trip it. GATE B (shape allowlist, fail-closed) requires masked-multiset
 # equality of removed vs added lines per file — only a pure version/digest/action-pin
 # bump satisfies it. Exit 0 = safe shape; exit 1 = human review required.
+#
+# TYPED SUPPORTING-EDIT ALLOWLIST (2026-07-06). Widening the generic shape is and
+# stays forbidden — instead, individually-vetted, machine-checkable edit shapes are
+# admitted ONE AT A TIME, each with adversarial cases in scripts/diff-scope-test.sh.
+# Pattern 1 (app-template v5 automount restore) is defined at the loop below; the
+# worst case it admits is bounded to "a pod mounts the ServiceAccount it ALREADY
+# declares" — it cannot mint an identity (adding serviceAccount*/RBAC still hard-fails)
+# and cannot grant that SA anything (rbac paths still hard-fail; Kyverno enforces).
 set -uo pipefail
 
 BASE_BRANCH="${DIFF_SCOPE_BASE_BRANCH:-main}"
@@ -79,8 +87,34 @@ for entry in "${NAME_STATUS[@]}"; do
   [[ "$path" == kubernetes/*/apps/kyverno/* ]] && violation "touches the Kyverno guardrail tree: ${path}"
   [[ "$path" == scripts/diff-scope.sh ]]      && violation "touches the diff-scope guard itself: ${path}"
 
+  # ---- TYPED SUPPORTING-EDIT ALLOWLIST — pattern 1: app-template automount restore.
+  #      app-template v5 flips automountServiceAccountToken to false; every HR that
+  #      already declares a serviceAccount needs `automountServiceAccountToken: true`
+  #      (re-)added alongside the chart bump — the exact playbook landmine. Qualify:
+  #        * the file is a kubernetes/** helmrelease.yaml (kyverno tree already fails
+  #          GATE A above), AND
+  #        * the BASE version of the file ALREADY declares `serviceAccount:` — so the
+  #          edit can only restore token-mounting for an identity that exists; a PR
+  #          that also ADDS the serviceAccount still hard-fails GATE A.
+  #      Then ONLY these exact added lines are excluded from GATE A content checks and
+  #      the GATE B multiset: `automountServiceAccountToken: true` and its bare parent
+  #      key `defaultPodOptions:`. Any other added/removed line still gates. A
+  #      true<-false FLIP still gates (the removed `false` line has no filtered pair —
+  #      deliberately: an explicit false is a defense-in-depth choice a human made).
+  TYPED_AUTOMOUNT_RE='^\+?[[:space:]]*automountServiceAccountToken:[[:space:]]*true$'
+  TYPED_PARENT_RE='^\+?[[:space:]]*defaultPodOptions:$'
+  typed_ok=0
+  if [ "$base" = "helmrelease.yaml" ] && [[ "$path" == kubernetes/* ]]; then
+    if git show "${RANGE%%..*}:${path}" 2>/dev/null | grep -qE '^[[:space:]]*serviceAccount:'; then
+      typed_ok=1
+    fi
+  fi
+
   # ---- GATE A: sensitive ADDED content (only '+' lines) ----
   added="$(git diff --no-color "${RANGE}" -- "$path" | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+  if [ "$typed_ok" = "1" ]; then
+    added="$(printf '%s\n' "$added" | grep -vE "$TYPED_AUTOMOUNT_RE" | grep -vE "$TYPED_PARENT_RE" || true)"
+  fi
   printf '%s\n' "$added" | grep -qEi "$SENSITIVE_ADD_RE"  && violation "adds security-sensitive field in ${path}"
   printf '%s\n' "$added" | grep -qE  "$SENSITIVE_KIND_RE" && violation "adds sensitive resource kind in ${path}"
   printf '%s\n' "$added" | grep -qE  "$SENSITIVE_WORD_RE" && violation "adds sensitive token in ${path}"
@@ -88,7 +122,11 @@ for entry in "${NAME_STATUS[@]}"; do
 
   # ---- GATE B: shape allowlist (masked-multiset equality of removed vs added) ----
   rm_lines="$(git diff --no-color "${RANGE}" -- "$path" | grep -E '^-'  | grep -vE '^---' | sed 's/^-//' | normalize | LC_ALL=C sort)"
-  add_lines="$(git diff --no-color "${RANGE}" -- "$path" | grep -E '^\+' | grep -vE '^\+\+\+' | sed 's/^+//' | normalize | LC_ALL=C sort)"
+  add_raw="$(git diff --no-color "${RANGE}" -- "$path" | grep -E '^\+' | grep -vE '^\+\+\+' | sed 's/^+//')"
+  if [ "$typed_ok" = "1" ]; then
+    add_raw="$(printf '%s\n' "$add_raw" | grep -vE "$TYPED_AUTOMOUNT_RE" | grep -vE "$TYPED_PARENT_RE" || true)"
+  fi
+  add_lines="$(printf '%s\n' "$add_raw" | normalize | LC_ALL=C sort)"
   [ "$rm_lines" != "$add_lines" ] && violation "diff exceeds allowed shape (not a pure version/digest bump): ${path}"
 done
 


### PR DESCRIPTION
Track A5 of the 2026-07-06 agent-ops plan — the single biggest step toward "shepherd researches the breaking change AND lands it" without weakening the security gate.

## The approach: typed patterns, not a wider shape

The Phase-D handoff correctly forbids widening diff-scope's generic allowed shape. This PR keeps that: GATE A/B are untouched for everything except **one enumerated, machine-checkable edit shape**, admitted with its own qualification checks and regression-locked by adversarial tests. Future patterns get added one at a time, each with its own cases.

## Pattern 1 — app-template automount restore

The exact playbook landmine: app-template v5 flips `automountServiceAccountToken` to `false`; every HR with a `serviceAccount:` must set it back `true` alongside the bump. Qualification (ALL required, else the lines gate as before):

- file is a `kubernetes/**` `helmrelease.yaml` (kyverno tree still hard-fails earlier),
- the **base** version of the file already declares `serviceAccount:` — the edit can only restore token-mounting for an identity that already exists,
- the only exempted added lines are exactly `automountServiceAccountToken: true` and the bare parent key `defaultPodOptions:`.

**Bounded worst case:** a pod mounts the SA it already declares. It cannot mint an identity (`serviceAccount*`/RBAC additions still hard-fail GATE A), cannot grant that SA anything (rbac-file paths hard-fail; Kyverno RBAC policies enforce at admission), an explicit `false`→`true` flip still gates (a deliberate defense-in-depth `false` stays human), and any adjacent edit still fails GATE A/B.

## Suite: 26/26

19 original regression locks unchanged + 5 new typed cases (qualified bump+restore passes; restore-alone passes — documented accepted shape; sneaky-hostNetwork, false→true flip, non-HR file all still gate) + the crux proofs updated (unqualified automount — no pre-existing SA — and rook CSI edits stay blocked).

Also updates the scheduled shepherd's AUTO prompt: it may arm auto-merge on exactly this shape; the server-side check still decides, so a wrong guess just queues for a human.

Note: per the tamper-proofing, the workflow executes diff-scope.sh from the **base branch**, so this takes effect only after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLJgCzmxxtqjqfikkpRFpC
