### PR TITLE
fix(appdaemon): 1.5.1 — immich fetcher album assets on Immich v3

### DIFF
--- a/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
+++ b/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/thaynes43/appdaemon
-              tag: 1.5.0
+              tag: 1.5.1
             env:
               TZ: America/New_York
             envFrom:


### PR DESCRIPTION
Deploys hass-sandbox v1.5.1 (thaynes43/hass-sandbox#91): immich_fetcher album-filtered fetch was 404ing every cycle since Immich v3 removed POST /api/search/assets; now uses POST /api/search/metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuMSAu2NVfs5owDjiPiWoR