### PR TITLE
feat(dev-env): workhorse image + signed build workflow (saga plan 01)

### DIFF
--- a/.agents/sagas/dev-env/backlog/01-image.md
+++ b/.agents/sagas/dev-env/backlog/01-image.md
@@ -1,6 +1,6 @@
 # 01 — dev-env container image + signed build workflow
 
-**Status:** backlog
+**Status:** in review (branch `dev-env/01-image`)
 **Depends on:** nothing (first mover)
 **Parallel with:** 02 can be authored against the expected image name while this bakes
 

--- a/.github/workflows/dev-env-build.yml
+++ b/.github/workflows/dev-env-build.yml
@@ -1,0 +1,61 @@
+name: Build and Push Dev Env Image
+
+# Builds the dev-env workhorse image (ghcr.io/thaynes43/dev-env) for the dev-env saga
+# (.agents/sagas/dev-env/): agent CLIs + ops toolchain + code-server + SDKs. Build
+# context is the REPO ROOT so the Dockerfile can COPY scripts/github-app-token.sh
+# (single source of truth); the repo-root .dockerignore keeps secrets/.git out of the
+# context. Builds only on main.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/dev-env/**'
+      - 'scripts/github-app-token.sh'
+      - '.github/workflows/dev-env-build.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write   # keyless cosign signing (OIDC) — proves the image came from THIS workflow
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v2.4.1   # v2 writes legacy .sig tags (Kyverno-verifiable)
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./scripts/dev-env/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/dev-env:0.1.0
+            ghcr.io/${{ github.repository_owner }}/dev-env:latest
+
+      # Keyless sign by DIGEST (covers both tags — they share the manifest). Verified
+      # in-cluster by the Kyverno verify-thaynes43-images policy against this
+      # workflow's OIDC identity (no key to manage or leak).
+      - name: Sign the image (keyless)
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/dev-env
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/kubernetes/main/apps/kyverno/policies/app/verify-thaynes43-images.yaml
+++ b/kubernetes/main/apps/kyverno/policies/app/verify-thaynes43-images.yaml
@@ -5,10 +5,10 @@
 # but NOT this — it requires a keyless cosign signature proving the image was built by
 # OUR GitHub Actions workflow (OIDC identity), not swapped by an attacker.
 #
-# SCOPE: only the images whose build workflows sign (upgrade-agent, upgrade-shepherd).
-# Other ghcr.io/thaynes43/* images (appdaemon, hass-immich-addon, todos-for-dues,
-# ytdl-sub-config-manager) are NOT covered yet — add them here as their builds gain
-# `cosign sign` (appdaemon is the next one, in hass-sandbox).
+# SCOPE: only the images whose build workflows sign (upgrade-agent, upgrade-shepherd,
+# dev-env). Other ghcr.io/thaynes43/* images (appdaemon, hass-immich-addon,
+# todos-for-dues, ytdl-sub-config-manager) are NOT covered yet — add them here as
+# their builds gain `cosign sign` (appdaemon is the next one, in hass-sandbox).
 #
 # PHASE: Audit first (observe the report), then flip to Enforce once the running/summoned
 # pods are all on signed digests. fail-open (failurePolicy: Ignore). background:false —
@@ -32,6 +32,7 @@ spec:
         - imageReferences:
             - "ghcr.io/thaynes43/upgrade-agent*"
             - "ghcr.io/thaynes43/upgrade-shepherd*"
+            - "ghcr.io/thaynes43/dev-env*"
           failureAction: Audit
           mutateDigest: false   # we pin tag@digest in the manifests; don't rewrite
           verifyDigest: false

