### PR TITLE
feat(kometa): home-release-only acquisition — drop In Theaters chart + theatrical-window guard [DO NOT MERGE — audit review]

### DIFF
--- a/kubernetes/main/apps/media/kometa/app/config/movies-charts.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/movies-charts.yml
@@ -6,8 +6,8 @@
 # MODERNIZATION:
 #   * tmdb_discover charts filter SERVER-SIDE (with_original_language: en,
 #     vote_count.gte) so foreign/low-vote titles never reach Kometa.
-#   * builders that can't filter server-side (imdb_chart, tmdb_now_playing) get
-#     CLIENT-SIDE filters (original_language / tmdb_vote_count).
+#   * builders that can't filter server-side (imdb_chart) get CLIENT-SIDE
+#     filters (original_language / tmdb_vote_count).
 #   * curated quality lists (IMDb Top 250) stay unfiltered — acclaimed foreign
 #     films belong there.
 #
@@ -15,11 +15,20 @@
 # search true globally). radarr_tag applies the umbrella "Kometa-Added" + a
 # per-chart tag. The language/vote filters above are what make chart acquisition
 # SANE (the un-filtered 2023 charts are exactly what flooded Radarr with foreign
-# junk). ⚠ CONTINUOUS ACQUISITION: "Popular Now", "In Theaters" and "IMDB
-# Popular" refresh with new releases, so they keep pulling new English-language
-# titles on every daily run — not a one-time wave. "Top Rated" / "Top Grossing" /
-# "IMDB Top 250" are effectively static (one-time fill). To make any chart
-# display-only again, add `radarr_add_missing: false` to its block.
+# junk). ⚠ CONTINUOUS ACQUISITION: "Popular Now" and "IMDB Popular" refresh with
+# new releases, so they keep pulling new English-language titles on every daily
+# run — not a one-time wave. "Top Rated" / "Top Grossing" / "IMDB Top 250" are
+# effectively static (one-time fill). To make any chart display-only again, add
+# `radarr_add_missing: false` to its block.
+#
+# THEATRICAL-WINDOW GUARD (owner ruling 2026-07-10): this server does NOT acquire
+# currently-in-theaters titles. The "In Theaters" chart (tmdb_now_playing) was
+# REMOVED entirely (below), and the Chart template now carries
+# `radarr_availability: released` so that even if a remaining chart names a title
+# still in its theatrical window, Radarr will NOT search until that title's home
+# (physical/digital) release per TMDB dates. Global radarr.availability in
+# config.yml is already `released`; this per-template key makes the guard explicit
+# and survives any change to the global.
 #
 # TRAKT GAP: Trakt charts are preserved but COMMENTED (no trakt block in
 # config.yml). Add trakt to the externalsecret to re-enable them.
@@ -27,6 +36,10 @@ templates:
   Chart:
     collection_order: custom
     sync_mode: sync
+    # theatrical-window guard — never search a title until its home (physical/
+    # digital) release per TMDB (owner ruling 2026-07-10). Redundant-but-explicit
+    # with the global radarr.availability: released in config.yml.
+    radarr_availability: released
 
 collections:
   Popular Now:
@@ -65,17 +78,12 @@ collections:
       vote_count.gte: 300
       limit: 100
 
-  In Theaters:
-    template: {name: Chart}
-    sort_title: "!023 In Theaters"
-    summary: "English-language movies now playing in theaters (in this library)"
-    url_poster: https://theposterdb.com/api/assets/213600
-    radarr_tag: "Kometa-Added,InTheaters"
-    tmdb_now_playing: 100
-    tmdb_region: US
-    filters:
-      - original_language: en
-      - tmdb_vote_count.gte: 25
+  # In Theaters (tmdb_now_playing US top-100) REMOVED 2026-07-10 by owner ruling:
+  # this server does NOT acquire currently-in-theaters titles. It was the source
+  # of the 6:30 re-import of "Chum" (tmdb 1694978) the morning after the sweep
+  # deleted it (tagged Kometa-Added,intheaters in Radarr). Do NOT re-add —
+  # theatrical-window acquisition is out of scope for this server. The orphaned
+  # "In Theaters" Plex collection is deleted out-of-band (see PR notes).
 
   IMDB Popular:
     template: {name: Chart}

