### PR TITLE
feat(shepherd): add cert-manager to the ramp (PATCH only)

### DIFF
--- a/.github/workflows/pr-disposition.yml
+++ b/.github/workflows/pr-disposition.yml
@@ -61,6 +61,7 @@ jobs:
               'kubernetes/main/apps/database/dragonfly/',
               'kubernetes/main/apps/kube-system/cilium/',
               'kubernetes/main/apps/network/authentik/',
+              'kubernetes/main/apps/cert-manager/cert-manager/',
             ];
             const DISPOS = ['disposition:auto-merge', 'disposition:shepherd', 'disposition:stranded'];
             const isRenovate = (l) => /renovate/i.test(l || '');

--- a/docs/renovate/README.md
+++ b/docs/renovate/README.md
@@ -425,6 +425,7 @@ guard, and the health gate + guardrail alerts.
 | `dragonfly-operator` | **revertible cluster-infra** | 2026-07-08 | operator patch/minor auto-merge (in-memory flush on restart re-enqueues). |
 | `cilium` | **revertible cluster-infra** | 2026-07-08 | PATCH auto-merge; MINOR/MAJOR = one-way eBPF map layout → authored for confirm. |
 | `authentik` | **revertible cluster-infra** | 2026-07-08 | PATCH within same `YYYY.M` auto-merge; `YYYY.M` major = forward-only migration (one-way) → authored for confirm. |
+| `cert-manager` | **revertible cluster-infra** | 2026-07-09 | PATCH only auto-merge. MINOR/MAJOR authored for human review — the Helm schema is strict (`additionalProperties:false`) and minors REMOVE values keys (v1.21.0 dropped `prometheus.servicemonitor.*`), so they need release-note + values vetting. |
 
 **Operating principle (2026-07-08): the split is REVERTIBLE vs ONE-WAY, not
 cluster-breaker vs not.** "Cluster-breaker stays manual" was the wrong frame — a
