### PR TITLE
feat(dev-env): GitOps'd agent configs + MCP first wave (saga plan 03)

### DIFF
--- a/.agents/sagas/dev-env/backlog/03-agent-configs.md
+++ b/.agents/sagas/dev-env/backlog/03-agent-configs.md
@@ -1,8 +1,18 @@
 # 03 — GitOps-managed agent configs (.claude / .codex)
 
-**Status:** backlog
+**Status:** in review (branch `dev-env/03-configs-deploy`; image 0.3.0 with
+playwright+chromium merged via PR #2035)
 **Depends on:** 02
 **Parallel with:** 04, 05
+
+**MCP first wave (Tom-approved 2026-07-13):** home-assistant (cluster-local
+ha-mcp.home-automation.svc:8086, secret path via the existing `ha-mcp` 1P item),
+grafana-mcp (cluster-local mcp-grafana.observability.svc:8000/mcp), playwright
+(headless chromium baked into image 0.3.0 — for UI/UX testing of cluster apps via
+traefik-internal). **mcp-unifi**: approved but STUBBED — the exact server
+package/config Tom previously used is unrecoverable from this Mac; do not guess a
+community package (supply-chain risk) — needs Tom's pointer, then wire like the
+others. **outline**: deferred (not selected). Codex MCP parity: follow-up.
 
 ## Goal
 

--- a/kubernetes/main/apps/dev/dev-env/app/externalsecret.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# MCP secrets for the GitOps'd agent config (saga plan 03). Reuses the EXISTING
+# 1Password items — nothing new to provision:
+#   ha-mcp/MCP_SECRET_PATH — the private path segment of the in-cluster HA MCP
+#   endpoint (same item the ha-mcp app itself consumes).
+# dev-init.sh envsubst-expands ${HA_MCP_SECRET_PATH} into the registered MCP URL.
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dev-env-mcp
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: dev-env-mcp-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: HA_MCP_SECRET_PATH
+      remoteRef: { key: ha-mcp, property: MCP_SECRET_PATH }

--- a/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
@@ -17,19 +17,24 @@ spec:
         # PVC is RWO and agent/tmux state doesn't survive a pod swap anyway.
         replicas: 1
         strategy: Recreate
+        annotations:
+          # Config/scripts ConfigMap changes roll the pod (dev-init re-links on boot).
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:
               repository: ghcr.io/thaynes43/dev-env
-              tag: 0.2.0@sha256:c5970b0b3d75af3380e4cb019237cf2118162d5461bb941fad92928f2046cbd9
+              tag: 0.3.0@sha256:3757e8b185a13b13dbe88f83377c902a60b615c5a95978ff8d3a865e2055b877
             command: ["/bin/bash", "-c"]
             args:
-              # tmux server first (agent sessions survive browser/exec disconnects;
-              # /remote-control + agent-run sessions live here), then code-server.
+              # dev-init links GitOps configs into $HOME, then tmux (agent sessions
+              # survive browser/exec disconnects; /remote-control + agent-run
+              # sessions live here), then code-server.
               # --auth none is safe ONLY because ingress is traefik-internal + the
               # Authentik forward-auth middleware AND the CNP restricts ingress to
               # traefik — do not add other ingress paths without adding auth.
               - >-
+                bash /opt/dev-env/scripts/dev-init.sh;
                 tmux new-session -d -s main 2>/dev/null || true;
                 exec code-server
                 --bind-addr 0.0.0.0:8443
@@ -45,6 +50,10 @@ spec:
               DISABLE_AUTOUPDATER: "1"
               DISABLE_ERROR_REPORTING: "1"
               DISABLE_TELEMETRY: "1"
+            envFrom:
+              # HA_MCP_SECRET_PATH — expanded into the MCP URL by dev-init.
+              - secretRef:
+                  name: dev-env-mcp-secret
             probes:
               liveness:
                 enabled: true
@@ -98,3 +107,21 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /tmp
+      # GitOps'd agent configs + init script (auditable in PR diffs, shepherd
+      # pattern). dev-init.sh links/copies these into $HOME on every boot.
+      scripts:
+        type: configMap
+        name: dev-env-scripts
+        defaultMode: 0555
+        globalMounts:
+          - path: /opt/dev-env/scripts
+      config-claude:
+        type: configMap
+        name: dev-env-config-claude
+        globalMounts:
+          - path: /opt/dev-env/config/claude
+      config-codex:
+        type: configMap
+        name: dev-env-config-codex
+        globalMounts:
+          - path: /opt/dev-env/config/codex

--- a/kubernetes/main/apps/dev/dev-env/app/kustomization.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/kustomization.yaml
@@ -6,6 +6,25 @@ components:
 resources:
   - ./pvc.yaml
   - ./rbac.yaml
+  - ./externalsecret.yaml
   - ./networkpolicy.yaml
   - ./ingressroute.yaml
   - ./helmrelease.yaml
+configMapGenerator:
+  # GitOps'd agent configuration (saga plan 03) — the declarative half of
+  # ~/.claude and ~/.codex; mutable auth/state stays on the PVC (dev-init.sh
+  # enforces the split).
+  - name: dev-env-scripts
+    files:
+      - resources/dev-init.sh
+  - name: dev-env-config-claude
+    files:
+      - resources/config/claude/CLAUDE.md
+      - resources/config/claude/mcp.json
+  - name: dev-env-config-codex
+    files:
+      - resources/config/codex/config.toml
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    app.kubernetes.io/name: dev-env

--- a/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
@@ -67,6 +67,40 @@ spec:
               # code-server extension marketplace (Open VSX)
               - matchName: "open-vsx.org"
               - matchName: "openvsxorg.blob.core.windows.net"
+              # our own apps' internal ingress names (playwright UI/UX testing —
+              # traffic goes to the traefik-internal pods, rule 2b)
+              - matchName: "haynesops.com"
+              - matchPattern: "*.haynesops.com"
+              - matchName: "haynesnetwork.com"
+              - matchPattern: "*.haynesnetwork.com"
+    # 2a. Cluster-local MCP servers (saga plan 03): HA + Grafana — the agents'
+    #     introspection tools, reached via svc FQDNs, never the public ingress.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: home-automation
+            app.kubernetes.io/name: ha-mcp
+      toPorts:
+        - ports:
+            - port: "8086"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: mcp-grafana
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+    # 2b. traefik-internal — playwright (headless chromium MCP) drives the cluster's
+    #     own apps for UI/UX testing via their https://<app>.haynesops.com ingress.
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+            app.kubernetes.io/instance: traefik-internal-network
+      toPorts:
+        - ports:
+            - port: "8443"
+              protocol: TCP
     # 2. Kube API server — in-cluster kubectl via kubernetes.default.svc (the whole
     #    point of saga Decision #1).
     - toEntities: [kube-apiserver]

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/claude/CLAUDE.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/claude/CLAUDE.md
@@ -1,0 +1,43 @@
+# You are in the haynes-ops dev-env pod
+
+A 24/7 in-cluster agent workhorse (namespace `dev`, saga: `.agents/sagas/dev-env/`
+in the haynes-ops repo). This file is GitOps-managed — edit it in
+`kubernetes/main/apps/dev/dev-env/app/resources/config/claude/CLAUDE.md`, never here.
+
+## Ground rules
+
+- **Worktree per task.** Never work directly in `~/repos/<name>` (canonical clones).
+  Create `git worktree add ~/work/<task-slug> -b agent/<task-slug>` and work there.
+  Multiple agents share this pod; the canonical clones are fetch-only.
+- **GitOps strictly** for the haynes-ops repo: cluster changes go through git + Flux.
+  The kubectl ServiceAccount here is read-only (operator tier pending, saga plan 05)
+  — do not fight RBAC denials, they are the design.
+- **Never push to main.** Branch + PR, always.
+- Egress is a default-deny allowlist (CiliumNetworkPolicy `dev-env`). If a fetch
+  times out, the domain probably isn't allowlisted — propose adding it via git, do
+  not look for proxies/workarounds.
+
+## Tool auth status (know before you reach)
+
+| Tool | Auth | Notes |
+|---|---|---|
+| claude | ✅ Max plan | credential on PVC, self-refreshes |
+| codex | ✅ ChatGPT plan | `~/.codex/auth.json`, self-refreshes |
+| kubectl / flux | ✅ in-cluster SA | READ-ONLY (get/list/watch) |
+| gh / git push | ❌ NOT YET | haynes-ops-bot wiring is saga plan 04 — `gh` calls will 401 |
+| sops / age | ❌ deliberately absent | the age key never enters this pod without an explicit decision |
+| talosctl / omnictl | ❌ absent | node/Omni ops happen elsewhere (omni-service-account runbook) |
+| terraform/tofu providers | ❌ no cloud creds | plan/validate only |
+
+## MCP servers (GitOps-managed, `~/.config/dev-env/mcp.json`)
+
+- `home-assistant` — cluster-local HA MCP (entities, automations, logs)
+- `grafana-mcp` — PromQL/LogQL, dashboards (cluster-local)
+- `playwright` — headless chromium for UI/UX testing of cluster apps
+  (reach them via their `https://<app>.haynesops.com` internal ingress)
+- UniFi MCP: not wired yet (package pending — saga plan 03 stub)
+
+## Sessions
+
+Run inside tmux (session `main`) so work survives disconnects. For phone-driven
+sessions, start `claude` and use `/remote-control`.

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/claude/mcp.json
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/claude/mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "home-assistant": {
+      "type": "http",
+      "url": "http://ha-mcp.home-automation.svc.cluster.local:8086/${HA_MCP_SECRET_PATH}"
+    },
+    "grafana-mcp": {
+      "type": "http",
+      "url": "http://mcp-grafana.observability.svc.cluster.local:8000/mcp"
+    },
+    "playwright": {
+      "command": "mcp-server-playwright",
+      "args": ["--browser", "chromium", "--headless"]
+    }
+  }
+}

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/codex/config.toml
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/codex/config.toml
@@ -1,0 +1,11 @@
+# Codex config for the dev-env pod — GitOps-managed (edit in
+# kubernetes/main/apps/dev/dev-env/app/resources/config/codex/config.toml).
+# dev-init.sh copies this over ~/.codex/config.toml on every pod boot;
+# ~/.codex/auth.json (ChatGPT-plan credential) lives on the PVC and is never touched.
+
+# Worktree-per-task and never-push-main rules mirror the Claude-side CLAUDE.md.
+# MCP parity (home-assistant / grafana / playwright) is a saga plan 03 follow-up —
+# codex MCP wiring differs enough from claude's that it lands separately.
+
+[history]
+persistence = "save-all"

