### PR TITLE
fix(dev-env): MCP wiring — playwright bin name, HA path slash, svc FQDN DNS

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
@@ -41,6 +41,12 @@ spec:
             dns:
               - matchPattern: "*.cluster.local"
               - matchPattern: "*.svc"
+              # Multi-label svc FQDNs need EXACT names — Cilium `*` is single-label,
+              # so `*.cluster.local` does NOT match name.ns.svc.cluster.local (the
+              # same trap the shepherd hit with the Prometheus FQDN; re-proven here
+              # via `claude mcp list` failures 2026-07-13).
+              - matchName: "ha-mcp.home-automation.svc.cluster.local"
+              - matchName: "mcp-grafana.observability.svc.cluster.local"
               # git + gh + release notes + ghcr blobs
               - matchName: "github.com"
               - matchPattern: "*.github.com"

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/claude/mcp.json
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/claude/mcp.json
@@ -2,14 +2,14 @@
   "mcpServers": {
     "home-assistant": {
       "type": "http",
-      "url": "http://ha-mcp.home-automation.svc.cluster.local:8086/${HA_MCP_SECRET_PATH}"
+      "url": "http://ha-mcp.home-automation.svc.cluster.local:8086${HA_MCP_SECRET_PATH}"
     },
     "grafana-mcp": {
       "type": "http",
       "url": "http://mcp-grafana.observability.svc.cluster.local:8000/mcp"
     },
     "playwright": {
-      "command": "mcp-server-playwright",
+      "command": "playwright-mcp",
       "args": ["--browser", "chromium", "--headless"]
     }
   }


### PR DESCRIPTION
Three live-debugged fixes from the first `claude mcp list` health check: the @playwright/mcp global bin is `playwright-mcp` (not mcp-server-playwright); the ha-mcp 1P secret path is slash-prefixed (URL had `//`); and cluster-svc FQDN DNS lookups were refused because Cilium wildcards are single-label — exact matchNames added (same class as the shepherd's Prometheus-FQDN gotcha). Saga plan 03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6