### PR TITLE
fix(appdaemon): 1.5.4 — repair hold covers 'success' (close promote race)

### DIFF
--- a/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
+++ b/kubernetes/main/apps/home-automation/appdaemon/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/thaynes43/appdaemon
-              tag: 1.5.3
+              tag: 1.5.4
             env:
               TZ: America/New_York
             envFrom:


### PR DESCRIPTION
Deploys hass-sandbox v1.5.4 (thaynes43/hass-sandbox#94): the repair hold now covers repair_state 'success', closing a 23ms race where a successful auto-repair still false-paged before the recovered status propagated (observed live 2026-07-09 on a UniFi Protect reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuMSAu2NVfs5owDjiPiWoR