### PR TITLE
feat(observability): PLAN-018 exportarr metrics — bazarr sidecar + curated *arr/downloads dashboards

### DIFF
--- a/kubernetes/main/apps/media/bazarr/app/externalsecret.yaml
+++ b/kubernetes/main/apps/media/bazarr/app/externalsecret.yaml
@@ -11,6 +11,11 @@ spec:
   target:
     name: bazarr-secret
   data:
+    # Bazarr's own API key — consumed by the exportarr sidecar (PLAN-018).
+    - secretKey: BAZARR_API_KEY
+      remoteRef:
+        key: media-stack
+        property: BAZARR_API_KEY
     - secretKey: RADARR_API_KEY
       remoteRef:
         key: media-stack

--- a/kubernetes/main/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/main/apps/media/bazarr/app/helmrelease.yaml
@@ -70,6 +70,45 @@ spec:
               capabilities:
                 drop: ["ALL"]
               readOnlyRootFilesystem: true
+          # exportarr v2.3.0 supports bazarr (added upstream v1.6.0). Mirrors the
+          # radarr/sonarr/lidarr/sabnzbd sidecar pattern; bazarr metrics are
+          # subtitle-pipeline infrastructure (no user attribution).
+          exportarr:
+            image:
+              repository: ghcr.io/onedr0p/exportarr
+              tag: v2.3.0
+            args: ["bazarr"]
+            env:
+              PORT: &metricsPort 9712
+              URL: http://localhost:6767
+              APIKEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: bazarr-secret
+                    key: BAZARR_API_KEY
+            probes:
+              liveness: &exportarrProbes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *metricsPort
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *exportarrProbes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -85,6 +124,17 @@ spec:
         ports:
           http:
             port: *port
+          metrics:
+            port: *metricsPort
+    serviceMonitor:
+      app:
+        serviceName: bazarr
+        endpoints:
+          - port: metrics
+            scheme: http
+            path: /metrics
+            interval: 4m
+            scrapeTimeout: 90s
     ingress:
       app:
         annotations:

--- a/kubernetes/main/apps/observability/grafana/app/dashboards/arr-library-overview.json
+++ b/kubernetes/main/apps/observability/grafana/app/dashboards/arr-library-overview.json
@@ -1,0 +1,315 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": ["media", "arr", "exportarr", "plan-018"],
+  "templating": { "list": [] },
+  "time": { "from": "now-7d", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Media *arr — Library & Acquisition",
+  "uid": "arr-library-overview",
+  "version": 1,
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Library Size",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Titles in Library",
+      "description": "Total catalogued items per *arr: Radarr movies, Sonarr episodes, Lidarr albums. Infrastructural counts — no user attribution (both access levels).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "radarr_movie_total", "legendFormat": "Movies", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sonarr_episode_total", "legendFormat": "Episodes", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "lidarr_albums_total", "legendFormat": "Albums", "refId": "C" }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Monitored",
+      "description": "Items the *arr is actively monitoring for acquisition/upgrade. Radarr movies, Sonarr series, Lidarr artists.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "radarr_movie_monitored_total", "legendFormat": "Movies monitored", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sonarr_series_monitored_total", "legendFormat": "Series monitored", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "lidarr_artists_monitored_total", "legendFormat": "Artists monitored", "refId": "C" }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Have / Downloaded (trend)",
+      "description": "Files the *arr already holds, over time — the library-growth curve. Radarr movies downloaded, Sonarr episodes downloaded, Lidarr songs downloaded.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 1 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 8, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "radarr_movie_downloaded_total", "legendFormat": "Movies have", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sonarr_episode_downloaded_total", "legendFormat": "Episodes have", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "lidarr_songs_downloaded_total", "legendFormat": "Songs have", "refId": "C" }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "row",
+      "title": "Backlog — Missing & Upgrades",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "panels": []
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Missing (monitored, not yet grabbed)",
+      "description": "Monitored items with no file — the acquisition backlog. Radarr movies missing, Sonarr episodes missing, Lidarr albums missing.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 8 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 8, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "yellow", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "radarr_movie_missing_total", "legendFormat": "Movies missing", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sonarr_episode_missing_total", "legendFormat": "Episodes missing", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "lidarr_albums_missing_total", "legendFormat": "Albums missing", "refId": "C" }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Cutoff Unmet (quality upgrades pending)",
+      "description": "Items that have a file below the quality cutoff — the upgrade backlog. Radarr + Sonarr.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 8 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 8, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "radarr_movie_cutoff_unmet_total", "legendFormat": "Movies upgrade-pending", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sonarr_episode_cutoff_unmet_total", "legendFormat": "Episodes upgrade-pending", "refId": "B" }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Acquisition Pipeline",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Queue Depth by App",
+      "description": "Items currently in each *arr's activity queue (downloading / importing). A rising floor = imports are stalling.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 16 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (radarr_queue_total)", "legendFormat": "radarr", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (sonarr_queue_total)", "legendFormat": "sonarr", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (lidarr_queue_total)", "legendFormat": "lidarr", "refId": "C" }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Grabs + Imports Rate (events/hr)",
+      "description": "Per-hour rate of history events (grabs, imports, upgrades) for each *arr — how fast the pipeline is moving. Derived from the monotonic history counter.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 16 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 8, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (rate(radarr_history_total[1h])) * 3600", "legendFormat": "radarr", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (rate(sonarr_history_total[1h])) * 3600", "legendFormat": "sonarr", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (rate(lidarr_history_total[1h])) * 3600", "legendFormat": "lidarr", "refId": "C" }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "Health & Storage",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "panels": []
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "System Health Issues (per app)",
+      "description": "Open health warnings/errors from each *arr's System > Status page. Green = clean.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 24 },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (radarr_system_health_issues)", "legendFormat": "radarr", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (sonarr_system_health_issues)", "legendFormat": "sonarr", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (lidarr_system_health_issues)", "legendFormat": "lidarr", "refId": "C" }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Root Folder Free Space",
+      "description": "Free bytes on each *arr root folder (labelled by mount path). The historical companion to the app's Storage tab; see the Media Storage — Utilization board for the % target line.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 16, "x": 8, "y": 24 },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "bytes",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 6, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "radarr_rootfolder_freespace_bytes", "legendFormat": "radarr {{path}}", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sonarr_rootfolder_freespace_bytes", "legendFormat": "sonarr {{path}}", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "lidarr_rootfolder_freespace_bytes", "legendFormat": "lidarr {{path}}", "refId": "C" }
+      ]
+    }
+  ]
+}