--- a/scripts/dev-env/Dockerfile
+++ b/scripts/dev-env/Dockerfile
@@ -1,0 +1,177 @@
+# syntax=docker/dockerfile:1
+# ghcr.io/thaynes43/dev-env — 24/7 in-cluster agent development environment.
+#
+# The kitchen-sink workhorse image for the dev-env saga (.agents/sagas/dev-env/):
+# agent CLIs (Claude Code, Codex) + the full ops toolchain + code-server + the SDKs
+# covering haynesnetwork (Node/TypeScript), haynes-ops (bash/python/k8s), and
+# hass-sandbox (Python). Runs as a long-lived pod with a PVC home at /home/dev.
+#
+# UNLIKE the upgrade-shepherd image this is NOT a contained one-shot runner —
+# containment lives in the deployment (operator-tier SA, enumerated egress CNP,
+# Authentik-only ingress; saga Hard news #1), not in image minimalism.
+#
+# Debian/glibc (kubectl/claude glibc-linked); amd64-only (all Talos nodes x86_64).
+FROM node:24-slim
+
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
+ARG KUBECTL_VERSION=v1.35.5
+# renovate: datasource=github-releases depName=fluxcd/flux2
+ARG FLUX_VERSION=2.4.0
+# renovate: datasource=github-releases depName=cli/cli
+ARG GH_VERSION=2.95.0
+# renovate: datasource=github-releases depName=helm/helm
+ARG HELM_VERSION=3.19.0
+# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize/v(?<version>.+)$
+ARG KUSTOMIZE_VERSION=5.6.0
+# renovate: datasource=github-releases depName=getsops/sops
+ARG SOPS_VERSION=3.10.2
+# renovate: datasource=github-releases depName=FiloSottile/age extractVersion=^v(?<version>.+)$
+ARG AGE_VERSION=1.2.1
+# renovate: datasource=github-releases depName=mikefarah/yq extractVersion=^v(?<version>.+)$
+ARG YQ_VERSION=4.44.3
+# renovate: datasource=github-releases depName=go-task/task extractVersion=^v(?<version>.+)$
+ARG TASK_VERSION=3.40.0
+# renovate: datasource=github-releases depName=opentofu/opentofu extractVersion=^v(?<version>.+)$
+ARG OPENTOFU_VERSION=1.9.0
+# renovate: datasource=github-releases depName=restic/restic extractVersion=^v(?<version>.+)$
+ARG RESTIC_VERSION=0.17.3
+# renovate: datasource=github-releases depName=coder/code-server extractVersion=^v(?<version>.+)$
+ARG CODE_SERVER_VERSION=4.96.4
+# renovate: datasource=github-releases depName=astral-sh/uv
+ARG UV_VERSION=0.5.24
+# renovate: datasource=npm depName=@anthropic-ai/claude-code
+ARG CLAUDE_CODE_VERSION=2.1.197
+# renovate: datasource=npm depName=@openai/codex
+ARG CODEX_VERSION=0.42.0
+# renovate: datasource=npm depName=tsx
+ARG TSX_VERSION=4.19.2
+# renovate: datasource=npm depName=pnpm
+ARG PNPM_VERSION=10.0.0
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Base packages: dev essentials + python3 (hass-sandbox/makejinja) + tmux (agent
+# sessions live in tmux) + ripgrep (agents search with rg) + build-essential
+# (native npm modules, C extensions).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates curl git openssh-client jq openssl bash \
+      tar gzip unzip bzip2 xz-utils \
+      tmux ripgrep less procps rsync file make build-essential \
+      python3 python3-venv python3-pip \
+ && rm -rf /var/lib/apt/lists/*
+
+# kubectl (checksum-verified) — in-cluster via kubernetes.default.svc + the
+# operator-tier SA (saga Decision #1).
+RUN curl -fsSLo /usr/local/bin/kubectl \
+      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+ && curl -fsSLo /tmp/kubectl.sha256 \
+      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" \
+ && echo "$(cat /tmp/kubectl.sha256)  /usr/local/bin/kubectl" | sha256sum -c - \
+ && chmod +x /usr/local/bin/kubectl && rm -f /tmp/kubectl.sha256
+
+# flux CLI.
+RUN curl -fsSLo /tmp/flux.tar.gz \
+      "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz" \
+ && tar -xzf /tmp/flux.tar.gz -C /usr/local/bin flux \
+ && chmod +x /usr/local/bin/flux && rm -f /tmp/flux.tar.gz
+
+# gh CLI.
+RUN curl -fsSLo /tmp/gh.tar.gz \
+      "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+ && tar -xzf /tmp/gh.tar.gz -C /tmp \
+ && install -m 0755 "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh \
+ && rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_amd64"
+
+# helm.
+RUN curl -fsSLo /tmp/helm.tar.gz \
+      "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
+ && tar -xzf /tmp/helm.tar.gz -C /tmp \
+ && install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm \
+ && rm -rf /tmp/helm.tar.gz /tmp/linux-amd64
+
+# kustomize (release tags are kustomize/vX.Y.Z — hence the URL-encoded path).
+RUN curl -fsSLo /tmp/kustomize.tar.gz \
+      "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" \
+ && tar -xzf /tmp/kustomize.tar.gz -C /usr/local/bin kustomize \
+ && chmod +x /usr/local/bin/kustomize && rm -f /tmp/kustomize.tar.gz
+
+# sops + age (SOPS_AGE_KEY_FILE workflows, same as the Mac direnv setup).
+RUN curl -fsSLo /usr/local/bin/sops \
+      "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" \
+ && chmod +x /usr/local/bin/sops \
+ && curl -fsSLo /tmp/age.tar.gz \
+      "https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz" \
+ && tar -xzf /tmp/age.tar.gz -C /tmp \
+ && install -m 0755 /tmp/age/age /usr/local/bin/age \
+ && install -m 0755 /tmp/age/age-keygen /usr/local/bin/age-keygen \
+ && rm -rf /tmp/age.tar.gz /tmp/age
+
+# yq.
+RUN curl -fsSLo /usr/local/bin/yq \
+      "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" \
+ && chmod +x /usr/local/bin/yq
+
+# go-task (the repo's Taskfile runner).
+RUN curl -fsSLo /tmp/task.tar.gz \
+      "https://github.com/go-task/task/releases/download/v${TASK_VERSION}/task_linux_amd64.tar.gz" \
+ && tar -xzf /tmp/task.tar.gz -C /usr/local/bin task \
+ && chmod +x /usr/local/bin/task && rm -f /tmp/task.tar.gz
+
+# opentofu.
+RUN curl -fsSLo /tmp/tofu.zip \
+      "https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_linux_amd64.zip" \
+ && unzip -q /tmp/tofu.zip -d /tmp/tofu \
+ && install -m 0755 /tmp/tofu/tofu /usr/local/bin/tofu \
+ && rm -rf /tmp/tofu.zip /tmp/tofu
+
+# restic (volsync debugging per the runbooks).
+RUN curl -fsSLo /tmp/restic.bz2 \
+      "https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2" \
+ && bunzip2 /tmp/restic.bz2 \
+ && install -m 0755 /tmp/restic /usr/local/bin/restic && rm -f /tmp/restic
+
+# code-server (standalone) — the browser IDE, fronted by traefik-internal +
+# Authentik (saga Decision #6); started by the HelmRelease, not baked as ENTRYPOINT.
+RUN curl -fsSLo /tmp/code-server.tar.gz \
+      "https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server-${CODE_SERVER_VERSION}-linux-amd64.tar.gz" \
+ && mkdir -p /usr/local/lib/code-server \
+ && tar -xzf /tmp/code-server.tar.gz -C /usr/local/lib/code-server --strip-components=1 \
+ && ln -s /usr/local/lib/code-server/bin/code-server /usr/local/bin/code-server \
+ && rm -f /tmp/code-server.tar.gz
+
+# uv — modern python env/dependency management (hass-sandbox, makejinja venvs).
+RUN curl -fsSLo /tmp/uv.tar.gz \
+      "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" \
+ && tar -xzf /tmp/uv.tar.gz -C /tmp \
+ && install -m 0755 /tmp/uv-x86_64-unknown-linux-gnu/uv /usr/local/bin/uv \
+ && install -m 0755 /tmp/uv-x86_64-unknown-linux-gnu/uvx /usr/local/bin/uvx \
+ && rm -rf /tmp/uv.tar.gz /tmp/uv-x86_64-unknown-linux-gnu
+
+# Agent CLIs + TS tooling (haynesnetwork runs tsx).
+RUN npm install -g \
+      "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+      "@openai/codex@${CODEX_VERSION}" \
+      "tsx@${TSX_VERSION}" \
+      "pnpm@${PNPM_VERSION}" \
+ && npm cache clean --force
+
+# github-app-token.sh (single source of truth) — used by the token-refresher
+# sidecar/initContainer to mint short-lived ghs_ tokens from the haynes-ops-bot PEM
+# (saga Decision #5). The agent containers never see the PEM, only /creds tokens.
+WORKDIR /opt/dev-env
+COPY scripts/github-app-token.sh ./github-app-token.sh
+RUN chmod +x ./github-app-token.sh
+
+# Non-root: rename the base image's uid-1000 'node' user to 'dev' with /home/dev —
+# the PVC mounts over /home/dev at runtime (dev-init.sh repopulates config links).
+RUN usermod -l dev -d /home/dev node && groupmod -n dev node \
+ && mkdir -p /home/dev && chown dev:dev /home/dev
+
+USER dev
+WORKDIR /home/dev
+ENV HOME=/home/dev \
+    CLAUDE_CONFIG_DIR=/home/dev/.claude \
+    CODEX_HOME=/home/dev/.codex \
+    PATH=/opt/dev-env:/usr/local/bin:/usr/bin:/bin
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
## Saga: dev-env — plan 01 (image + signed build)

First implementation PR of the [dev-env saga](https://github.com/thaynes43/haynes-ops/blob/main/.agents/sagas/dev-env/README.md) (all 8 scoping decisions recorded there, 2026-07-13).

### What

- **`scripts/dev-env/Dockerfile`** → `ghcr.io/thaynes43/dev-env`: the 24/7 workhorse image.
  - Agent CLIs: `@anthropic-ai/claude-code` 2.1.197, `@openai/codex` 0.42.0
  - Ops: kubectl v1.35.5 (checksum-verified), flux 2.4.0, gh 2.95.0, helm 3.19.0, kustomize 5.6.0, sops 3.10.2, age 1.2.1, yq 4.44.3, go-task 3.40.0, opentofu 1.9.0, restic 0.17.3
  - IDE: code-server 4.96.4 (standalone; started by the plan-02 HelmRelease, Authentik-fronted)
  - SDKs (Decision #8 — covers haynesnetwork/haynes-ops/hass-sandbox): Node 24 base + tsx/pnpm, Python 3 + uv
  - tmux + ripgrep + build-essential; non-root `dev` uid 1000, `HOME=/home/dev` (PVC mountpoint), `CLAUDE_CONFIG_DIR`/`CODEX_HOME` pre-set
  - `github-app-token.sh` baked at `/opt/dev-env` for the haynes-ops-bot token refresher (Decision #5; PEM never in agent containers)
- **`.github/workflows/dev-env-build.yml`**: mirror of the upgrade-shepherd build — repo-root context, push on main, keyless cosign sign by digest.
- **Kyverno `verify-thaynes43-images`**: `ghcr.io/thaynes43/dev-env*` added to the signed-image verification set (Audit-phase, same ramp the shepherd image followed).
- Backlog 01 marked in-review.

### Verification done

- All 12 GitHub release tags + 4 npm versions confirmed to exist (git-ref/npm-view checks), so the first build won't die on a bad pin.
- Renovate datasource comments on every ARG (kustomize/age/yq/task/tofu/restic/code-server use `extractVersion` for their tag prefixes).

### Notes for review

- Versions are deliberately conservative-but-valid; Renovate will PR bumps immediately after merge.
- Image is fat by design (saga Hard news #6) — containment is environmental (plan 02: operator SA, enumerated egress CNP, Authentik ingress), not image minimalism.
- No cluster effect until plan 02 deploys something that references the image; the Kyverno change is Audit-mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6
