### PR TITLE
fix(upgrade-agent): responder Loki endpoint (gateway has 0 replicas) + Pushover 1000-char clamp

### DIFF
--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/helmrelease.yaml
@@ -41,7 +41,11 @@ spec:
             env:
               ALERTMANAGER_URL: http://kube-prometheus-stack-alertmanager.observability.svc.cluster.local:9093
               PROMETHEUS_URL: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
-              LOKI_URL: http://loki-gateway.observability.svc.cluster.local:80
+              # NOT loki-gateway: this chart deploys gateway.replicas: 0 (Service with
+              # ZERO endpoints — DNS resolves, CNP passes, every query times out =
+              # silent log-blind diagnosis; caught by adversarial review 2026-07-06).
+              # Every other consumer here talks to loki:3100 directly.
+              LOKI_URL: http://loki.observability.svc.cluster.local:3100
               RESPONDER_MODEL: sonnet
               RESPONDER_MAX_PER_RUN: "1"
               RESPONDER_MAX_BUDGET_USD: "2.00"

--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/networkpolicy.yaml
@@ -31,7 +31,7 @@ spec:
               - matchPattern: "*.svc"
               - matchName: "kube-prometheus-stack-alertmanager.observability.svc.cluster.local"
               - matchName: "kube-prometheus-stack-prometheus.observability.svc.cluster.local"
-              - matchName: "loki-gateway.observability.svc.cluster.local"
+              - matchName: "loki.observability.svc.cluster.local"
               - matchName: "github.com"          # apex — *.github.com does NOT match it
               - matchPattern: "*.github.com"
               - matchPattern: "*.githubusercontent.com"

--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/resources/loki-query.sh
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/resources/loki-query.sh
@@ -3,7 +3,9 @@
 # from Loki, NOT kubectl logs — the read-only ClusterRole deliberately denies pods/log).
 # Usage: loki-query.sh '<logql>' [lookback-minutes=60] [limit=100]
 set -uo pipefail
-LOKI="${LOKI_URL:-http://loki-gateway.observability.svc.cluster.local:80}"
+# Default = the loki Service DIRECT (:3100). loki-gateway runs replicas:0 here — a
+# Service with no endpoints that resolves fine and then times out every query.
+LOKI="${LOKI_URL:-http://loki.observability.svc.cluster.local:3100}"
 q="${1:?usage: loki-query.sh '<logql>' [minutes] [limit]}"
 mins="${2:-60}"; limit="${3:-100}"
 start="$(date -u -d "-${mins} minutes" +%s)000000000"

--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/resources/gate.sh
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/resources/gate.sh
@@ -103,6 +103,10 @@ if [ "$API_OK" -ne 0 ] && [ "$PROM_OK" -ne 0 ]; then
   page warning gate-blind self "Gate cannot reach the API server OR Prometheus — health unknown."
   exit 0
 fi
+# Blind is NOT green — symmetric with the Prometheus-alone warning below: API-server
+# alone unreachable used to silently skip the Flux/GitRepository/orphan dimensions
+# (the gate's SOLE-catcher checks) while the heartbeat kept pinging (2026-07-06).
+[ "$API_OK" -ne 0 ] && page warning gate-blind apiserver "API server unreachable — Flux/GitRepository/orphan dimensions are blind this cycle (Prometheus checks continue)."
 
 # ---- Coordination decision (Flux NotReady + persisted pods, remediation-aware). ONE
 #      signature, per-dimension paging: Flux is the sole catcher (page unless a fix is in

--- a/kubernetes/main/apps/upgrade-agent/health-gate/app/resources/page.sh
+++ b/kubernetes/main/apps/upgrade-agent/health-gate/app/resources/page.sh
@@ -6,6 +6,12 @@ set -u
 SEV="${1:?severity}"; CHECK="${2:?check}"; COMP="${3:-unknown}"; SUM="${4:?summary}"
 : "${PUSHOVER_TOKEN:?PUSHOVER_TOKEN unset}"; : "${PUSHOVER_USER_KEY:?PUSHOVER_USER_KEY unset}"
 
+# Pushover rejects messages >1024 chars — and a rejected page is WORSE than a trimmed
+# one, because gate.sh stamps last_paged regardless and dedupes the retry for 6h. A
+# mass incident (20+ NotReady kustomizations, ESO outage) builds exactly such a body.
+# Clamp here so EVERY caller is covered (found by adversarial review 2026-07-06).
+SUM="${SUM:0:1000}"
+
 # critical -> priority 1 (breaks through quiet hours); else 0.
 prio=0; [ "$SEV" = "critical" ] && prio=1
 


### PR DESCRIPTION
Fixes the two CONFIRMED findings from the post-merge Fable adversarial review of #1980/#1981/#1983:

1. **[HIGH] alert-responder was log-blind by construction.** `LOKI_URL` pointed at `loki-gateway.observability:80` — this chart deploys `gateway.replicas: 0`, so the Service has **zero endpoints** (confirmed live: `kubectl get endpoints loki-gateway` → `<none>`). DNS resolves and the CNP passes, so every LogQL call would burn its 20s timeout and return QUERY FAILED — indistinguishable from "no matching logs". Since Loki is the responder's only log path (the shared ClusterRole deliberately denies `pods/log`), every $2 diagnosis would have been log-blind with nothing surfacing it. Now `loki.observability:3100` direct (what promtail/grafana use) + an exact DNS `matchName` in the CNP (Cilium `*` doesn't cross dots — the proven 07-04 gotcha).

2. **[MEDIUM] Pushover body clamp in page.sh.** Pushover rejects >1024-char messages; `curl -sf` swallows the 4xx; `gate.sh` stamps `last_paged` regardless → an oversized mass-incident page (20+ NotReady Kustomizations, ESO outage — with #1980's `| shepherd:` suffix adding up to ~233 chars) would be silently dropped AND dedupe-suppressed for 6h, on the one channel that is the sole Flux catcher. `SUM=${SUM:0:1000}` in page.sh covers every caller.

Post-merge verification planned: in-pod `loki-query.sh` probe through the CNP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLJgCzmxxtqjqfikkpRFpC
