### PR TITLE
feat(appdaemon): 1.5.0 — record_note relay command + shepherd runbooks

### DIFF
--- a/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
+++ b/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/thaynes43/appdaemon
-              tag: 1.4.0
+              tag: 1.5.0
             env:
               TZ: America/New_York
             envFrom:


### PR DESCRIPTION
Deploys hass-sandbox v1.5.0 (thaynes43/hass-sandbox#90): record_note relay command (triage audit trail) + shepherd runbooks. Paging routes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuMSAu2NVfs5owDjiPiWoR