### PR TITLE
feat(dev-env): PoC deployment — namespace, pod, SSO, egress (saga plan 02)

### DIFF
--- a/.agents/sagas/dev-env/backlog/02-poc-deploy.md
+++ b/.agents/sagas/dev-env/backlog/02-poc-deploy.md
@@ -1,7 +1,15 @@
 # 02 — PoC deployment (namespace, HelmRelease, PVC, ingress, egress)
 
-**Status:** backlog
-**Depends on:** 01 (image published)
+**Status:** in review (branch `dev-env/02-poc-deploy`)
+**Depends on:** 01 (image published) — done
+
+**Implementation notes (2026-07-13):** SSO is Authentik forward-auth via the EMBEDDED
+outpost (unused until now — headlamp/paperless ride the named internal/external
+outposts), GitOps'd as blueprint `network/authentik/app/blueprints/50-dev-env.yaml`
+which now OWNS the embedded outpost's provider list. The haynesops wildcard cert
+reaches namespace `dev` via the reflector allowlist on certificate-haynesops-prod.
+code-server runs `--auth none` — safe ONLY behind the middleware + the CNP ingress
+rule (traefik-internal pods only); never add another ingress path without auth.
 
 ## Goal
 

--- a/kubernetes/main/apps/cert-manager/certificates/certificates-letsencrypt-wildcard/certificate-haynesops-prod.yaml
+++ b/kubernetes/main/apps/cert-manager/certificates/certificates-letsencrypt-wildcard/certificate-haynesops-prod.yaml
@@ -14,6 +14,6 @@ spec:
   secretTemplate:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "network,home-automation,ai,frontend,observability"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "network,home-automation,ai,frontend,observability,dev"
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "network,home-automation,ai,frontend,observability"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "network,home-automation,ai,frontend,observability,dev"

--- a/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
@@ -1,0 +1,90 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dev-env
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+  values:
+    controllers:
+      dev-env:
+        # The 24/7 agent workhorse (saga .agents/sagas/dev-env/): code-server +
+        # tmux-hosted agent CLI sessions on a persistent home. Recreate: the home
+        # PVC is RWO and agent/tmux state doesn't survive a pod swap anyway.
+        replicas: 1
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/thaynes43/dev-env
+              tag: 0.1.0@sha256:95e9919f3f10724b31cf4586227ae5aefd5fc9adbc7c49675a1c290eeca296e8
+            command: ["/bin/bash", "-c"]
+            args:
+              # tmux server first (agent sessions survive browser/exec disconnects;
+              # /remote-control + agent-run sessions live here), then code-server.
+              # --auth none is safe ONLY because ingress is traefik-internal + the
+              # Authentik forward-auth middleware AND the CNP restricts ingress to
+              # traefik — do not add other ingress paths without adding auth.
+              - >-
+                tmux new-session -d -s main 2>/dev/null || true;
+                exec code-server
+                --bind-addr 0.0.0.0:8443
+                --auth none
+                --disable-telemetry
+                --disable-update-check
+                /home/dev
+            env:
+              HOME: /home/dev
+              CLAUDE_CONFIG_DIR: /home/dev/.claude
+              CODEX_HOME: /home/dev/.codex
+              # The image pins CLI versions (Renovate-bumped); no self-updates.
+              DISABLE_AUTOUPDATER: "1"
+              DISABLE_ERROR_REPORTING: "1"
+              DISABLE_TELEMETRY: "1"
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              requests:
+                cpu: 500m
+                memory: 2Gi
+              limits:
+                memory: 8Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+    defaultPodOptions:
+      automountServiceAccountToken: true   # in-cluster kubectl via the dev-env SA
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000                      # PVC ownership for /home/dev
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    serviceAccount:
+      dev-env: {}
+    service:
+      app:
+        controller: dev-env
+        ports:
+          http:
+            port: 8443
+    persistence:
+      home:
+        existingClaim: dev-env-home
+        globalMounts:
+          - path: /home/dev
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/main/apps/dev/dev-env/app/ingressroute.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/ingressroute.yaml
@@ -1,0 +1,35 @@
+---
+# code-server, LAN-only (saga Decision #6): traefik-internal + the Authentik
+# embedded-outpost forward-auth middleware (provider/application/outpost assignment
+# is GitOps'd in kubernetes/main/apps/network/authentik/app/blueprints/50-dev-env.yaml).
+# Fail-closed: until the blueprint applies and the provider is on the outpost, the
+# middleware denies everything. NOT published through the Cloudflare Tunnel — remote
+# interaction with running agents is /remote-control (outbound via claude.ai).
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: dev-env
+  annotations:
+    external-dns.alpha.kubernetes.io/target: internal.haynesops
+    kubernetes.io/ingress.class: traefik-internal
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/href: "https://dev-env.haynesops.com"
+    gethomepage.dev/group: Frontend
+    gethomepage.dev/name: Dev Env
+    gethomepage.dev/description: In-cluster agent dev environment (code-server)
+    gethomepage.dev/icon: vscode
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`dev-env.haynesops.com`) && PathPrefix(`/`)
+      middlewares:
+        - name: ak-outpost-authentik-embedded-outpost
+          namespace: network
+      services:
+        - kind: Service
+          name: dev-env
+          port: 8443
+  tls:
+    secretName: certificate-haynesops

