### PR TITLE
fix(shepherd): rook guard matches ride-the-default Ceph policy (not a pin)

### DIFF
--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
@@ -103,9 +103,13 @@ spec:
                 component playbook, then act:
                 REVERTIBLE (auto-merge, backup/health-gated) — a bump whose failure a git
                 revert or HR strategy:rollback recovers with the data plane untouched:
-                rook chart/operator/csi PATCH or safe minor with cephVersion PINNED
-                UNCHANGED (verify the Ceph image tag in the cluster CR is not bumped) and
-                Ceph HEALTH_OK now; cnpg OPERATOR chart bump with the PG imageName
+                rook chart/operator/csi PATCH (a rook PATCH does not move the Ceph daemon
+                major) with Ceph HEALTH_OK now — NOTE Ceph is deliberately NOT pinned in
+                this repo (ride-the-chart-default policy; see the ceph-tentacle memory +
+                playbook), so for a rook MINOR/MAJOR you MUST read the chart release notes
+                and confirm the bundled Ceph default does NOT cross a Ceph DAEMON major (if
+                it does, that bump is ONE-WAY → author for confirm, do not auto-merge);
+                cnpg OPERATOR chart bump with the PG imageName
                 UNCHANGED (no PG major); dragonfly operator patch/minor; cilium PATCH;
                 authentik PATCH within the same YYYY.M. Confirm the backup gate
                 (append-system-prompt rule) AND, for rook, Ceph HEALTH_OK, then enable


### PR DESCRIPTION
The revertible-rook guard referenced a `cephVersion` pin that doesn't exist here — Ceph is deliberately unpinned (ride-the-chart-default, memory ceph-tentacle-unpinned). Corrected: rook PATCH is revertible (doesn't move Ceph daemon major) behind HEALTH_OK; rook minor/major requires release-note confirmation the bundled Ceph default doesn't cross a daemon major, else it's authored as one-way. Prompt-string only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)