### PR TITLE
feat(traefik): upgrade traefik-external chart to 41.0.2 (phase 2/2)

### DIFF
--- a/kubernetes/main/apps/network/traefik/traefik-external/app/helmrelease.yaml
+++ b/kubernetes/main/apps/network/traefik/traefik-external/app/helmrelease.yaml
@@ -6,7 +6,7 @@ spec:
   chart:
     spec:
       chart: traefik
-      version: 41.0.1
+      version: 41.0.2
       sourceRef:
         kind: HelmRepository
         name: traefik-external


### PR DESCRIPTION
Phase 2 of the traefik 41.0.2 split. Phase 1 (traefik-internal, #1993) is merged and verified healthy (41.0.2, 3/3 Running, `/ping` OK, LB 192.168.40.203 / Flux webhook route intact). This bumps traefik-external to match and completes the split; supersedes Renovate #1985.

🤖 Generated with [Claude Code](https://claude.com/claude-code)