@@ -531,6 +532,21 @@ EMQX holds (operator + broker, [emqx/emqx#17600](https://github.com/emqx/emqx/is
   runbook for the failing component.
 
 ## Changelog
+
+- **2026-07-09** — **cert-manager added to the ramp (PATCH only).** Sixth revertible
+  cluster-infra component. cert-manager minors are deliberately NOT auto-merged: the
+  chart's Helm schema is `additionalProperties:false` and minors remove values keys
+  (v1.21.0 dropped `prometheus.servicemonitor.*`), which hard-fails an upgrade if a
+  stale key lingers — so minors get release-note + values vetting and a human-review PR.
+  Also handled the stranded #2007 by hand (v1.20.3→v1.21.0 minor): vetted the three v1.21
+  breaking changes (none applied — we're already on v1.20.3 for the RBAC one, don't use
+  the token-RBAC pattern, and set none of the removed metrics values), merged, rolled
+  clean (all 5 pods Running, both ClusterIssuers Ready). Also fixed alert-responder
+  noise (PR #2010): it now only pages when its verdict is action-needed AND the alert is
+  still firing, and denylists the appdaemon-owned `Protect.*` class (was double-paging a
+  self-healed UniFi Protect freeze + a documented ceph-mgr OOM cycle). GHA majors now
+  auto-merge too (revertible + fail-safe: a breaking major reddens its own required check
+  and can't merge).
 
 - **2026-07-08** — **Cluster-breaker ramp: revertible-vs-one-way, + cadence.** Reframed
   the floor from "cluster-breaker vs not" to "git-revertible vs one-way" (a supervised

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
@@ -83,7 +83,7 @@ spec:
               # tracks the ramp) + /kyverno-verify after each. Manual/targeted summons
               # must clear this var (and UPGRADE_AGENT_PREFILTER_GLOBS if set) to
               # bypass the pre-filter.
-              UPGRADE_AGENT_RAMP: coredns traefik multus device-plugins flux immich-major rook-ceph cnpg dragonfly-operator cilium authentik
+              UPGRADE_AGENT_RAMP: coredns traefik multus device-plugins flux immich-major rook-ceph cnpg dragonfly-operator cilium authentik cert-manager
               # The LLM's merge scope + per-class rules live here — every ramp
               # component above must be named in this prompt (checked at run start).
               UPGRADE_AGENT_PROMPT: >-
@@ -99,8 +99,8 @@ spec:
                 (3) REVERTIBLE CLUSTER-INFRA — rook (storage/rook-ceph, incl.
                 ceph-csi-drivers), cnpg (database/cloudnative-pg), dragonfly
                 (database/dragonfly), cilium (kube-system/cilium), authentik
-                (network/authentik). For these, decide REVERTIBLE vs ONE-WAY from the
-                component playbook, then act:
+                (network/authentik), cert-manager (cert-manager/cert-manager). For
+                these, decide REVERTIBLE vs ONE-WAY from the component playbook, then act:
                 REVERTIBLE (auto-merge, backup/health-gated) — a bump whose failure a git
                 revert or HR strategy:rollback recovers with the data plane untouched:
                 rook chart/operator/csi PATCH (a rook PATCH does not move the Ceph daemon
@@ -111,7 +111,12 @@ spec:
                 it does, that bump is ONE-WAY → author for confirm, do not auto-merge);
                 cnpg OPERATOR chart bump with the PG imageName
                 UNCHANGED (no PG major); dragonfly operator patch/minor; cilium PATCH;
-                authentik PATCH within the same YYYY.M. Confirm the backup gate
+                authentik PATCH within the same YYYY.M; cert-manager PATCH only (a
+                cert-manager MINOR/MAJOR is NOT auto-merge — its Helm schema is strict
+                additionalProperties:false and minors REMOVE values keys, e.g. v1.21.0
+                dropped prometheus.servicemonitor.*, so a minor needs release-note +
+                values vetting → author it for human review, do not auto-merge).
+                Confirm the backup gate
                 (append-system-prompt rule) AND, for rook, Ceph HEALTH_OK, then enable
                 auto-merge. rook moves as a UNIT — operator (app/) then csi-drivers/ then
                 cluster/ per the playbook order; if separate Renovate PRs, merge them in

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/run-shepherd.sh
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/run-shepherd.sh
@@ -99,6 +99,7 @@ ramp_globs_for() {
     dragonfly-operator) printf '%s' "kubernetes/main/apps/database/dragonfly/" ;;
     cilium)         printf '%s' "kubernetes/main/apps/kube-system/cilium/" ;;
     authentik)      printf '%s' "kubernetes/main/apps/network/authentik/" ;;
+    cert-manager)   printf '%s' "kubernetes/main/apps/cert-manager/cert-manager/" ;;
     *)              printf '' ;;
   esac
 }

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/silence.sh
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/silence.sh
@@ -36,6 +36,8 @@ case "$COMP" in
     MATCHERS='[{"name":"alertname","value":"KubePod(NotReady|CrashLooping)","isRegex":true,"isEqual":true},{"name":"namespace","value":"network","isRegex":false,"isEqual":true}]' ;;
   cilium)
     MATCHERS='[{"name":"alertname","value":"KubePod(NotReady|CrashLooping)","isRegex":true,"isEqual":true},{"name":"namespace","value":"kube-system","isRegex":false,"isEqual":true}]' ;;
+  cert-manager)
+    MATCHERS='[{"name":"alertname","value":"KubePod(NotReady|CrashLooping)","isRegex":true,"isEqual":true},{"name":"namespace","value":"cert-manager","isRegex":false,"isEqual":true}]' ;;
   *)
     log "silence.sh: '$COMP' has no rollout-transient set — no silence (fine for stateless clean-tier: coredns/traefik/multus/device-plugins/flux self-heal fast)."; exit 0 ;;
 esac


### PR DESCRIPTION
Adds cert-manager as the sixth revertible cluster-infra ramp component, so future cert-manager **patches** auto-merge hands-off (behind the health gate + upgrade-window silence + auto-revert).

**Patches only, deliberately.** cert-manager MINOR/MAJOR bumps are *not* auto-merged — the chart's Helm schema is `additionalProperties:false` and minors remove values keys (v1.21.0 dropped `prometheus.servicemonitor.*`), so a stale key hard-fails the upgrade. Minors get release-note + values vetting and a human-review PR instead.

Ramp map (`ramp_globs_for`), prompt, `UPGRADE_AGENT_RAMP`, the disposition labeler, `silence.sh` (cert-manager ns), and docs are all updated in lockstep — consistency check green (12 components).

The stranded **#2007** (v1.20.3→v1.21.0, a minor) was handled by hand: I vetted the three v1.21 breaking changes (none apply — we're already on v1.20.3 for the RBAC change, don't use the token-RBAC pattern, and set none of the removed metrics values), merged it, and it rolled clean — all 5 cert-manager pods Running, both ClusterIssuers still Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)