### PR TITLE
fix(dev-env): roll to 0.2.0; ndots:1 + claude.com egress (claude-code startup fix)

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
           app:
             image:
               repository: ghcr.io/thaynes43/dev-env
-              tag: 0.1.0@sha256:95e9919f3f10724b31cf4586227ae5aefd5fc9adbc7c49675a1c290eeca296e8
+              tag: 0.2.0@sha256:c5970b0b3d75af3380e4cb019237cf2118162d5461bb941fad92928f2046cbd9
             command: ["/bin/bash", "-c"]
             args:
               # tmux server first (agent sessions survive browser/exec disconnects;
@@ -63,6 +63,16 @@ spec:
                 drop: ["ALL"]
     defaultPodOptions:
       automountServiceAccountToken: true   # in-cluster kubectl via the dev-env SA
+      # ndots:1 — external names resolve directly instead of first expanding through
+      # the cluster search domains (api.anthropic.com.dev.svc.cluster.local…), which
+      # the CNP DNS allowlist refuses (Cilium `*` is single-label) and Node/c-ares
+      # treats a REFUSED as fatal EREFUSED (claude-code startup failure, proven via
+      # Hubble 2026-07-13). In-cluster targets must use FQDNs (kubectl is unaffected
+      # — in-cluster config connects to KUBERNETES_SERVICE_HOST, an IP).
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
@@ -46,11 +46,15 @@ spec:
               - matchPattern: "*.github.com"
               - matchPattern: "*.githubusercontent.com"
               - matchName: "ghcr.io"
-              # Anthropic: API + claude.ai (/remote-control relay) + statsig etc.
+              # Anthropic: API + claude.ai (/remote-control relay) + claude.com
+              # (platform.claude.com — claude-code startup checks, proven via Hubble
+              # 2026-07-13) + statsig etc.
               - matchName: "anthropic.com"
               - matchPattern: "*.anthropic.com"
               - matchName: "claude.ai"
               - matchPattern: "*.claude.ai"
+              - matchName: "claude.com"
+              - matchPattern: "*.claude.com"
               # OpenAI: Codex API + ChatGPT-plan auth/backend
               - matchName: "openai.com"
               - matchPattern: "*.openai.com"
@@ -82,6 +86,8 @@ spec:
         - matchPattern: "*.anthropic.com"
         - matchName: "claude.ai"
         - matchPattern: "*.claude.ai"
+        - matchName: "claude.com"
+        - matchPattern: "*.claude.com"
         - matchName: "openai.com"
         - matchPattern: "*.openai.com"
         - matchName: "chatgpt.com"


### PR DESCRIPTION
Rolls the dev-env pod to image 0.2.0 (codex 0.144.3 device-auth, claude 2.1.207) and fixes the two Hubble-diagnosed claude-code startup blockers: **ndots:1** dnsConfig (search-domain expansion of external names hit the CNP DNS allowlist as REFUSED, fatal to Node/c-ares) and **claude.com egress** (claude-code startup calls platform.claude.com, only claude.ai/anthropic.com were allowed). Saga plan 04 unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6