### PR TITLE
feat(qbittorrent): MyAnonaMouse dynamic-seedbox sidecar + ExternalSecret (PLAN-031)

### DIFF
--- a/kubernetes/main/apps/downloads/qbittorrent/app/externalsecret.yaml
+++ b/kubernetes/main/apps/downloads/qbittorrent/app/externalsecret.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# MyAnonaMouse session cookies (PLAN-031). Two SEPARATE sessions — MAM rotates the
+# mam_id on use, so sharing one cookie across consumers invalidates both:
+#   * MAM_ID_PROWLARR — Session A, ASN-locked to the home Comcast ASN. Prowlarr's
+#     MyAnonaMouse indexer searches egress the home WAN, matching this lock.
+#   * MAM_ID_SEEDBOX  — Session B, "allow dynamic seedbox IP". Consumed ONLY by the
+#     mam-update sidecar (this pod) as the FIRST-RUN seed; the live rotated cookie
+#     then lives on the config PVC (/state), not here.
+# 1Password item `myanonamouse` in the HaynesKube vault.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: myanonamouse
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: myanonamouse-secret
+  data:
+    - secretKey: MAM_ID_PROWLARR
+      remoteRef:
+        key: myanonamouse
+        property: MAM_ID_PROWLARR
+    - secretKey: MAM_ID_SEEDBOX
+      remoteRef:
+        key: myanonamouse
+        property: MAM_ID_SEEDBOX

--- a/kubernetes/main/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/main/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -119,6 +119,51 @@ spec:
               capabilities:
                 drop: ["ALL"]
               readOnlyRootFilesystem: true
+          # MyAnonaMouse dynamic-seedbox IP keeper (PLAN-031). In THIS pod on
+          # purpose: it shares the macvlan netns, so its dynamicSeedbox.php calls
+          # egress the exact Mullvad exit IP qBittorrent announces from — the IP we
+          # register is provably the IP MAM sees. It confirms the Mullvad exit before
+          # every call (fail-closed), self-throttles to <=1 call/hr, and persists the
+          # rotating mam_id cookie to /state (a subpath of the config PVC) so it
+          # survives restarts. See scripts/mam-update.sh for the full contract.
+          # IMPORTANT: no readiness/startup probe — only the app container's Mullvad
+          # egress check may gate pod readiness (same rule as the exporter sidecar).
+          mam-update:
+            image:
+              repository: docker.io/curlimages/curl
+              tag: 8.21.0
+            command: ["/bin/sh", "/scripts/mam-update.sh"]
+            env:
+              TZ: America/New_York
+              HOME: /tmp
+              STATE_DIR: /state
+              MAM_SEEDBOX_URL: https://t.myanonamouse.net/json/dynamicSeedbox.php
+              MAM_CHECK_URL: https://am.i.mullvad.net/json
+              INTERVAL: "3600"
+              MIN_GAP: "3600"
+              MAM_ID_SEED:
+                valueFrom:
+                  secretKeyRef:
+                    name: myanonamouse-secret
+                    key: MAM_ID_SEEDBOX
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -168,6 +213,27 @@ spec:
     persistence:
       config:
         existingClaim: qbittorrent
+        advancedMounts:
+          qbittorrent:
+            app:
+              - path: /config
+            # mam-update persists its rotating mam_id cookie + IP/rate-limit state
+            # under a subpath of the same PVC (backed up by volsync with the rest of
+            # /config). Isolated from qBittorrent's own config tree.
+            mam-update:
+              - path: /state
+                subPath: mam-update
+      # mam-update sidecar script (configMapGenerator; hash-suffixed name wired in
+      # via kustomizeconfig.yaml so edits roll the pod).
+      mam-update-script:
+        type: configMap
+        name: qbittorrent-mam-update
+        advancedMounts:
+          qbittorrent:
+            mam-update:
+              - path: /scripts/mam-update.sh
+                subPath: mam-update.sh
+                readOnly: true
       data-tower:
         type: nfs
         server: haynestower.haynesnetwork

--- a/kubernetes/main/apps/downloads/qbittorrent/app/kustomization.yaml
+++ b/kubernetes/main/apps/downloads/qbittorrent/app/kustomization.yaml
@@ -6,5 +6,17 @@ components:
   - ../../../../../shared/components/gatus/gaurded
   - ../../../../../shared/components/volsync/aws
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./multus-vpn.yaml
+configMapGenerator:
+  - name: qbittorrent-mam-update
+    files:
+      - scripts/mam-update.sh
+generatorOptions:
+  # The script uses ${VAR:-default} shell expansions — keep Flux post-build
+  # substitution out of it (matches the ytdl-sub/peloton precedent).
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+configurations:
+  - ./kustomizeconfig.yaml

