### PR TITLE
feat(shepherd): upgrade-window auto-silencing of rollout-transient alerts

### DIFF
--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
@@ -132,7 +132,18 @@ spec:
                 bump needing NO supporting edit in the REVERTIBLE set (or class 1, or an
                 immich major past the backup gate): enable auto-merge with
                 gh pr merge <N> --auto --squash --delete-branch (GitHub merges only when
-                Flux Local AND Diff Scope are both green). If it needs a supporting edit,
+                Flux Local AND Diff Scope are both green).
+                UPGRADE-WINDOW SILENCE: immediately AFTER you enable auto-merge on a
+                REVERTIBLE CLUSTER-INFRA component (rook-ceph, cnpg, dragonfly-operator,
+                cilium, authentik), run '/opt/shepherd/silence.sh <component> 90' to
+                suppress that component's EXPECTED rollout-transient alerts (OSD/mgr churn,
+                Ceph backfill IO, pod restarts) for the reconcile+roll window — a normal
+                roll must NOT page the human. Do this ONLY for cluster-infra you just
+                auto-merged; NEVER for the stateless clean-tier (they self-heal fast) and
+                NEVER with any argument other than the component name (the matchers are
+                hardcoded in the script). Real regressions the health gate catches (Flux
+                NotReady, HEALTH_ERR) are deliberately NOT in the silenced set.
+                If it needs a supporting edit,
                 author it on a NEW branch shepherd/<pkg>-<version> and open a PR (diff-scope
                 holds it for human review) — EXCEPT the one TYPED shape diff-scope admits
                 (pattern 1): restoring automountServiceAccountToken: true (plus its bare

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/kustomization.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/kustomization.yaml
@@ -14,6 +14,7 @@ configMapGenerator:
     files:
       - resources/run-shepherd.sh
       - resources/triage.sh
+      - resources/silence.sh
 generatorOptions:
   disableNameSuffixHash: true
   labels:

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/networkpolicy.yaml
@@ -32,6 +32,7 @@ spec:
               - matchPattern: "*.cluster.local"
               - matchPattern: "*.svc"
               - matchName: "kube-prometheus-stack-prometheus.observability.svc.cluster.local"
+              - matchName: "kube-prometheus-stack-alertmanager.observability.svc.cluster.local"
               - matchName: "github.com"          # apex — *.github.com does NOT match it
               - matchPattern: "*.github.com"
               - matchPattern: "*.githubusercontent.com"
@@ -44,13 +45,16 @@ spec:
               protocol: TCP
             - port: "6443"
               protocol: TCP
-    # 3. In-cluster Prometheus — mode-2 diagnosis queries.
+    # 3. In-cluster Prometheus (9090, mode-2 diagnosis) + Alertmanager (9093, the
+    #    upgrade-window silence POST from silence.sh — bounded, hardcoded matchers).
     - toEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: observability
       toPorts:
         - ports:
             - port: "9090"
+              protocol: TCP
+            - port: "9093"
               protocol: TCP
     # 4. GitHub — git clone/push, gh PRs, gh release view (release notes).
     - toFQDNs:

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/run-shepherd.sh
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/run-shepherd.sh
@@ -275,6 +275,12 @@ WRITE_TOOLS=(Edit Write
 # GitHub merges server-side ONLY when Flux Local + Diff Scope are both green. It cannot
 # merge past a red/pending check, and `--admin` (skip-checks) fails for a non-admin.
 MERGE_TOOLS=("Bash(gh pr merge:*)")
+# Upgrade-window silencing (2026-07-08): after auto-merging a cluster-infra component,
+# the shepherd may set a BOUNDED Alertmanager silence for that component's expected
+# rollout-transient alerts (OSD/mgr churn, backfill IO, pod restarts) so a normal roll
+# doesn't page. silence.sh hardcodes the matchers + max duration; the LLM passes ONLY a
+# component name (contained — it cannot silence arbitrary alerts). auto/remediate only.
+SILENCE_TOOLS=("Bash(/opt/shepherd/silence.sh:*)")
 
 # NB: set PROMPT/SAFETY defaults on their OWN line — NOT inline via ${VAR:-default}.
 # An apostrophe or brace inside a ${VAR:-default} breaks bash quote parsing.
@@ -286,12 +292,12 @@ case "$MODE" in
     [ -n "$PROMPT" ] || PROMPT="You are the Tier-4 upgrade shepherd. Follow .agents/runbooks/upgrade-shepherd.md exactly. Survey open manual-tier Renovate PRs (gh pr list); pick the NEXT one by the runbook merge-order. CONSULT .renovate/holds.json5 first (skip if held). Read the release notes (gh release view) and the component section in .agents/runbooks/tier4-component-playbooks.md. Make the required supporting helmrelease/values edits on a NEW branch shepherd/<pkg>-<version>, commit, push, and open a PR with gh pr create. Do NOT merge, do NOT push to main, do NOT touch anything outside kubernetes/**. One PR only, then stop and summarize."
     ;;
   auto)      # open a PR AND enable server-side auto-merge (Phase 4b.3)
-    ALLOWED=("${READONLY_TOOLS[@]}" "${WRITE_TOOLS[@]}" "${MERGE_TOOLS[@]}")
+    ALLOWED=("${READONLY_TOOLS[@]}" "${WRITE_TOOLS[@]}" "${MERGE_TOOLS[@]}" "${SILENCE_TOOLS[@]}")
     SAFETY_MERGE="you MAY enable auto-merge with 'gh pr merge <N> --auto --squash --delete-branch' AFTER opening the PR; NEVER merge immediately, NEVER use --admin, NEVER push to main"
     [ -n "$PROMPT" ] || PROMPT="You are the Tier-4 upgrade shepherd in AUTO mode. Follow .agents/runbooks/upgrade-shepherd.md. Survey open manual-tier Renovate PRs (gh pr list); pick the NEXT one by the runbook merge-order. CONSULT .renovate/holds.json5 first (skip if held). Read the release notes and the component playbook. If supporting edits are needed, make them on a NEW branch shepherd/<pkg>-<version>, commit, push, and open a PR (gh pr create); then enable auto-merge with gh pr merge <N> --auto --squash --delete-branch. GitHub merges only when Flux Local AND Diff Scope are both green. Do NOT merge immediately, do NOT push to main, do NOT touch anything outside kubernetes/**. One PR only, then stop and summarize."
     ;;
   remediate) # mode 2: diagnose a regression, forward-fix or rollback+hold (Phase 4b.3)
