### PR TITLE
feat: media pipeline resilience (VPN readiness, gatus, dashboards)

### DIFF
--- a/kubernetes/main/apps/observability/grafana/app/dashboards/media-pipeline-resilience.json
+++ b/kubernetes/main/apps/observability/grafana/app/dashboards/media-pipeline-resilience.json
@@ -1,0 +1,474 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["media", "arr", "downloads", "exportarr"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Media Pipeline — *arr + Download Clients",
+  "uid": "media-pipeline-resilience",
+  "version": 1,
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Pipeline Health & Reachability",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "*arr + Download Clients Reachable",
+      "description": "Prometheus target up for each exportarr sidecar. DOWN = the exporter can't reach its app or the pod is gone.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 10, "x": 0, "y": 1 },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "index": 1 }, "1": { "text": "UP", "index": 0 } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "up{job=~\"radarr|sonarr|lidarr|prowlarr|sabnzbd|sabnzbd-fast\"}",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "System Health Issues (per app)",
+      "description": "Count of open health warnings/errors reported by each *arr's System > Status page.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 8, "x": 10, "y": 1 },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (radarr_system_health_issues)", "legendFormat": "radarr", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (sonarr_system_health_issues)", "legendFormat": "sonarr", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (lidarr_system_health_issues)", "legendFormat": "lidarr", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (prowlarr_system_health_issues)", "legendFormat": "prowlarr", "refId": "D" }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "SAB Download Speed (now)",
+      "description": "Live download throughput for each SABnzbd instance (regular + fast lane).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 1 },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "Bps",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sabnzbd_speed_bps", "legendFormat": "{{job}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "row",
+      "title": "Queues & Import Lag",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 },
+      "panels": []
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Queue Depth by App",
+      "description": "Total items in each app's activity queue. Torrent/usenet clients + *arr import queues. Persistently rising = imports stalled or downloads not clearing.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 7 },
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never", "spanNulls": true, "stacking": { "mode": "none" } },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (radarr_queue_total)", "legendFormat": "radarr", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (sonarr_queue_total)", "legendFormat": "sonarr", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (lidarr_queue_total)", "legendFormat": "lidarr", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (sabnzbd_queue_length)", "legendFormat": "{{job}}", "refId": "D" }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Import Lag — *arr queue items by state",
+      "description": "Queue items broken out by download_state. importBlocked / importPending / importFailed / warning states surfacing here mean grabs landed but aren't getting imported into the library.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 7 },
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 25, "lineWidth": 1, "showPoints": "never", "spanNulls": true, "stacking": { "mode": "normal" } },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job, download_state) (radarr_queue_total)", "legendFormat": "radarr / {{download_state}}", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job, download_state) (sonarr_queue_total)", "legendFormat": "sonarr / {{download_state}}", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job, download_state) (lidarr_queue_total)", "legendFormat": "lidarr / {{download_state}}", "refId": "C" }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Download Client Throughput",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "SAB Download Speed",
+      "description": "Instantaneous download throughput per SABnzbd instance.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "mean"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "showPoints": "never", "spanNulls": true, "gradientMode": "opacity" },
+          "unit": "Bps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sabnzbd_speed_bps", "legendFormat": "{{job}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "SAB Queue Remaining (bytes)",
+      "description": "Bytes left to download in each SAB queue — proxy for backlog / how far behind the fast + regular lanes are.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 12, "y": 16 },
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "showPoints": "never", "spanNulls": true },
+          "unit": "bytes",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sabnzbd_remaining_bytes", "legendFormat": "{{job}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "Downloaded (24h)",
+      "description": "Total bytes downloaded per SAB instance over the last 24h.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 4, "x": 20, "y": 16 },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "bytes",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (increase(sabnzbd_downloaded_bytes[24h]))", "legendFormat": "{{job}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "row",
+      "title": "Indexers (Prowlarr)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+      "panels": []
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Grab Rate by Indexer (grabs/hr)",
+      "description": "Successful grabs per hour, per indexer, derived from the Prowlarr grabs counter. Shows which indexers are actually feeding the pipeline.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "interval": "4m",
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "auto", "spanNulls": true },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (indexer) (rate(prowlarr_indexer_grabs_total[30m])) * 3600", "legendFormat": "{{indexer}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Indexer Avg Response Time",
+      "description": "Average query response time per indexer. Rising latency flags an indexer going bad before it fully fails.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 0, "lineWidth": 2, "showPoints": "never", "spanNulls": true },
+          "unit": "ms",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "prowlarr_indexer_average_response_time_ms", "legendFormat": "{{indexer}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "stat",
+      "title": "Indexers Enabled / Total",
+      "description": "Enabled indexers vs total configured in Prowlarr.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 33 },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "prowlarr_indexer_enabled_total", "legendFormat": "Enabled", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "prowlarr_indexer_total", "legendFormat": "Total", "refId": "B" }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Indexer Failed Query Rate (per hr)",
+      "description": "Failed indexer queries per hour, per indexer. Sustained failures = an indexer is throttling, rate-limiting, or down.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 12, "x": 6, "y": 33 },
+      "interval": "4m",
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "auto", "spanNulls": true },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (indexer) (rate(prowlarr_indexer_failed_queries_total[30m])) * 3600", "legendFormat": "{{indexer}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "stat",
+      "title": "Indexers Unavailable",
+      "description": "Count of indexers Prowlarr currently marks unavailable (blocked by failures). 0 / no data = all healthy.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 33 },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum(prowlarr_indexer_unavailable)", "legendFormat": "unavailable", "refId": "A" }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "row",
+      "title": "Library Overview",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
+      "panels": []
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Missing / Wanted Items",
+      "description": "Monitored items the library is still missing (radarr movies, sonarr episodes, lidarr albums). Trending down = the pipeline is catching up.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 5, "lineWidth": 2, "showPoints": "never", "spanNulls": true },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "radarr_movie_missing_total", "legendFormat": "radarr movies missing", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sonarr_episode_missing_total", "legendFormat": "sonarr episodes missing", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "lidarr_albums_missing_total", "legendFormat": "lidarr albums missing", "refId": "C" }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Root Folder Free Space",
+      "description": "Free space on each *arr root folder. A cliff here stalls imports pipeline-wide.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "min"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "asc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 0, "lineWidth": 2, "showPoints": "never", "spanNulls": true },
+          "unit": "bytes",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "radarr_rootfolder_freespace_bytes", "legendFormat": "radarr {{path}}", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sonarr_rootfolder_freespace_bytes", "legendFormat": "sonarr {{path}}", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "lidarr_rootfolder_freespace_bytes", "legendFormat": "lidarr {{path}}", "refId": "C" }
+      ]
+    }
+  ]
+}