--- a/kubernetes/main/apps/downloads/qbittorrent/app/kustomizeconfig.yaml
+++ b/kubernetes/main/apps/downloads/qbittorrent/app/kustomizeconfig.yaml
@@ -1,0 +1,10 @@
+---
+# Wire the hash-suffixed configMapGenerator name into the HelmRelease's
+# persistence reference so the mam-update sidecar always mounts the current
+# ConfigMap (and a script change rolls the pod).
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/values/persistence/mam-update-script/name
+        kind: HelmRelease

--- a/kubernetes/main/apps/downloads/qbittorrent/app/scripts/mam-update.sh
+++ b/kubernetes/main/apps/downloads/qbittorrent/app/scripts/mam-update.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+# mam-update — MyAnonaMouse dynamic-seedbox IP keeper (PLAN-031)
+#
+# Runs as a SIDECAR in the qBittorrent pod. Because it shares the pod's macvlan
+# netns (static-vpn-qbittorrent, VLAN-30), every request it makes egresses the
+# SAME Mullvad exit IP that qBittorrent announces from. That is the whole point
+# of the sidecar placement (owner ruling Q-02): the IP we register at MAM is
+# guaranteed to be the IP MAM sees on our announces.
+#
+# COMPLIANCE INVARIANTS (mam-rules-scrape.md / research doc §3) — do not weaken:
+#   * The ONLY MyAnonaMouse endpoint contacted is dynamicSeedbox.php (documented
+#     API). No scraping, no other site automation.
+#   * At most ONE dynamicSeedbox.php call per hour (MIN_GAP). Exceeding it returns
+#     "Last Change Too Recent" and risks the account.
+#   * NEVER register an off-VPN IP. We confirm we are on the Mullvad exit
+#     (am.i.mullvad.net/json -> mullvad_exit_ip:true) BEFORE every call; if we
+#     cannot confirm it, we skip (fail-closed) — mirrors the pod readiness probe.
+#   * MAM rotates the mam_id cookie on use. We keep a curl cookie jar on a subpath
+#     of qBittorrent's config PVC (/state) so the rotated cookie survives pod
+#     restarts. The env seed (MAM_ID_SEED, from the ExternalSecret) is written into
+#     the jar ONCE, on first run only; thereafter the persisted (rotated) cookie
+#     is authoritative.
+#   * We only call when the exit IP actually changed (or was never registered) —
+#     a "No Change" reply otherwise.
+# ---------------------------------------------------------------------------
+set -u
+
+STATE_DIR="${STATE_DIR:-/state}"
+JAR="$STATE_DIR/mam.cookies"          # curl cookie jar (holds the live, rotated mam_id)
+IP_CACHE="$STATE_DIR/mam.ip"          # last successfully-registered exit IP
+LAST_CALL="$STATE_DIR/mam.last_call"  # epoch of the last dynamicSeedbox.php call (rate-limit guard)
+URL="${MAM_SEEDBOX_URL:-https://t.myanonamouse.net/json/dynamicSeedbox.php}"
+CHECK_URL="${MAM_CHECK_URL:-https://am.i.mullvad.net/json}"
+INTERVAL="${INTERVAL:-3600}"          # loop cadence
+MIN_GAP="${MIN_GAP:-3600}"            # hard floor between dynamicSeedbox.php calls
+
+mkdir -p "$STATE_DIR"
+
+log() { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) mam-update: $*"; }
+
+log "starting; state=$STATE_DIR endpoint=$URL check=$CHECK_URL interval=${INTERVAL}s min_gap=${MIN_GAP}s"
+if [ -s "$JAR" ]; then
+  log "cookie jar present — using persisted (rotated) mam_id"
+else
+  log "no cookie jar yet — will seed it from MAM_ID_SEED on first run"
+fi
+
+while true; do
+  now=$(date +%s)
+
+  # 1) Confirm we are on the Mullvad exit AND learn the current exit IP, in one call.
+  #    am.i.mullvad.net/json -> {"ip":"x.x.x.x", ..., "mullvad_exit_ip":true}
+  #    Same host the pod's readiness probe uses, so it is reachable over the tunnel.
+  check=$(curl -fsS --max-time 15 "$CHECK_URL" 2>/dev/null)
+  cur_ip=$(printf '%s' "$check" | sed -n 's/.*"ip"[[:space:]]*:[[:space:]]*"\([0-9A-Fa-f.:]*\)".*/\1/p')
+  on_mullvad=$(printf '%s' "$check" | grep -o '"mullvad_exit_ip"[[:space:]]*:[[:space:]]*true')
+  if [ -z "$cur_ip" ] || [ -z "$on_mullvad" ]; then
+    log "WARN could not confirm Mullvad exit (VPN down/leaking or check unreachable) — skipping (fail-closed)"
+    sleep "$INTERVAL"; continue
+  fi
+
+  last_ip=$(cat "$IP_CACHE" 2>/dev/null || true)
+  last_call=$(cat "$LAST_CALL" 2>/dev/null || echo 0)
+  since=$(( now - last_call ))
+
+  # 2) Nothing to do if the exit IP is unchanged since our last successful registration.
+  if [ -n "$last_ip" ] && [ "$cur_ip" = "$last_ip" ]; then
+    log "No exit-IP change ($cur_ip); no update needed"
+    sleep "$INTERVAL"; continue
+  fi
+
+  # 3) Rate-limit guard: never call more than once per MIN_GAP, even on a rapid re-change.
+  if [ "$last_call" -ne 0 ] && [ "$since" -lt "$MIN_GAP" ]; then
+    wait=$(( MIN_GAP - since ))
+    log "exit IP changed (${last_ip:-none} -> $cur_ip) but last call was ${since}s ago (<${MIN_GAP}s) — deferring ${wait}s"
+    sleep "$wait"; continue
+  fi
+
+  # 4) Seed the jar once (first run), then always drive it from the jar so the
+  #    server-rotated mam_id is captured and reused. Netscape cookie-jar format;
+  #    far-future expiry so curl persists it (not treated as a session cookie).
+  if [ ! -s "$JAR" ]; then
+    printf '# Netscape HTTP Cookie File\n.myanonamouse.net\tTRUE\t/\tTRUE\t2147483647\tmam_id\t%s\n' "${MAM_ID_SEED:-}" > "$JAR"
+    log "seeded cookie jar from MAM_ID_SEED (first run)"
+  fi
+
+  # 5) Register the current exit IP. -b/-c on the same jar loads the current mam_id
+  #    and writes back whatever (possibly rotated) cookie the server returns.
+  resp=$(curl -fsS --max-time 30 -b "$JAR" -c "$JAR" "$URL" 2>"$STATE_DIR/mam.err")
+  rc=$?
+  echo "$now" > "$LAST_CALL"   # count EVERY call against the hourly limit (conservative)
+
+  if [ "$rc" -ne 0 ]; then
+    log "ERROR curl rc=$rc calling dynamicSeedbox.php: $(cat "$STATE_DIR/mam.err" 2>/dev/null)"
+    sleep "$INTERVAL"; continue
+  fi
+
+  # 6) Interpret the reply. Update the IP cache only on a confirmed success.
+  case "$resp" in
+    *Completed*|*completed*)
+      echo "$cur_ip" > "$IP_CACHE"
+      log "Completed: registered seedbox IP ${last_ip:-none} -> $cur_ip" ;;
+    *"No change"*|*"No Change"*|*"no change"*)
+      echo "$cur_ip" > "$IP_CACHE"
+      log "No Change: MAM already had $cur_ip as the seedbox IP" ;;
+    *"Last Change Too Recent"*|*"too recent"*)
+      log "WARN MAM rate-limited us (Last Change Too Recent) — will retry next cycle" ;;
+    *)
+      log "ERROR unexpected dynamicSeedbox.php response: $resp" ;;
+  esac
+
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## What

