### PR TITLE
fix(alert-responder): ignore the ceph-mgr OOMKilled self-heal cycle (namespace-scoped)

### DIFF
--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/helmrelease.yaml
@@ -56,6 +56,14 @@ spec:
               #    burning ~$0.15-0.20/diagnosis on unactionable NAS drive wear-out.
               # Keep in sync with respond.sh's default.
               RESPONDER_ALERT_DENYLIST: "^(Watchdog|InfoInhibitor|AlertmanagerReceiversNotConfigured|Protect.*|Smart.*|Hardware.*|NodeRAIDDiskFailure)$"
+              # Namespace-scoped ignores (alertname@namespace, space-separated) — surgical
+              # skips for KNOWN-benign recurrers without a blanket alertname denylist.
+              # 2026-07-12: OOMKilled@rook-ceph = the ceph-mgr documented ~8wk memory-leak
+              # self-heal OOM cycle (re-diagnosed 7x/month = $). A real OOMKilled in any
+              # OTHER namespace is still diagnosed; a genuine Ceph OOM still surfaces via the
+              # gate's Ceph HEALTH_ERR page. Grow this as we identify other noisy recurrers
+              # (state CM + Loki logs record every diagnosis, so we can see spend triggers).
+              RESPONDER_IGNORE_PAIRS: "OOMKilled@rook-ceph"
               RESPONDER_MODEL: sonnet
               RESPONDER_MAX_PER_RUN: "1"
               RESPONDER_MAX_BUDGET_USD: "2.00"

--- a/kubernetes/main/apps/upgrade-agent/alert-responder/app/resources/respond.sh
+++ b/kubernetes/main/apps/upgrade-agent/alert-responder/app/resources/respond.sh
@@ -29,6 +29,15 @@ ALLOWLIST="${RESPONDER_ALERT_ALLOWLIST:-.*}"
 # (Smart.*/Hardware.*/NodeRAIDDiskFailure — self-evident, unactionable-by-cluster, and
 # they RECUR so at-most-once doesn't help; were burning LLM $ on NAS drive wear-out).
 DENYLIST="${RESPONDER_ALERT_DENYLIST:-^(Watchdog|InfoInhibitor|AlertmanagerReceiversNotConfigured|Protect.*|Smart.*|Hardware.*|NodeRAIDDiskFailure)$}"
+# Namespace-SCOPED ignores (space-separated `alertname@namespace` pairs) — a surgical
+# skip for a KNOWN-benign recurring alert without a blanket alertname denylist that would
+# also hide the same alert elsewhere. 2026-07-12: OOMKilled@rook-ceph — the ceph-mgr has a
+# documented ~8wk memory-leak self-heal OOM cycle; the responder re-diagnosed it 7x this
+# month ($). A REAL OOMKilled on any OTHER namespace is still diagnosed; a genuine Ceph OOM
+# disaster still surfaces via the gate's Ceph HEALTH_ERR page + Alertmanager. Grow this
+# list as we identify other noisy recurrers (the state CM + Loki logs record every diagnosis
+# → alertname/cost, so we can see what else is triggering spend before a broader scope call).
+IGNORE_PAIRS="${RESPONDER_IGNORE_PAIRS:-OOMKilled@rook-ceph}"
 MAX_PER_RUN="${RESPONDER_MAX_PER_RUN:-1}"
 MAX_AGE_HOURS="${RESPONDER_MAX_AGE_HOURS:-24}"
 STATE_TTL_HOURS="${RESPONDER_STATE_TTL_HOURS:-168}"
@@ -124,11 +133,16 @@ if [ -z "$alerts" ]; then
   log "Alertmanager unreachable/empty response — nothing to do (Alertmanager pages independently; the gate covers blind spots)."
   exit 0
 fi
-candidates="$(printf '%s' "$alerts" | jq -c --arg sev "$SEVERITY" --arg allow "$ALLOWLIST" --arg deny "$DENYLIST" --argjson now "$NOW" --argjson maxage "$(( MAX_AGE_HOURS * 3600 ))" '
-  [ .[]
+candidates="$(printf '%s' "$alerts" | jq -c --arg sev "$SEVERITY" --arg allow "$ALLOWLIST" --arg deny "$DENYLIST" --arg ignore "$IGNORE_PAIRS" --argjson now "$NOW" --argjson maxage "$(( MAX_AGE_HOURS * 3600 ))" '
+  ($ignore | split(" ") | map(select(. != ""))) as $ignorepairs
+  | [ .[]
     | select(.labels.severity == $sev)
     | select(.labels.alertname | test($allow))
     | select(.labels.alertname | test($deny) | not)
+    # namespace-scoped ignore (2026-07-12): drop known-benign recurrers by
+    # alertname@namespace (e.g. OOMKilled@rook-ceph = the ceph-mgr self-heal cycle),
+    # WITHOUT a blanket alertname denylist. Uses the same ns resolution as the loop below.
+    | select((.labels.alertname + "@" + (.labels.namespace // .labels.exported_namespace // "")) as $p | ($ignorepairs | index($p)) == null)
     # scope=host opt-out (2026-07-10): the CLEAN, future-proof way to keep the responder
     # out of an alert — host/hardware/appliance alerts (SMART, RAID, fan/power, NAS) that
     # are self-evident + unactionable-by-cluster. The alert author labels the rule


### PR DESCRIPTION
The responder re-diagnosed `OOMKilled` **7x this month** — it's the ceph-mgr's documented ~8-week memory-leak self-heal OOM cycle in rook-ceph, not an upgrade and not actionable. The ACTION=none gate stopped its *page* but not the diagnose-*spend*.

Adds a **namespace-scoped** ignore (`RESPONDER_IGNORE_PAIRS = alertname@namespace`, default `OOMKilled@rook-ceph`) so it's skipped pre-diagnosis ($0) **without** a blanket `OOMKilled` denylist — a real OOM in any other namespace is still diagnosed, and a genuine Ceph OOM disaster still surfaces via the gate's Ceph `HEALTH_ERR` page. Per the operator: ignore the Ceph OOM now, keep the responder running on everything else to collect data on what else is triggering spend before deciding a broader scope. Verified the filter: Ceph OOM dropped, other-namespace OOM kept, normal alerts kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)