--- a/kubernetes/main/apps/observability/grafana/app/kustomization.yaml
+++ b/kubernetes/main/apps/observability/grafana/app/kustomization.yaml
@@ -8,3 +8,18 @@ resources:
   - ./helmrepository.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+# Custom dashboards delivered as sidecar-watched ConfigMaps (label
+# grafana_dashboard). The grafana sidecar (searchNamespace: ALL) auto-imports
+# them into the folder named by the grafana_folder annotation. JSON is kept
+# token-free ($__range/$__rate_interval removed) so Flux postBuild.substitute
+# can't blank Grafana's built-in variables.
+configMapGenerator:
+  - name: grafana-dashboard-media-pipeline
+    files:
+      - dashboards/media-pipeline-resilience.json
+    options:
+      disableNameSuffixHash: true
+      labels:
+        grafana_dashboard: "true"
+      annotations:
+        grafana_folder: Media


### PR DESCRIPTION
## Media pipeline resilience — status of all three scoped items

Draft PR. Cluster access was **read-only** throughout (Prometheus queried via the Grafana MCP; no apply/reconcile/rollout). Branch `feat/pipeline-resilience-2026-07-07` only.

### TL;DR
Two of the three brief items were **already implemented on `main`** when I branched, so this PR carries only the new work: **item 3, the exportarr Grafana dashboard**. Details below.

---

