### PR TITLE
fix(appdaemon): 1.5.2 — protect outage fast-confirm + battery dependency mask

### DIFF
--- a/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
+++ b/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/thaynes43/appdaemon
-              tag: 1.5.1
+              tag: 1.5.2
             env:
               TZ: America/New_York
             envFrom:


### PR DESCRIPTION
Deploys hass-sandbox v1.5.2 (thaynes43/hass-sandbox#92): Protect total-outage confirms critical in ~3min arming auto-repair (repair hold keeps Pushover quiet); protect_batteries dependency-masked behind protect. This morning's 07:41 page scenario now self-repairs silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuMSAu2NVfs5owDjiPiWoR