--- a/kubernetes/main/apps/media/kometa/app/config/movies-franchises.yml
+++ b/kubernetes/main/apps/media/kometa/app/config/movies-franchises.yml
@@ -32,6 +32,11 @@ templates:
     imdb_list: <<imdb_list>>
     collection_order: release
     radarr_tag: "Kometa-Added,MovieCollection"
+    # theatrical-window guard (owner ruling 2026-07-10): TMDb Collections can list
+    # announced / in-production / still-theatrical entries — never search one until
+    # its home (physical/digital) release per TMDB. Explicit mirror of the global
+    # radarr.availability: released.
+    radarr_availability: released
 
 collections:
   The Addams Family:

--- a/kubernetes/main/apps/media/kometa/app/externalsecret.yaml
+++ b/kubernetes/main/apps/media/kometa/app/externalsecret.yaml
@@ -44,25 +44,38 @@ spec:
                 # also be tagged.) NOTE: oscars/golden/seasonal are the largest
                 # one-time-wave contributors (decades of award films / every
                 # seasonal title on the Default lists not yet in the library).
+                # radarr_availability: released is the THEATRICAL-WINDOW GUARD
+                # (owner ruling 2026-07-10) — these acquisition-ON Defaults may
+                # name a title still in its theatrical window (oscars especially
+                # can list a current-season theatrical contender), so Radarr must
+                # not search until the title's home (physical/digital) release per
+                # TMDB. Redundant-but-explicit with the global radarr.availability:
+                # released below (which is already LIVE on the PVC — verified by a
+                # Radarr add showing minimumAvailability=released). Kept explicit so
+                # the guard survives any change to the global and is auditable here.
                 - default: universe
                   template_variables:
                     radarr_add_missing: true
                     radarr_search: true
+                    radarr_availability: released
                     radarr_tag: "Kometa-Added,UniverseCollection"
                 - default: seasonal
                   template_variables:
                     radarr_add_missing: true
                     radarr_search: true
+                    radarr_availability: released
                     radarr_tag: "Kometa-Added,SeasonalCollection"
                 - default: oscars
                   template_variables:
                     radarr_add_missing: true
                     radarr_search: true
+                    radarr_availability: released
                     radarr_tag: "Kometa-Added,OscarsCollection"
                 - default: golden
                   template_variables:
                     radarr_add_missing: true
                     radarr_search: true
+                    radarr_availability: released
                     radarr_tag: "Kometa-Added,GoldenGlobeCollection"
                 # franchise Default = COMPLEMENT to the hand-curated
                 # movies-franchises.yml, NOT a replacement. It auto-discovers a
@@ -206,6 +219,14 @@ spec:
             add_existing: false
             upgrade_existing: false
             monitor: true
+            # THEATRICAL-WINDOW GUARD (owner ruling 2026-07-10): 'released' =
+            # Radarr minimumAvailability=released, so a newly-added movie is not
+            # searched until its physical/digital (home) release per TMDB dates —
+            # even if a chart/list/Default names a title still in theaters. This is
+            # the global default inherited by every acquisition-ON movie builder;
+            # the charts/franchises files and the Defaults above also set it
+            # explicitly. VERIFIED LIVE: Radarr movie records added by Kometa show
+            # minimumAvailability=released.
             availability: released
             # MUST match a LIVE Radarr profile or Kometa fails the whole Radarr
             # connection (every add_missing/tag op then errors). FHD-UHD is the


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — owner reviews the audit table first

Implements the owner ruling (2026-07-10): **this server does not acquire currently-in-theaters titles.** Remove the *In Theaters* chart entirely, audit every acquisition-ON builder for theatrical / not-home-available leak, and add a structural availability guard. Radarr cleanup (Chum + 14 exclusions) was done out-of-band via API and is reported below, not in git.

