### PR TITLE
feat(dev-env): image 0.2.0 — codex 0.144.3 (device-auth), claude 2.1.207

### DIFF
--- a/.github/workflows/dev-env-build.yml
+++ b/.github/workflows/dev-env-build.yml
@@ -48,7 +48,7 @@ jobs:
           file: ./scripts/dev-env/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/dev-env:0.1.0
+            ghcr.io/${{ github.repository_owner }}/dev-env:0.2.0
             ghcr.io/${{ github.repository_owner }}/dev-env:latest
 
       # Keyless sign by DIGEST (covers both tags — they share the manifest). Verified

--- a/scripts/dev-env/Dockerfile
+++ b/scripts/dev-env/Dockerfile
@@ -40,9 +40,9 @@ ARG CODE_SERVER_VERSION=4.96.4
 # renovate: datasource=github-releases depName=astral-sh/uv
 ARG UV_VERSION=0.5.24
 # renovate: datasource=npm depName=@anthropic-ai/claude-code
-ARG CLAUDE_CODE_VERSION=2.1.197
+ARG CLAUDE_CODE_VERSION=2.1.207
 # renovate: datasource=npm depName=@openai/codex
-ARG CODEX_VERSION=0.42.0
+ARG CODEX_VERSION=0.144.3
 # renovate: datasource=npm depName=tsx
 ARG TSX_VERSION=4.19.2
 # renovate: datasource=npm depName=pnpm


### PR DESCRIPTION
Bumps the two agent CLIs: codex 0.42.0 → 0.144.3 (0.42.0 predates the device-code auth flow needed for in-pod phone-driven login) and claude-code 2.1.197 → 2.1.207. Workflow tag 0.1.0 → 0.2.0. HR digest pin follows in a separate PR once the image builds (appdaemon-style flow). Part of saga plan 04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6