-    ALLOWED=("${READONLY_TOOLS[@]}" "${WRITE_TOOLS[@]}" "${MERGE_TOOLS[@]}")
+    ALLOWED=("${READONLY_TOOLS[@]}" "${WRITE_TOOLS[@]}" "${MERGE_TOOLS[@]}" "${SILENCE_TOOLS[@]}")
     # COST CONTROL (2026-07): remediate runs on a LOWER turn budget and MUST bail early.
     # triage already proved the regression is upgrade-attributable, so the LLM's only job is
     # a git fix OR a fast BREAK-GLASS verdict — never a max-turns investigation. Set the

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/silence.sh
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/silence.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# silence.sh <component> [minutes] — set a BOUNDED Alertmanager silence for the
+# EXPECTED rollout-transient alerts of a cluster-infra component the shepherd just
+# auto-merged, so a normal reconcile/roll (OSD restart, mgr swap, disk-IO backfill,
+# pod restart) does not page the human. Added 2026-07-08 after a rook auto-merge
+# double-paged (CephOSDDownHigh + PrometheusRuleFailures) for its own normal rollout.
+#
+# CONTAINMENT (the shepherd LLM is prompt-injectable): the LLM passes ONLY a component
+# NAME from the hardcoded case below — never matchers, never a target. The matcher set
+# and the max duration are hardcoded HERE, so an injected agent cannot silence arbitrary
+# alerts (e.g. it can NOT silence KubeAPIDown, Watchdog, a real critical, or all alerts)
+# nor for an arbitrary time. Unknown component => no-op. Every silence is logged.
+set -uo pipefail
+AM="${ALERTMANAGER_URL:-http://kube-prometheus-stack-alertmanager.observability.svc.cluster.local:9093}"
+COMP="${1:-}"
+MINS="${2:-90}"
+log(){ printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" >&2; }
+[ -n "$COMP" ] || { log "silence.sh: usage: silence.sh <component> [minutes]"; exit 2; }
+
+# Clamp duration to [10,120] minutes — a rollout window, never open-ended.
+case "$MINS" in ''|*[!0-9]*) MINS=90;; esac
+[ "$MINS" -lt 10 ]  && MINS=10
+[ "$MINS" -gt 120 ] && MINS=120
+
+# component -> HARDCODED matcher array. alertname regexes cover ONLY expected
+# rollout-transient alerts; pod alerts are namespace-scoped so we never blanket-silence
+# unrelated apps. NEVER add Watchdog / KubeAPIDown / KubeletDown / gate-blind / a
+# standing critical here.
+case "$COMP" in
+  rook-ceph)
+    # Ceph daemon churn + the mgr-restart PrometheusRuleFailures artifact + backfill IO.
+    MATCHERS='[{"name":"alertname","value":"Ceph(OSD|Mon|Mgr|Daemon).*|PrometheusRuleFailures|NodeDiskIOSaturation","isRegex":true,"isEqual":true}]' ;;
+  cnpg|dragonfly-operator)
+    MATCHERS='[{"name":"alertname","value":"KubePod(NotReady|CrashLooping)","isRegex":true,"isEqual":true},{"name":"namespace","value":"database","isRegex":false,"isEqual":true}]' ;;
+  authentik)
+    MATCHERS='[{"name":"alertname","value":"KubePod(NotReady|CrashLooping)","isRegex":true,"isEqual":true},{"name":"namespace","value":"network","isRegex":false,"isEqual":true}]' ;;
+  cilium)
+    MATCHERS='[{"name":"alertname","value":"KubePod(NotReady|CrashLooping)","isRegex":true,"isEqual":true},{"name":"namespace","value":"kube-system","isRegex":false,"isEqual":true}]' ;;
+  *)
+    log "silence.sh: '$COMP' has no rollout-transient set — no silence (fine for stateless clean-tier: coredns/traefik/multus/device-plugins/flux self-heal fast)."; exit 0 ;;
+esac
+
+START="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+END="$(date -u -d "+${MINS} minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || { log "silence.sh: date math failed"; exit 1; }
+BODY="$(jq -cn --argjson m "$MATCHERS" --arg s "$START" --arg e "$END" --arg c "$COMP" \
+  '{matchers:$m, startsAt:$s, endsAt:$e, createdBy:"upgrade-shepherd",
+    comment:("auto: expected rollout-transient alerts during \($c) upgrade the shepherd just auto-merged; bounded \($e). Real regressions the health gate catches (Flux NotReady / HEALTH_ERR) are NOT in this set.")}' 2>/dev/null)"
+[ -n "$BODY" ] || { log "silence.sh: could not build request body"; exit 1; }
+
+RESP="$(curl -sf --max-time 15 -X POST "$AM/api/v2/silences" -H 'Content-Type: application/json' -d "$BODY" 2>/dev/null)" || {
+  log "silence.sh: POST to Alertmanager failed (egress/AM down?) — proceeding WITHOUT a silence (the gate still pages; worst case is a transient page)."; exit 0; }
+SID="$(printf '%s' "$RESP" | jq -r '.silenceID // .id // ""' 2>/dev/null)"
+log "silence.sh: set ${MINS}m silence for '$COMP' rollout-transients (id=${SID:-?}) until $END."