### What happened this morning
The 6:30 collections run re-imported **Chum** (tmdb `1694978`) via the *In Theaters* chart (`tmdb_now_playing`, US top-100). Radarr grabbed a file in ~25 min. On inspection the grabbed file was a legitimate **`WEBDL-2160p [AMZN]`** — **not a CAM**. Chum's Radarr record showed `minimumAvailability=released`, `digitalRelease=2026-06-05` (5 weeks ago). So the availability guard *was* honored — Chum simply had already reached home/digital release and passed it legitimately. The real leak was the *In Theaters* chart existing at all. Removing it is the fix; the availability guard is defense-in-depth for the other charts.

---

## Audit table — every acquisition-ON builder (radarr_add_missing true, explicit or inherited)

| Builder (file) | Source | Can it list a not-yet-home title? | Verdict / change |
|---|---|---|---|
| **In Theaters** (movies-charts) | `tmdb_now_playing` US 100 | **YES — by definition** (now-playing = theatrical window) | **REMOVED entirely** |
| Popular Now (movies-charts) | `tmdb_discover` `popularity.desc`, en, votes≥300 | **YES** — popularity peaks during theatrical run | Kept; **`radarr_availability: released`** (Chart template) |
| Top Grossing (movies-charts) | `tmdb_discover` `revenue.desc`, en, votes≥300 | **YES** — top grossers are current blockbusters | Kept; **`radarr_availability: released`** |
| IMDB Popular (movies-charts) | `imdb_chart: popular_movies`, en, votes≥300 | **YES** — IMDb popularity tracks current releases | Kept; **`radarr_availability: released`** |
| Top Rated (movies-charts) | `tmdb_discover` `vote_average.desc`, votes≥2000 | Low — 2000-vote floor ⇒ effectively historical | Kept; guard applied (harmless) |
| IMDB Top 250 (movies-charts) | `imdb_chart: top_movies` | No — static all-time list | Kept; guard applied (harmless) |
| Franchises (movies-franchises) | `tmdb_collection` / `tmdb_movie` / `imdb_list` | **YES** — TMDb Collections include announced / in-production / still-theatrical entries | Kept; **`radarr_availability: released`** (Movies template) |
| `oscars` Default (config.yml) | Kometa oscars Default | **YES** — current-season nominees can still be in theaters | Kept; **`radarr_availability: released`** |
| `golden` Default (config.yml) | Kometa golden (Golden Globes) Default | **YES** — current-season contenders | Kept; **`radarr_availability: released`** |
| `universe` Default (config.yml) | Kometa universe Default | Mostly historical; a universe can list an upcoming entry | Kept; **`radarr_availability: released`** |
| `seasonal` Default (config.yml) | Kometa seasonal Default | Low — holiday catalogue is historical | Kept; **`radarr_availability: released`** |
| `franchise` Default (config.yml) | auto-discovered TMDb Collections | N/A — **acquisition already OFF** (`radarr_add_missing: false`) | No change (tag-only) |

**Acquisition-OFF movie builders (no change, listed for completeness):** `movies-lists.yml` (Studio + Special Genre — `radarr_add_missing: false`), `movies-people.yml` (Director/Actor — `radarr_add_missing: false`), `movies-collections.yml` (Christmas HNet `false`; Spatial/Atmos/DTS-X are `plex_all` filters over existing media — nothing to add). All tag-only ⇒ zero theatrical risk.

**TV (`shows-*.yml`) — acquisition ON (Sonarr):** `shows-collections.yml` and `shows-franchises.yml` add specific hand-picked series by `tmdb_show` / `tvdb_show` / `tvdb_list_details` IDs — not charts, so no "trending theatrical" leak. Airing/unaired series are normal for TV: Sonarr just monitors and grabs episodes as they air. **There is no theatrical-window / CAM analog for TV, and Sonarr has no `availability` knob** — so no change is warranted. The Sonarr FHD-UHD profile likewise excludes low qualities.

---

## Availability-guard diff summary

`released` = Radarr `minimumAvailability=released` = do not search until the title's physical/digital (home) release per TMDB dates.