--- a/kubernetes/main/apps/dev/dev-env/app/kustomization.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/kustomization.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../../shared/components/common/repos/app-template
+resources:
+  - ./pvc.yaml
+  - ./rbac.yaml
+  - ./networkpolicy.yaml
+  - ./ingressroute.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
@@ -1,0 +1,97 @@
+---
+# CiliumNetworkPolicy for the dev-env pod. Broader than the shepherd's BY DESIGN
+# (agents doing real dev work need package registries + both LLM vendors), but still
+# default-deny + ENUMERATED — this list is the exfil boundary for yolo-mode agents
+# holding subscription/git credentials (saga Hard news #1). Extend it deliberately,
+# one named destination at a time; watch Hubble drops during bring-up.
+#
+# Ingress: ONLY traefik-internal → 8443 (code-server runs --auth none behind the
+# Authentik forward-auth middleware, so nothing else may reach it directly).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: dev-env
+  namespace: dev
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: dev-env
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/instance: traefik-internal-network
+      toPorts:
+        - ports:
+            - port: "8443"
+              protocol: TCP
+  egress:
+    # 1. DNS via CoreDNS — only cluster-internal + the exact external names below
+    #    (closes DNS-tunnel exfil, shepherd pattern; Cilium `*` does not cross label
+    #    boundaries, so apex domains need matchName alongside their matchPattern).
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*.cluster.local"
+              - matchPattern: "*.svc"
+              # git + gh + release notes + ghcr blobs
+              - matchName: "github.com"
+              - matchPattern: "*.github.com"
+              - matchPattern: "*.githubusercontent.com"
+              - matchName: "ghcr.io"
+              # Anthropic: API + claude.ai (/remote-control relay) + statsig etc.
+              - matchName: "anthropic.com"
+              - matchPattern: "*.anthropic.com"
+              - matchName: "claude.ai"
+              - matchPattern: "*.claude.ai"
+              # OpenAI: Codex API + ChatGPT-plan auth/backend
+              - matchName: "openai.com"
+              - matchPattern: "*.openai.com"
+              - matchName: "chatgpt.com"
+              - matchPattern: "*.chatgpt.com"
+              # package registries (real dev work)
+              - matchName: "registry.npmjs.org"
+              - matchName: "pypi.org"
+              - matchName: "files.pythonhosted.org"
+              # code-server extension marketplace (Open VSX)
+              - matchName: "open-vsx.org"
+              - matchName: "openvsxorg.blob.core.windows.net"
+    # 2. Kube API server — in-cluster kubectl via kubernetes.default.svc (the whole
+    #    point of saga Decision #1).
+    - toEntities: [kube-apiserver]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "6443"
+              protocol: TCP
+    # 3. HTTPS to the enumerated external names (same set as the DNS rules).
+    - toFQDNs:
+        - matchName: "github.com"
+        - matchPattern: "*.github.com"
+        - matchPattern: "*.githubusercontent.com"
+        - matchName: "ghcr.io"
+        - matchName: "anthropic.com"
+        - matchPattern: "*.anthropic.com"
+        - matchName: "claude.ai"
+        - matchPattern: "*.claude.ai"
+        - matchName: "openai.com"
+        - matchPattern: "*.openai.com"
+        - matchName: "chatgpt.com"
+        - matchPattern: "*.chatgpt.com"
+        - matchName: "registry.npmjs.org"
+        - matchName: "pypi.org"
+        - matchName: "files.pythonhosted.org"
+        - matchName: "open-vsx.org"
+        - matchName: "openvsxorg.blob.core.windows.net"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/main/apps/dev/dev-env/app/pvc.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/pvc.yaml
@@ -1,0 +1,19 @@
+---
+# The dev-env home (/home/dev): repo clones + worktrees, agent auth state
+# (~/.codex/auth.json etc.), npm/pip caches, code-server state. Deliberately NOT
+# VolSync'd (saga Decision #7): everything but auth state regenerates from
+# git/registries, and keeping subscription/git credentials OUT of restic/S3 is a
+# feature. Disaster recovery: PVC re-creates empty, dev-init re-links GitOps configs,
+# re-auth is two ~2-minute ceremonies (.agents/sagas/dev-env/backlog/04-auth.md).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dev-env-home
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: ceph-block