### PR DESCRIPTION
The durable fix for the second half of today's noise: cluster-infra auto-merges now restart OSDs/mgr/pods and fire **transient** alerts for their own normal rollout. Today's rook auto-merge double-paged you (`CephOSDDownHigh`, then `PrometheusRuleFailures`) — neither was a real fault.

## What

After the shepherd enables auto-merge on a **revertible cluster-infra** component (rook-ceph, cnpg, dragonfly, cilium, authentik), it calls `/opt/shepherd/silence.sh <component>`, which sets a **bounded (≤120 min)** Alertmanager silence for exactly that component's expected rollout-transient alerts:
- **rook-ceph** → `Ceph(OSD|Mon|Mgr|Daemon).*`, `PrometheusRuleFailures`, `NodeDiskIOSaturation`
- **cnpg/dragonfly/authentik/cilium** → `KubePod(NotReady|CrashLooping)`, namespace-scoped so unrelated apps are never touched

Real regressions the health gate catches (`Flux NotReady`, Ceph `HEALTH_ERR`) are **deliberately not** in the silenced set — so a genuinely bad upgrade still pages.

## Containment (the shepherd LLM is prompt-injectable)

`silence.sh` hardcodes the matcher sets and the max duration; the LLM passes **only a component name** from a fixed `case`. An injected agent cannot silence arbitrary alerts (never `Watchdog`/`KubeAPIDown`/standing criticals) nor for an arbitrary time. The CNP gains Alertmanager egress (9093 + exact DNS name); the tool is allowlisted in `auto`/`remediate` only.

## Validation
- E2E against the live Alertmanager: `silence.sh rook-ceph` created a real silence (verified, then expired); unknown component (`coredns`) correctly no-ops.
- Per-component matcher construction checked; ramp consistency green; render + YAML parse clean.
- Post-merge: an in-pod probe to confirm the shepherd pod can reach AM through the new CNP rule.

Paired with #2002 (dropping the fragile `CephPoolGrowthWarning` rule), this closes both of today's noise pages: #2002 stops the chronic 2-day rule-failure tail, and this suppresses the short rollout transients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