- **Global** `radarr.availability: released` in `externalsecret.yaml` config.yml — **was already present and is LIVE-verified** (Kometa-added Radarr records show `minimumAvailability=released`). Comment strengthened only.
- **Added explicit `radarr_availability: released`** to every acquisition-ON builder, so the guard is auditable and survives any change to the global:
  - `Chart` template → `movies-charts.yml` (live from git via ConfigMap; effective next 6:30 run)
  - `Movies` template → `movies-franchises.yml` (live from git; effective next run)
  - `universe` / `seasonal` / `oscars` / `golden` Defaults → config.yml seed

### ⚙️ config.yml is git-editable — no 1Password change needed
`config.yml` is fully templated in `externalsecret.yaml`; **only secret *values*** (API keys / Plex token) come from 1Password. **No 1P edit is required for this change.** Nuance: an init container seeds config.yml to the PVC **only if `/config/config.yml` is absent**, so edits to the config.yml *seed* (the Defaults + global) do **not** hot-apply to the running config. This is fine here because the global `availability: released` is **already live** and the Defaults inherit it live; the explicit per-Default keys are for git auditability / future re-seed. The collection **files** (`movies-charts.yml`, `movies-franchises.yml`) are mounted live from git and apply on the next run.

---

## Radarr cleanup (out-of-band via API — NOT in git; scope-limited)

- **Chum (tmdb 1694978) removed with its file** (`DELETE /movie/9583?deleteFiles=true&addImportExclusion=true`) → library empty for it, `Chum (2026) …WEBDL-2160p…` file deleted. Restores last night's sweep decision.
- **Import exclusions added for all 14 swept titles** (Chum + the 13): `1503900, 1249385, 1241934, 1426822, 1353333, 1301122, 1426297, 1357933, 1352874, 1288246, 1328402, 1497970, 1022046`. Additive/reversible metadata; no deletions.
- All 14 verified home-released (digital-release dates in the past) — they were low-value B-movies grabbed as legit WEB-DLs, **not CAMs**.

### 🔬 Exclusion-blocks-direct-add test (report only)
After excluding Chum I re-POSTed it to `/api/v3/movie` (unmonitored, no search). **Radarr created it anyway (HTTP 201, id 9589)** — I deleted it immediately. **Finding: import-list exclusions do NOT block a direct API add; they only gate Radarr's own import-list syncs.** Radarr currently has **zero import lists configured**, and both Kometa and the app's sweep add via the direct `/movie` API — so **exclusions are not a viable barrier against a Kometa/sweep re-add**; they only prevent resurrection by a future Radarr import list. The effective guard against Kometa re-adding Chum is the *In Theaters* removal (source gone) plus the availability guard.

---

## Defense-in-depth: does the Radarr profile block CAM/TS? (read-only finding)
**Yes — structurally.** The recyclarr-managed **FHD-UHD** profile allows only `WEB/Bluray/Remux 1080p+2160p` and `HDTV-2160p`. Every theatrical-source quality — **CAM, TELESYNC, TELECINE, WORKPRINT, DVDSCR, REGIONAL, SDTV, DVD** — is present-but-**disallowed**, so Radarr can never grab a CAM/TS release (unallowed qualities are never downloaded). Second layer: **LQ, LQ (Release Title), BR-DISK, x265 (HD), AV1, 3D, Upscaled all score `-10000`** with `minFormatScore=0` (junk release groups rejected). The owner's CAM/low-quality fear is already structurally impossible under FHD-UHD.

---

## 🧾 Owner action items
1. **Delete the orphaned "In Theaters" Plex collection** (one manual step): Plex → *HOps Movies* → Collections → **In Theaters** → *Delete Collection*. Removes only the grouping, not the movies. (I did not add Kometa's `delete_collections` operation — `configured:false, managed:true` would delete *every* Kometa-labeled collection not in config, too broad for a one-off.)
2. Review this audit table, then merge.
3. Optional: no re-seed needed, but if you want the explicit per-Default `radarr_availability` live before the next natural re-seed, delete `/config/config.yml` on the kometa PVC to force a git re-seed (global `released` is already enforcing live regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU9cU9mSv19WMB64bMGP71