--- a/kubernetes/main/apps/dev/dev-env/app/resources/dev-init.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/dev-init.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# dev-init — runs at pod start (before code-server) to link the GitOps-managed agent
+# configs into the PVC-backed $HOME. Idempotent; NEVER touches mutable auth/state
+# (~/.claude/.credentials.json, ~/.codex/auth.json, history, caches).
+# Mounted from the dev-env-scripts ConfigMap; source of truth is
+# kubernetes/main/apps/dev/dev-env/app/resources/ (auditable in PR diffs).
+set -uo pipefail
+
+CFG=/opt/dev-env/config
+log() { printf 'dev-init: %s\n' "$*"; }
+
+mkdir -p "$HOME/.claude" "$HOME/.codex" "$HOME/.config/dev-env" "$HOME/repos" "$HOME/work"
+
+# ── Claude: global memory + MCP config ──────────────────────────────────────────
+# CLAUDE.md symlinks (live-updates with the ConfigMap); the MCP config is COPIED to
+# a stable path with env placeholders EXPANDED (claude reads ${VAR} in .mcp.json
+# itself, but registering via `claude mcp add-json` stores the resolved URL — the
+# secret path env only exists in this pod, which is the point).
+ln -sf "$CFG/claude/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
+cp -f "$CFG/claude/mcp.json" "$HOME/.config/dev-env/mcp.json"
+
+# Register the GitOps-defined MCP servers at user scope so EVERY claude invocation
+# (any repo, any worktree) sees them. remove-then-add = declarative overwrite; a
+# server Tom removes from git therefore disappears here on the next boot.
+if command -v claude >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  for name in $(jq -r '.mcpServers | keys[]' "$CFG/claude/mcp.json"); do
+    spec="$(jq -c --arg n "$name" '.mcpServers[$n]' "$CFG/claude/mcp.json")"
+    # Expand ${VAR} references from this pod's env (ExternalSecret-fed).
+    spec="$(printf '%s' "$spec" | envsubst)"
+    claude mcp remove -s user "$name" >/dev/null 2>&1 || true
+    claude mcp add-json -s user "$name" "$spec" >/dev/null 2>&1 \
+      && log "mcp '$name' registered" || log "WARN mcp '$name' registration failed"
+  done
+fi
+
+# ── Codex: declarative config, auth untouched ───────────────────────────────────
+cp -f "$CFG/codex/config.toml" "$HOME/.codex/config.toml"
+
+log "done"


### PR DESCRIPTION
Delivers plan 03: the declarative half of ~/.claude and ~/.codex now lives in git (ConfigMaps + dev-init.sh boot linking; auth/state stays PVC-only). MCP first wave (Tom-approved): **home-assistant** (cluster-local, secret path from the existing ha-mcp 1Password item), **grafana-mcp** (cluster-local), **playwright** (chromium baked into image 0.3.0, drives cluster apps through traefik-internal for UI/UX testing). **unifi** stubbed pending the exact package pointer; **outline** deferred. Pod CLAUDE.md documents worktree rules + which CLI tools still lack auth (gh/sops/talosctl). CNP gains the two MCP service routes + traefik-internal:8443 + haynesops/haynesnetwork DNS names. Rolls the pod to 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6