--- a/kubernetes/main/apps/dev/dev-env/app/rbac.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/rbac.yaml
@@ -1,0 +1,21 @@
+---
+# PoC tier (saga backlog 02): READ-ONLY cluster access via the gate's shared
+# ClusterRole (get/list/watch; no secrets/exec/log/write) — the same reuse the
+# shepherd does. The decided end-state is the OPERATOR tier (read-all + targeted
+# writes: pod delete, rollout-restart patch, Flux reconcile annotations, Job create,
+# CronJob suspend) — that lands as its own reviewed change in backlog 05, NOT here.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app dev-env
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: upgrade-health-gate # the shared read-only role (defined by the gate)
+subjects:
+  - kind: ServiceAccount
+    name: *app
+    namespace: dev

--- a/kubernetes/main/apps/dev/dev-env/ks.yaml
+++ b/kubernetes/main/apps/dev/dev-env/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dev-env
+  namespace: dev
+spec:
+  targetNamespace: dev
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: upgrade-health-gate # PoC reuses its read-only ClusterRole (backlog 05 = operator tier)
+      namespace: upgrade-agent
+  path: ./kubernetes/main/apps/dev/dev-env/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+  # NO postBuild.substitute (shepherd precedent): future agent-run.sh scripts carry
+  # shell `${VAR}` syntax that Flux envsubst would mangle. YAML anchors only.

--- a/kubernetes/main/apps/dev/kustomization.yaml
+++ b/kubernetes/main/apps/dev/kustomization.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Pre Flux-Kustomizations
+  - ./namespace.yaml
+  # Flux-Kustomizations
+  - ./dev-env/ks.yaml

--- a/kubernetes/main/apps/dev/namespace.yaml
+++ b/kubernetes/main/apps/dev/namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev
+  labels:
+    # The dev-env pod carries credentials (subscription tokens, bot gh tokens) and
+    # runs yolo-mode agents — same tightened PSA boundary as upgrade-agent.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/main/apps/network/authentik/app/blueprints/50-dev-env.yaml
+++ b/kubernetes/main/apps/network/authentik/app/blueprints/50-dev-env.yaml
@@ -1,0 +1,42 @@
+# dev-env saga (.agents/sagas/dev-env/) — forward-auth SSO for the in-cluster dev
+# environment (code-server at dev-env.haynesops.com), config-as-code.
+#
+# Creates the Proxy Provider (forward_single) + Application and assigns the provider
+# to the EMBEDDED outpost. The embedded outpost carries no providers today (headlamp
+# rides proxy-provider-internal-outpost, paperless the external one — see
+# ../../exports/applications.json), so the `providers` list below clobbers nothing.
+# ⚠ This blueprint now OWNS the embedded outpost's provider list: assign any future
+# provider to it HERE (blueprints re-apply on an interval and will revert UI edits).
+version: 1
+metadata:
+  name: dev-env-proxy
+  labels:
+    blueprints.goauthentik.io/description: 'dev-env forward-auth: proxy provider + application + embedded-outpost assignment for the in-cluster agent dev environment (saga: .agents/sagas/dev-env/).'
+context: {}
+entries:
+- model: authentik_providers_proxy.proxyprovider
+  state: present
+  identifiers:
+    name: dev-env
+  attrs:
+    external_host: https://dev-env.haynesops.com
+    mode: forward_single
+    authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+    invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+- model: authentik_core.application
+  state: present
+  identifiers:
+    slug: dev-env
+  attrs:
+    name: Dev Env
+    provider: !Find [authentik_providers_proxy.proxyprovider, [name, dev-env]]
+    meta_launch_url: https://dev-env.haynesops.com
+    meta_description: In-cluster agent dev environment (code-server)
+    open_in_new_tab: true
+- model: authentik_outposts.outpost
+  state: present
+  identifiers:
+    managed: goauthentik.io/outposts/embedded
+  attrs:
+    providers:
+    - !Find [authentik_providers_proxy.proxyprovider, [name, dev-env]]