Phase-B wiring for PLAN-031 (MyAnonaMouse books/audiobooks acquisition). This PR is the **GitOps** slice only — the ExternalSecret and the qBittorrent seedbox-IP sidecar. Live-config steps (Prowlarr MAM indexer, qBittorrent `books-mam` category, LazyLibrarian torznab provider) are applied imperatively against the running apps like the rest of the *arr stack (they live in each app's PVC/DB, not git).

- **ExternalSecret `myanonamouse`** → `myanonamouse-secret` with `MAM_ID_PROWLARR` (Session A, ASN-locked home → Prowlarr) and `MAM_ID_SEEDBOX` (Session B, dynamic-seedbox → this sidecar). Two sessions because MAM rotates `mam_id` on use.
- **`mam-update` sidecar** in the qBittorrent pod (owner ruling Q-02): shares the macvlan netns so `dynamicSeedbox.php` egresses the exact Mullvad exit IP qBittorrent announces from.
  - Confirms the Mullvad exit before every call (`am.i.mullvad.net/json` → `mullvad_exit_ip:true`) — **fail-closed**, never registers an off-VPN IP.
  - Self-throttles to **≤1 call/hour** (hard MAM limit).
  - Persists the **rotating `mam_id` cookie** to `/state` (subpath of the config PVC, volsync-backed) so it survives restarts; the ExternalSecret value seeds the jar on first run only.
  - **No readiness/startup probe** — only the app container's Mullvad-egress check may gate pod readiness (same rule as the exporter sidecar).

## Compliance (mam-rules-scrape.md)

- Automation limited to `dynamicSeedbox.php` only (no scraping). ✔
- ≤1 dynamicSeedbox call/hr. ✔
- Never announces/registers off-VPN (fail-closed check + sidecar placement; readiness probe untouched). ✔
- Fixed torrent port `50469` and the fail-closed readiness probe are **unchanged**. ✔

## Validation

`kubectl kustomize .../qbittorrent/app` renders clean (10 docs): the sidecar container, the two persistence mounts (`/config` for app, `/state` subpath for mam-update), the ExternalSecret, and the hash-wired script ConfigMap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU9cU9mSv19WMB64bMGP71