### PR TITLE
chore: kometa QA + polish

### DIFF
--- a/.agents/reports/kometa-qa-2026-07-07.md
+++ b/.agents/reports/kometa-qa-2026-07-07.md
@@ -1,0 +1,258 @@
+# Kometa collection QA + polish — 2026-07-07
+
+QA of the plexops Kometa collections after the "Defaults own franchises" declutter
+(2026-07-06). **Read-only** audit of live Plex (plexops, section 1 = HOps Movies /
+439 collections, section 2 = HOps TV Shows / 24 collections) + the completed
+`kometa-overlays-drain` job log + TMDb. Every recommendation below is a **proposal**
+— no Plex collection was created/edited/deleted, no Kometa job was run, no cluster
+mutation was made. Deletions are listed with ratingKeys for the main agent to action
+via the Plex API.
+
+Config source: `kubernetes/main/apps/media/kometa/app/config/` (branch
+`chore/kometa-qa-2026-07-07`, off `origin/main`).
+
+Key config facts confirmed from `externalsecret.yaml` (config.yml seed):
+- The **franchise Default IS enabled** on HOps Movies (`minimum_items: 2`,
+  `delete_below_minimum: true`, `remove_suffix "Collection"`), loaded **before**
+  `movies-franchises.yml`. Where a curated name == the Default canonical name they
+  merge into ONE collection; where they differ, both are kept (Default re-adopts the
+  orphan twin).
+- Global `settings.minimum_items: 2` + `delete_below_minimum: true` → any managed
+  collection with <2 items is pruned. This is why the sub-2 band is empty.
+- **HOps TV Shows has NO franchise Default** — only `shows-franchises.yml` +
+  `shows-collections.yml`. Any TV collection not in those files and not curated is an
+  unmanaged orphan.
+
+---
+
+## Task 1 — Empty / sparse / duplicate audit
+
+### Empty (0 items)
+| Collection | rk | items | Verdict |
+|---|---|---|---|
+| `Universe Collections` | 74320 | 0 | **KEEP** — this is the `universe` Default's **separator** collection (sort `!040_!Universe Collections`). Separators are 0-item by design and exempt from `minimum_items`. Not an orphan. |
+
+### Sparse (below min-items = 2)
+**None.** Global `delete_below_minimum: true` already prunes anything under 2 items
+(the drain run logged 11× `Plex Error: No Items found in Plex` for collections that
+built empty and were skipped/pruned). Lowest real collection is 2 items.
+
+### Near-duplicate PAIRS ("curated name vs Default canonical name both present")
+Detected by normalizing every collection title (strip `The/A`, parentheticals,
+`Collection/Universe/Original/Reboot/...`) and finding collisions. Classification:
+
+**TRUE remaining dup pairs — recommend action:**
+
+| # | Franchise | Managed / curated | Redundant twin (recommend DELETE) | Reasoning |
+|---|---|---|---|---|
+| 1 | Walking Dead (TV) | `Walking Dead` rk=**98232** cc5, sort `!010B Walking Dead` (managed by `shows-franchises.yml`, tvdb_list + tvdb_show 427464) | **`The Walking Dead` rk=93664** cc5, sort `Walking Dead` (plain) | No TV franchise Default exists, and `The Walking Dead` is **not in any config file** → pure orphan from the pre-cleanup `Shows.yml`, a full duplicate of the managed `Walking Dead`. **DELETE rk=93664.** |
+| 2 | Addams Family (movies) | `The Addams Family` rk=**95647** cc3, sort `!E Addams Family` (curated umbrella: TMDb 750822 + 11716 + imdb_list) | **`Addams Family` rk=93423** cc2, sort '' (franchise Default, TMDb 11716 live-action subset) | The Default `Addams Family` is a strict subset of the curated umbrella. To dedup, **exclude TMDb `11716` from the franchise Default** in `externalsecret.yaml` (so only the umbrella survives) — a plain Plex delete of rk=93423 will just rebuild next run. |
+| 3 | Planet of the Apes (movies) | Defaults `Planet of the Apes (Original)` rk=93504 cc2 + `Planet of the Apes (Reboot)` rk=93484 cc4 | **`Planet of the Apes` rk=95667** cc6, sort `!E Planet of the Apes` (orphan curated umbrella — **not in current config**) | The orphan umbrella (6 items) == Original(2) + Reboot(4). The `externalsecret.yaml` comment claims curated "Planet of the Apes" is intentionally kept alongside the Defaults, **but it is no longer in `movies-franchises.yml`** → it is an unmanaged orphan. Either re-add to config (if the umbrella is wanted) or **DELETE rk=95667** (Defaults fully cover it). |
+| 4 | Godzilla / MonsterVerse (movies) | curated `Monsterverse` rk=95664 cc4 (imdb_list) + Default `Godzilla (MonsterVerse)` rk=93531 cc4 | **`Godzilla` rk=95656** cc4, sort `!E Godzilla` (orphan curated — **not in current config**) | Three overlapping Godzilla/MonsterVerse collections. `Godzilla` rk=95656 is an orphaned curated collection with no config entry; its content overlaps `Monsterverse` and `Godzilla (MonsterVerse)`. **Recommend consolidating** — DELETE orphan `Godzilla` rk=95656 and keep `Monsterverse` (umbrella) + `Godzilla (MonsterVerse)` (Default). |
+
+**Soft overlap — keep both (noted, no action):**
+- `Monsterverse` rk=95664 (umbrella incl. Kong films) vs `Godzilla (MonsterVerse)`
+  rk=93531 (Godzilla subset) — different scope; both legitimate.
+
+**INTENTIONAL by design — NOT dups (universe Default + its sub-franchises):**
+`Conjuring Universe` + `The Conjuring`; `Mummy Universe` + `The Mummy`;
+`Star Trek` (universe) + `Star Trek: The Original Series`; `Star Wars Universe` +
+`Star Wars`; `X-Men Universe` + `X-Men`. The universe Default deliberately groups the
+sub-franchise Defaults.
+
+**Distinct collections that merely normalize alike — NOT dups:**
+`Batman` vs `Batman (DC Universe Animated)`; `Father of the Bride (Spencer Tracy)` vs
+`(Steve Martin)`; `Justice League (DCAMU)` vs `(Tomorrowverse)`; `The Lion King` vs
+`The Lion King (Reboot)`; `Spider-Man` (Raimi) vs `Spider-Man (MCU)`;
+`Independence Day Movies` (July-4th seasonal, 90 items) vs `Independence Day` (Will
+Smith franchise).
+
+### Unmanaged TV orphans (not in config, no TV Default) — verify intent
+These TV collections have plain sort titles, are not in `shows-franchises.yml` /
+`shows-collections.yml`, and have no Default to build them. Leftovers from the
+pre-cleanup `Shows.yml`. Either add to config (to manage) or delete:
+`Doctor Who` rk=79399 (cc2), `Law & Order` rk=79436 (cc2), `NCIS` rk=79533 (cc2),
+`Star Trek` rk=79419 (cc12), plus `The Walking Dead` rk=93664 (dup, see #1 above).
+
+---
+
+## Task 2 — The 22 "uncertain-kept" curated franchises
+
+Method: resolved each entry's TMDb collection id → canonical Default name (TMDb name
+minus " Collection"), then checked **both** the curated name and the Default canonical
+name against live Plex section-1 collections.
+
+**Result: 21 KEEP, 1 DELETE-recommend.**
+
+Of all 22, **only Pacific Rim exists as a live Plex collection.** For the other 21,
+**neither** the curated name **nor** the Default canonical name is present in Plex —
+meaning the library currently holds <2 films of each TMDb collection, so the franchise
+Default does not build them (delete_below_minimum prunes them). The curated entries'
+value is **acquisition** (they push missing franchise films to Radarr); the Default
+covers none of them → **KEEP**.
+
+| # | Curated entry | TMDb id | Default canonical name | In Plex? | Verdict |
+|---|---|---|---|---|---|
+| 1 | Pacific Rim | 363369 | Pacific Rim (same) | **YES** rk=98421 cc2, sort '' | **DELETE-recommend** — franchise Default owns it; both films present (collection complete), nothing to acquire → curated entry is redundant (same class as the already-removed Top Gun/Toy Story). Name == Default, so removing it from config leaves **no orphan** (Default rebuilds the same-named collection). |
+| 2 | The Brave Little Toaster | 141282 | The Brave Little Toaster (same) | no | KEEP |
+| 3 | Captain Underpants | 732397 | Captain Underpants (same) | no | KEEP |
+| 4 | Daddy Day Care | 228887 | **Daddy Day Camp** (differs) | no (neither) | KEEP |
+| 5 | DC Super Hero Girls | 477208 | DC Super Hero Girls (same) | no | KEEP |
+| 6 | Fantastic Four | 9744 | Fantastic Four (same) | no | KEEP |
+| 7 | Flowers in the Attic | 293981 | **Dollanganger** (differs) | no (neither) | KEEP |
+| 8 | The Girl - Millennium Collection | 575987 | **Millennium** (differs) | no (neither) | KEEP |
+| 9 | Goosebumps | 508783 | Goosebumps (same) | no | KEEP |
+| 10 | The Grudge | 1974 | The Grudge (same) | no | KEEP |
+| 11 | LEGO DC Comics Super Heroes | 386162 | LEGO DC Comics Super Heroes (same) | no | KEEP |
+| 12 | Mean Girls | 99606 | Mean Girls (same) | no | KEEP |
+| 13 | My Big Fat Greek Wedding | 389767 | My Big Fat Greek Wedding (same) | no | KEEP |
+| 14 | Peter Rabbit | 595693 | Peter Rabbit (same) | no | KEEP |
+| 15 | The Princess Diaries | 107674 | The Princess Diaries (same) | no | KEEP |
+| 16 | Ring | 93369 | Ring (same; JP *Ringu* series) | no | KEEP — note: a **`The Ring`** rk=98113 cc2 exists but that's the **US remake** franchise (different TMDb collection), not this Japanese one. Not a dup. |
+| 17 | The Scorpion King | 116669 | The Scorpion King (same) | no | KEEP |
+| 18 | Sharknado | 286023 | Sharknado (same) | no | KEEP |
+| 19 | The Smurfs | 134897 | **The Smurfs (Theatrical)** (differs) | no (neither) | KEEP |
+| 20 | Space Jam | 722961 | Space Jam (same) | no | KEEP |
+| 21 | Spy Kids | 86486 | Spy Kids (same) | no | KEEP |
+| 22 | Taxi | 211721 | Taxi (same) | no | KEEP |
+
+Per the task instruction, **Pacific Rim was NOT removed from config** — it is listed
+here for the main agent. (Removing it is orphan-free since the Default owns the same
+name, but the deletion decision is left to the operator.)
+
+---
+
+## Task 3 — Poster gaps (Monsterverse + Unbreakable)
+
+Both have TODO comments (missing local `file_poster`, no `url_poster` → Plex mosaic).
+**Investigated TMDb for a confident source and found none**, so **no `url_poster` was
+committed** (honoring "confident additions only / don't assume reachability"):
+- **Unbreakable** (`tmdb_movie: 9741,381288,450465`): Unbreakable / Split / Glass
+  **belong to no shared TMDb collection** (verified `belongs_to_collection: null` on
+  all three) → there is no canonical TMDb collection poster to use.
+- **Monsterverse** (imdb_list): **no single TMDb "MonsterVerse" collection** exists;
+  the closest, `Godzilla Collection` (535313) and `Godzilla x Kong Collection`
+  (1539140), each cover only a subset.
+
+**Candidate `url_poster` URLs (ThePosterDB — require visual confirmation).** The repo
+already serves ThePosterDB posters via the `https://theposterdb.com/api/assets/<id>`
+pattern, and ThePosterDB's `/poster/<id>` page id maps to `/api/assets/<id>` (could
+not auto-verify — ThePosterDB returns 403 to automated fetches). Confirm the image
+visually before committing:
+
+- **Monsterverse** — `MonsterVerse Collection` poster pages found:
+  `theposterdb.com/poster/59416` (Hopper) or `theposterdb.com/poster/13579`
+  (Stevey_Mac) → candidate `url_poster: https://theposterdb.com/api/assets/59416`
+  (or `/13579`).
+- **Unbreakable** — `Eastrail 177 / Unbreakable` / `The Unbreakable Trilogy` poster
+  pages found: `theposterdb.com/poster/17577` (Ccooluke) or `theposterdb.com/poster/427204`
+  (gamesburger) → candidate `url_poster: https://theposterdb.com/api/assets/17577`
+  (or `/427204`).
+
+Recommendation: pick one visually-verified asset id for each and add a `url_poster:`
+line under the collection (replacing the mosaic). Left uncommitted pending
+confirmation.
+
+---
+
+## Task 4 — Overlay coverage QA (`kometa-overlays-drain`, Kometa 2.4.4)
+
+Job `kometa-overlays-drain` (pod `kometa-overlays-drain-z2k65`) **Complete**, run
+01:00:09→02:12:22 (1:12:13). Movies overlays: 5507 items, 0:10:24. TV overlays: 863
+items, 1:00:29. Overlay coverage is broadly **healthy** — the vast majority of items
+show full overlay stacks (resolution / audio_codec / video_format / ribbon / ratings,
+plus TV `status`); errors are edge cases only.
+
+### Overlay errors (13 total), by item
+
+**Movies (3):**
+- `Drishyam 2` (1417/5507) — **No `<<user_rating>>` found** (missing IMDb user
+  rating in source data).
+- `Wild Tales` (5347/5507) — **No `<<critic_rating%>>%` found** (missing RT critic
+  score).
+- `Sergeant York` (4332/5507) — **"poster already has an Overlay — manual attention
+  required."** ← the one flagged in the brief. Kometa detected an already-overlaid
+  base poster and refuses to double-overlay. **Fix (Plex-side, out of scope):** reset
+  Sergeant York's poster to a clean (un-overlaid) image in Plex, then Kometa will
+  re-apply overlays on the next run.
+
+**TV — "No poster found" (6):** the show has no usable base poster in Plex for Kometa
+to overlay onto:
+`Bubble Guppies` (136), `Gudetama: An Eggcellent Adventure` (324),
+`Hamilton's Pharmacopeia` (331), `Hazbin Hotel` (338), `The Tom and Jerry Show`
+(779), `WildC a T S` (842). **Fix (Plex-side, out of scope):** set a poster on each
+show.
+
+**TV — "No `<<critic_rating%>>%` found" (4):** missing RT critic score:
+`It's Always Sunny in Philadelphia` (370), `Our Flag Means Death` (543),
+`Succession` (740), `X-Men '97` (853).
+
+Tally: 6 no-poster + 5 no-critic (1 movie + 4 TV) + 1 no-user + 1 already-overlaid =
+**13**. (The brief's "18" appears to fold in the 9 Convert/Filter mapping errors —
+see below.)
+
+### Not overlay errors — informational (benign)
+- **"No Items found for 84 Overlays"** — 84 overlay *definitions* (exotic resolution/
+  edition variants like `Richard-Donner`, `Ulysses`, `TELESYNC`, `CAM`, `DTS-X`,
+  `Emmys Winner`, `Golden Globe Winner`, various `*-Dovetail`) matched zero library
+  items. Expected — the library simply has no media with those tags. No action.
+- **Convert Summary** — IMDb/TVDb/TMDb cross-id gaps (7 IMDb ids, 50 TMDb→TVDb, 4
+  TVDb→TMDb unmapped) + 9 body `Mapping Error` lines (e.g. Australian Survivor,
+  Battlestar Galactica, Bob the Builder, Jury Duty Presents: Company Retreat). These
+  are upstream metadata-source gaps, not config faults. Note: `Bubble Guppies`,
+  `Hamilton's Pharmacopeia`, `Hazbin Hotel`, `The Tom and Jerry Show`, `WildC a T S`
+  appear in **both** the TVDb-mapping gap **and** the no-poster list — a missing TVDb
+  id can be why no poster was resolved.
+- **Config Warning: Skipping duplicate collection: `Drishyam`** — two builders
+  produced a collection named "Drishyam" (multiple same-named TMDb "Drishyam"
+  collections: Malayalam original + Hindi remake); Kometa kept one, skipped the dup.
+  Benign, but flagged for awareness.
+- **Config Warning: `verify_ssl` not found, using True** — benign default.
+
+---
+
+## Task 5 — Typos / inconsistencies
+
+**Fixed in this PR (safe):**
+1. `movies-collections.yml` — `radarr_tag: "Kometa-Added,SpacialSurround"` →
+   `"...,SpatialSurround"` (the collection is "**Spatial** Surround"; "Spacial" is a
+   misspelling). **Zero live impact:** the audio collections are `plex_all` filters
+   over existing media, so `add_missing` is a no-op and the tag is never applied to
+   any acquired item — pure hygiene.
+2. `movies-franchises.yml` — The Brave Little Toaster `sort_title: "!E Brave Little
+   Toaster Collection"` → `"!E Brave Little Toaster"` (stray "Collection"; every other
+   `!E` sort_title omits it). Cosmetic; the collection isn't currently built so there
+   is no live effect.
+
+**Flagged, NOT edited (need operator intent):**
+3. **`movies-franchises.yml` header comment is inaccurate (highest-value finding).**
+   The header lists these as surviving **manual `tmdb_movie` augments** ("adds value
+   the Default can't reproduce"): *Ghostbusters, Godzilla, Hannibal, Lego Movie,
+   Nightmare on Elm St, Oceans, Resident Evil, The Muppets*. **None of these are
+   actually in the file's `collections:`.** In live Plex they persist as either
+   franchise-Default collections (Hannibal Lecter, The Lego Movie, Ocean's) or
+   orphaned curated `!E` collections (Godzilla rk=95656, Ghostbusters rk=93527, A
+   Nightmare on Elm Street rk=93594, Resident Evil rk=96647, The Muppets rk=93589) —
+   but the **augment films outside each TMDb collection are no longer being added**,
+   and on the next `sync_mode: sync` pass those extras will be dropped. Decide: re-add
+   the augments to `movies-franchises.yml` (restoring the value the header claims) or
+   correct the header to reflect Default-only coverage.
+4. `shows-collections.yml` line 51 — `77038  # Rugrats (TODO: get 2021 version)` is a
+   standing TODO (Kid Cartoons uses the same 77038 without the note). Informational.
+5. `movies-franchises.yml` — `The Girl - Millennium Collection` keeps a redundant
+   "Collection" in its **name** and lacks the article/`The`-stripping `sort_title`
+   its siblings use; its Default canonical is simply "Millennium". Cosmetic; left as-is.
+6. Stale `!E` sort_titles on now-Default-owned franchises (e.g. `!E Die Hard`,
+   `!E Alien`, `!E X-Men`) — leftover from the pre-cleanup curated template. Cosmetic
+   only, and not fixable via config (the sort lives in Plex, set by removed entries).
+
+---
+
+## Summary of proposed Plex API actions (for the main agent — NOT done here)
+- **DELETE** TV `The Walking Dead` rk=**93664** (orphan dup of managed `Walking Dead`).
+- **DELETE** movie `Planet of the Apes` rk=**95667** (orphan umbrella; Defaults cover it) — or re-add to config.
+- **DELETE** movie `Godzilla` rk=**95656** (orphan; overlaps Monsterverse + Godzilla (MonsterVerse)) — consolidate.
+- **Addams dedup**: exclude TMDb `11716` from the franchise Default (removes Default `Addams Family` rk=93423, subset of curated umbrella rk=95647).
+- **Pacific Rim** (config): DELETE-recommend curated entry (Default owns it, orphan-free) — operator's call.
+- Overlay: reset `Sergeant York`'s poster in Plex; set posters on the 6 no-poster TV shows.
+- Verify intent on unmanaged TV orphans: `Doctor Who` (79399), `Law & Order` (79436), `NCIS` (79533), `Star Trek` (79419).

--- a/kubernetes/main/apps/media/kometa/app/config/movies-collections.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/movies-collections.yml
@@ -32,7 +32,7 @@ collections:
     url_poster: https://haynesnetwork.com/wp-content/uploads/2023/11/SurroundTestCollection.png
     collection_order: release.desc
     schedule: weekly(saturday)
-    radarr_tag: "Kometa-Added,SpacialSurround"
+    radarr_tag: "Kometa-Added,SpatialSurround"
     filters:
       - filepath.regex: '(?i)^(?=.*\btrue[ ._-]?hd(\b|\d))(?=.*\batmos(\b|\d))'
       - audio_track_title.regex: '(?i)^(?=.*\btrue[ ._-]?hd(\b|\d))(?=.*\batmos(\b|\d))'

--- a/kubernetes/main/apps/media/kometa/app/config/movies-franchises.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/movies-franchises.yml
@@ -39,7 +39,7 @@ collections:
     sort_title: "!E Addams Family"
   The Brave Little Toaster:
     template: {name: Movies, collection: 141282}
-    sort_title: "!E Brave Little Toaster Collection"
+    sort_title: "!E Brave Little Toaster"
   Captain Underpants:
     template: {name: Movies, collection: 732397}
   Daddy Day Care:


### PR DESCRIPTION
QA + polish of the plexops Kometa collections after the **"Defaults own franchises"** declutter (2026-07-06). **Reviewable output only** — read-only audit of live Plex + the completed `kometa-overlays-drain` job + TMDb. No Plex collection was created/edited/deleted, no Kometa job was run, no cluster mutation was made.

## What's in this PR
- **Report:** `.agents/reports/kometa-qa-2026-07-07.md` — full findings + per-item recommendations with ratingKeys.
- **2 safe typo fixes** (validated YAML, no live effect):
  - `SpacialSurround` → `SpatialSurround` radarr_tag (inert tag on a `plex_all` audio collection).
  - Stray `Collection` removed from `The Brave Little Toaster` sort_title.

## Headline findings
- **22 uncertain-kept franchises:** 21 **KEEP**, 1 **DELETE-recommend** (`Pacific Rim` — franchise Default already owns it, both films present). The other 21 aren't built in Plex at all (library has <2 films each), so the Default doesn't cover them → their acquisition value stands.
- **Remaining dup pairs** (proposed Plex deletes, NOT applied): TV `The Walking Dead` rk=93664 (orphan of managed `Walking Dead`); movie orphan umbrellas `Planet of the Apes` rk=95667 and `Godzilla` rk=95656; Addams dedup (exclude TMDb 11716 from franchise Default).
- **Overlay drain QA (Kometa 2.4.4, 1:12:13):** coverage healthy; 13 overlay errors attributed to specific items — incl. the one `Sergeant York` "poster already has an Overlay — manual attention required", 6 no-poster TV shows, 5 missing-critic-rating, 1 missing-user-rating (`Drishyam 2`).
- **Posters:** no confident `url_poster` committed — Unbreakable (no shared TMDb collection) and Monsterverse (no single TMDb collection) have no verifiable canonical poster; ThePosterDB candidates proposed in the report for visual confirmation.
- **Doc inconsistency flagged:** `movies-franchises.yml` header claims 8 `tmdb_movie` augments survive (Ghostbusters, Godzilla, Hannibal, …) but none are actually in the file.

All Plex-API deletions / poster resets / config-deletion decisions are **left to the operator** and listed in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5wuGN8pzv3nNBZ2PhBwWG