### 1. VPN-down readiness for qBittorrent + slskd — ALREADY ON MAIN (no change)
Commit `aa5cbfcf` ("feat(downloads): Mullvad-egress readiness probes for qbt + slskd") already retrofitted the SAB pattern to both apps.
- **qbt** (`downloads/qbittorrent/app/helmrelease.yaml`): readiness `exec` → `wget -q -T 10 -O- https://am.i.mullvad.net/connected | grep -q "You are connected"`, `periodSeconds 60 / failureThreshold 4`. Liveness is a plain local check (a restart can't fix a down tunnel).
- **slskd** (`downloads/slskd/app/helmrelease.yaml`): readiness asserts local `/health` **AND** the same Mullvad-egress check; separate liveness heals a wedged Soulseek session.
- **Correctness check:** `am.i.mullvad.net/connected` returns "You are not connected to Mullvad" on **both** tunnel-down (request also fails outright) **and** WAN-leak (reaches Mullvad over the WAN and is reported as not-connected), so the `grep` fails NotReady in both cases → Traefik 503 → gatus → Pushover. Matches the brief's requirement. Nothing to add.

### 2. Gatus health checks for every *arr — ALREADY ON MAIN (no change)
All eight targets already wire the shared gatus component (`shared/components/gatus/gaurded`) and set `GATUS_SUBDOMAIN`/`GATUS_PATH` in their `ks.yaml`:

| app | GATUS_PATH | app | GATUS_PATH |
|---|---|---|---|
| radarr | `/ping` | seerr | `/api/v1/status` |
| sonarr | `/ping` | tautulli | `/status` |
| prowlarr | `/ping` | tautulli-k8plex | `/status` |
| bazarr | `/api/system/status` | lidarr | `/ping` |

(Note: the repo has two gatus component copies — `shared/components/gatus/gaurded` (typo, used by downloads+media) and `shared/components/common/gatus/guarded`. I matched the per-domain convention; downloads/media apps all use the former.) Nothing missing.

### 3. Grafana dashboards from exportarr metrics — NEW (this PR)
`observability/grafana/app/dashboards/media-pipeline-resilience.json` + a `configMapGenerator` entry in `observability/grafana/app/kustomization.yaml`.

**Delivery mechanism:** the Grafana sidecar (`sidecar.dashboards`, `searchNamespace: ALL`, `label: grafana_dashboard`, `folderAnnotation: grafana_folder`) already runs in the chart. The ConfigMap is generated with label `grafana_dashboard: "true"` and annotation `grafana_folder: Media`, so it auto-imports into a **Media** folder. No Grafana restart/redeploy needed beyond Flux applying the ConfigMap.

**Flux-safety:** the JSON is deliberately free of `$__range` / `$__rate_interval`. The grafana Kustomization runs `postBuild.substitute`, and Flux's envsubst blanks undefined `${VAR}`/`$VAR` tokens — which would silently break Grafana's built-in variables. rate()/increase() use fixed windows ≥ the 4m scrape interval instead. Verified `grep` finds zero `$` tokens in the final JSON.

**Panels (20), covering the brief's queue depth / grab rate / download-client throughput / import lag / indexer health, plus health + library context.**

**Every PromQL validated against live Prometheus (`query_prometheus`, uid `prometheus`) — sample results:**
- `up{job=~"radarr|sonarr|lidarr|prowlarr|sabnzbd|sabnzbd-fast"}` → all 6 = 1
- `sum by (job) (radarr_queue_total)` → 10 (queue metric carries a `download_state` label; summed for total, split by-state for the import-lag panel)
- Import lag: `sum by (job, download_state) (sonarr_queue_total)` → `importPending` = 90 (radarr showed `importBlocked`, lidarr `importFailed` — real import-lag signal)
- `sabnzbd_speed_bps` → both instances distinguished by `job` (`sabnzbd`, `sabnzbd-fast`)
- `sum by (job) (increase(sabnzbd_downloaded_bytes[24h]))` → sabnzbd ≈ 4.52 TB, sabnzbd-fast ≈ 105 GB
- `sum by (indexer) (rate(prowlarr_indexer_grabs_total[30m])) * 3600` → per-indexer grabs/hr (NZBgeek ≈ 2.1/hr; grabs counter has an `indexer` label: DrunkenSlug/NZBFinder/NZBgeek/NinjaCentral)
- `prowlarr_indexer_average_response_time_ms` → per-indexer (194–314 ms)
- `prowlarr_indexer_enabled_total` = 4, `prowlarr_indexer_total` = 15
- `sum by (indexer) (rate(prowlarr_indexer_failed_queries_total[30m])) * 3600` → all 0 (healthy)
- `sum by (job) (radarr_system_health_issues)` → radarr 1, prowlarr 2, sonarr/lidarr 0
- `radarr_movie_missing_total` = 61, `sonarr_episode_missing_total` = 40936, `lidarr_albums_missing_total` = 20320; `radarr_movie_total` = 9559
- `*_rootfolder_freespace_bytes` → per-`path` (e.g. `/data/haynestower/Media/Movies`)

`sum(prowlarr_indexer_unavailable)` currently returns no series (label-per-unavailable-indexer metric; none unavailable) — that panel uses `noValue: "0"` so it reads 0/green when healthy.

---

### Validation notes
- `kubectl kustomize observability/grafana/app` builds clean; the generated ConfigMap has the right label/annotation and the embedded dashboard parses (20 panels, uid `media-pipeline-resilience`).
- `task kubernetes:kubeconform` could **not** run locally: the task passes `kubernetes` but this repo's layout is `kubernetes/main/{flux,apps}`, and the `kubeconform` binary isn't on PATH in this environment. Both are pre-existing/environmental, unrelated to this change. flux-local CI on this PR will validate authoritatively. The only added K8s object is a standard ConfigMap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5wuGN8pzv3nNBZ2PhBwWG