--- a/kubernetes/main/apps/network/authentik/app/kustomization.yaml
+++ b/kubernetes/main/apps/network/authentik/app/kustomization.yaml
@@ -17,6 +17,8 @@ resources:
 # name stable so helmrelease.yaml's blueprints.configMaps reference resolves.
 #   40-hnet-mfa.yaml PROMOTED 2026-07-10 (PLAN-011 Phase 2, owner-present): native-account
 #   MFA enforcement is live; it owns the order-30 validation stage + binding.
+#   50-dev-env.yaml (2026-07-13, dev-env saga): forward-auth proxy provider +
+#   application + embedded-outpost assignment for dev-env.haynesops.com.
 configMapGenerator:
   - name: authentik-hnet-blueprints
     options:
@@ -26,3 +28,4 @@ configMapGenerator:
       - blueprints/20-hnet-flows.yaml
       - blueprints/30-hnet-sources.yaml
       - blueprints/40-hnet-mfa.yaml
+      - blueprints/50-dev-env.yaml


### PR DESCRIPTION
## Saga: dev-env — plan 02 (PoC deployment)

Deploys the 24/7 workhorse pod per the [saga](https://github.com/thaynes43/haynes-ops/blob/main/.agents/sagas/dev-env/README.md) decisions. Follows plan 01 (#2031, merged — image live + signed).

### What

- **New `dev` domain/namespace** (PSA `restricted`, prune-protected) — auto-registered by the flux `cluster-apps` tree walk like every other domain.
- **`dev-env` app** (`kubernetes/main/apps/dev/dev-env/`):
  - Deployment (Recreate, 1 replica) on `ghcr.io/thaynes43/dev-env:0.1.0@sha256:95e9…` — tmux server + code-server on 8443, `HOME=/home/dev`, `CLAUDE_CONFIG_DIR`/`CODEX_HOME` set per the saga sketch.
  - **PVC** `dev-env-home` 50Gi ceph-block, `prune: disabled`, deliberately **no VolSync** (Decision #7 — credentials stay out of S3).
  - **RBAC**: read-only PoC tier (reuses the `upgrade-health-gate` ClusterRole, shepherd pattern). Operator tier is backlog 05, its own reviewed change.
  - **CNP**: default-deny, enumerated egress (github/ghcr, anthropic + claude.ai for `/remote-control`, openai/chatgpt, npm/pypi, Open VSX, kube-apiserver); **ingress only from traefik-internal → 8443**.
  - **IngressRoute**: `dev-env.haynesops.com` on traefik-internal + Authentik **embedded-outpost** forward-auth middleware. Not tunnel-published (Decision #6).
- **Authentik blueprint `50-dev-env.yaml`** (config-as-code, PLAN-011 pattern): Proxy Provider (`forward_single`) + Application + **embedded outpost provider assignment**. The embedded outpost carries no providers today (headlamp/paperless ride the named outposts), so nothing is clobbered — but the blueprint now owns that list (noted loudly in the file).
- **Cert**: `dev` added to the `certificate-haynesops` reflector allowlist.

### Safety notes

- code-server runs `--auth none` — gated by BOTH the forward-auth middleware and the CNP ingress rule (traefik-internal pods only). Fail-closed until the blueprint applies.
- No secrets are mounted in this PoC (auth ceremonies are backlog 04); the pod's only credential is the read-only SA token.
- kustomize builds validated locally for all three touched trees; flux-local diffs both clusters in CI.

### Verification plan (post-merge)

1. `flux reconcile ks cluster-apps`, then `dev-env` ks Ready; pod Running.
2. Blueprint applied: worker logs + provider/application/outpost visible.
3. In-pod: `kubectl get nodes` (read-only SA), `git clone` haynes-ops, `claude --version`/`codex --version`.
4. Browser: `https://dev-env.haynesops.com` → Authentik login → code-server (LAN check by Tom later; fail-closed otherwise).
5. CNP: confirm no unexpected Hubble drops for the enumerated flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6
