### PR TITLE
fix(appdaemon): 1.5.3 — battery unavailable reads unknown, not critical

### DIFF
--- a/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
+++ b/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/thaynes43/appdaemon
-              tag: 1.5.2
+              tag: 1.5.3
             env:
               TZ: America/New_York
             envFrom:


### PR DESCRIPTION
Deploys hass-sandbox v1.5.3 (thaynes43/hass-sandbox#93): battery sensors reading unavailable/unknown/missing now report 'unknown' (no page) instead of critical. Stops false battery pages when a battery group's integration hiccups (this morning's protect_batteries near-miss). UPS unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuMSAu2NVfs5owDjiPiWoR