--- a/kubernetes/main/apps/observability/grafana/app/dashboards/downloads-clients-indexers.json
+++ b/kubernetes/main/apps/observability/grafana/app/dashboards/downloads-clients-indexers.json
@@ -1,0 +1,369 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["downloads", "arr", "exportarr", "plan-018"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Downloads — Clients & Indexers",
+  "uid": "downloads-clients-indexers",
+  "version": 1,
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Download Client Throughput (SABnzbd)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "SAB Download Speed (now)",
+      "description": "Live usenet download throughput per SABnzbd instance — the automation lane (sabnzbd) and the Seerr request fast lane (sabnzbd-fast).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "Bps",
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sabnzbd_speed_bps", "legendFormat": "{{job}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Downloaded (24h)",
+      "description": "Bytes fetched by each SABnzbd instance over the last 24 hours (increase of the monotonic downloaded-bytes counter).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "bytes",
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (job) (increase(sabnzbd_downloaded_bytes[24h]))", "legendFormat": "{{job}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "SAB Download Speed",
+      "description": "Usenet download throughput over time, per instance. Bytes/sec.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 1 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "Bps",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 12, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sabnzbd_speed_bps", "legendFormat": "{{job}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "row",
+      "title": "Queue Backlog (SABnzbd)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "panels": []
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Queue Remaining (bytes)",
+      "description": "Bytes still queued to download per instance — the depth of the usenet backlog.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 8 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "bytes",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sabnzbd_remaining_bytes", "legendFormat": "{{job}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Queue Length (items)",
+      "description": "Number of jobs queued per instance.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 8 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineInterpolation": "stepAfter", "fillOpacity": 10, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sabnzbd_queue_length", "legendFormat": "{{job}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Indexers (Prowlarr)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "Indexers Enabled / Unavailable",
+      "description": "Prowlarr indexer fleet health: how many indexers are enabled vs currently flagged unavailable.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 16 },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Unavailable" },
+            "properties": [
+              { "id": "thresholds", "value": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum(prowlarr_indexer_enabled_total)", "legendFormat": "Enabled", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum(prowlarr_indexer_unavailable)", "legendFormat": "Unavailable", "refId": "B" }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Indexer Avg Response Time",
+      "description": "Average query response latency per indexer (ms). Rising latency = an indexer degrading before it fails outright.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 9, "x": 6, "y": 16 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ms",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 6, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "prowlarr_indexer_average_response_time_ms", "legendFormat": "{{indexer}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Indexer Query Rate (per hr)",
+      "description": "Searches sent to each indexer per hour (rate of the query counter).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 9, "x": 15, "y": 16 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 6, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (indexer) (rate(prowlarr_indexer_queries_total[30m])) * 3600", "legendFormat": "{{indexer}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "row",
+      "title": "Indexer Reliability",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "panels": []
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Grab Rate by Indexer (per hr)",
+      "description": "Releases grabbed from each indexer per hour — which indexers are actually feeding the pipeline.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 23 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 8, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (indexer) (rate(prowlarr_indexer_grabs_total[30m])) * 3600", "legendFormat": "{{indexer}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Failed Query Rate by Indexer (per hr)",
+      "description": "Failed searches per indexer per hour — the early-warning signal for an indexer going bad (rate limits, auth, outages).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 23 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 8, "showPoints": "never", "axisSoftMin": 0 },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "sum by (indexer) (rate(prowlarr_indexer_failed_queries_total[30m])) * 3600", "legendFormat": "{{indexer}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "row",
+      "title": "Exporter Reachability",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
+      "panels": []
+    },
+    {
+      "id": 16,
+      "type": "stat",
+      "title": "Download / Indexer Exporters Up",
+      "description": "Prometheus target up for each download-side exportarr sidecar. DOWN = the exporter can't reach its app or the pod is gone.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 31 },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "index": 1 }, "1": { "text": "UP", "index": 0 } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "editorMode": "code", "expr": "up{job=~\"sabnzbd|sabnzbd-fast|prowlarr\"}", "legendFormat": "{{job}}", "refId": "A" }
+      ]
+    }
+  ]
+}

--- a/kubernetes/main/apps/observability/grafana/app/kustomization.yaml
+++ b/kubernetes/main/apps/observability/grafana/app/kustomization.yaml
@@ -32,3 +32,23 @@ configMapGenerator:
         grafana_dashboard: "true"
       annotations:
         grafana_folder: Media
+  # PLAN-018 metrics sub-tab deep-dive boards (curated *arr/downloader panels;
+  # the haynesnetwork app surfaces a trimmed subset and deep-links per group).
+  - name: grafana-dashboard-arr-library-overview
+    files:
+      - dashboards/arr-library-overview.json
+    options:
+      disableNameSuffixHash: true
+      labels:
+        grafana_dashboard: "true"
+      annotations:
+        grafana_folder: Media
+  - name: grafana-dashboard-downloads-clients-indexers
+    files:
+      - dashboards/downloads-clients-indexers.json
+    options:
+      disableNameSuffixHash: true
+      labels:
+        grafana_dashboard: "true"
+      annotations:
+        grafana_folder: Downloads


### PR DESCRIPTION
## What / why

Overnight prep for **PLAN-018** (the haynesnetwork *Metrics* section's **\*arr / downloader sub-tab**). The app surfaces a curated subset of panels and deep-links into Grafana per panel group; Grafana stays the deep-dive. **Additive & read-only.** Flux applies `main`, so **please review — do not expect this to self-apply.**

## Coverage audit (live-verified against cluster Prometheus)

All six existing exportarr targets are **UP**: `radarr, sonarr, lidarr, prowlarr, sabnzbd, sabnzbd-fast`.

| App | Kind | Metrics today | This PR | No exporter (why) |
|-----|------|---------------|---------|-------------------|
| radarr | *arr | exportarr ✅ | — | |
| sonarr | *arr | exportarr ✅ | — | |
| lidarr | *arr | exportarr ✅ | — | |
| prowlarr | indexer | exportarr ✅ | — | |
| sabnzbd (+ fast) | usenet | exportarr ✅ | — | |
| **bazarr** | subtitles | ❌ none | **exportarr sidecar added** | (exportarr *does* support bazarr since v1.6.0 — this was simply un-instrumented) |
| qbittorrent | torrent | ❌ none | routed to PLAN-018 TODO | exportarr can't do qbt; needs a community qbittorrent-exporter (VPN pod + WebUI auth → owner decision) |
| slskd | soulseek | ❌ none | routed to PLAN-018 TODO | has a **first-party** `/metrics` (`SLSKD_METRICS`), but enabling it forces a pod restart = 40–70 min share rescan |
| soularr | bridge script | ❌ none | — | cron/loop script, no HTTP metrics surface |
| ytdl-sub | batch dl | ❌ none | — | one-shot job, no metrics surface |

> Note: the task brief assumed "exportarr does not support bazarr" — that's outdated. exportarr **v2.3.0** (what the cluster runs) supports bazarr, so the clean move was to instrument it with the same sidecar pattern rather than hunt for a third-party bazarr exporter.

## Changes

**1. `media/bazarr` — exportarr sidecar (mirrors lidarr/sabnzbd)**
- `exportarr:v2.3.0` container, `args: ["bazarr"]`, metrics port `9712`, `/healthz` probes, tight resources, hardened securityContext.
- `service.app.ports.metrics` + a `serviceMonitor` (4m interval, matching the other *arrs).
- `externalsecret`: adds `BAZARR_API_KEY` from the `media-stack` 1Password item (the same property Homepage already consumes) into `bazarr-secret`.
- ⚠️ Deploy note: this restarts the bazarr pod (cheap) and depends on `media-stack/BAZARR_API_KEY` existing in 1Password (it does — Homepage's `HOMEPAGE_VAR_BAZARR_API_KEY` reads it).

**2. `observability/grafana` — two curated dashboard-as-code boards** (OPS-007 pattern: token-free JSON, `configMapGenerator` + `grafana_dashboard` label + `grafana_folder` annotation, sidecar auto-import). Every query validated against live Prometheus.
- **`arr-library-overview`** (uid `arr-library-overview`, folder *Media*): library size, monitored, have/downloaded trend, missing & cutoff-unmet backlog, queue depth by app, grabs+imports rate, system health, root-folder free space.
- **`downloads-clients-indexers`** (uid `downloads-clients-indexers`, folder *Downloads*): SABnzbd speed/24h/queue-remaining/queue-length (both lanes) + Prowlarr indexers enabled/unavailable, avg response time, query/grab/failed-query rates, exporter reachability.

## Reconciliation with the existing board
An existing `media-pipeline-resilience` board already spans *arr + download clients, but it's **health/reachability-first**. These two boards are **metrics-first** (totals, rates, trends) and are organized to mirror the app sub-tab's two panel groups so each group deep-links to a focused board. See PLAN-018 for the ID-reconciliation note.

## Validation
- `kubectl kustomize kubernetes/main/apps/observability/grafana/app` builds; all 4 dashboard ConfigMaps render (3 Media, 1 Downloads).
- Dashboard JSON: valid, **token-free** (no `$__range`/`$__rate_interval`/`${…}`).
- bazarr HelmRelease YAML parses with anchors resolved (`metrics` service port + `serviceMonitor` present).

## Rollback
Additive — revert the commit and reconcile; the Grafana sidecar removes the boards, and the bazarr sidecar/serviceMonitor/secret-key drop out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU9cU9mSv19WMB64bMGP71