### PR TITLE
feat(dev-env): wire mcp-unifi (in-cluster SSE) into the agent MCP set

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
@@ -47,6 +47,7 @@ spec:
               # via `claude mcp list` failures 2026-07-13).
               - matchName: "ha-mcp.home-automation.svc.cluster.local"
               - matchName: "mcp-grafana.observability.svc.cluster.local"
+              - matchName: "mcp-unifi.observability.svc.cluster.local"
               # git + gh + release notes + ghcr blobs
               - matchName: "github.com"
               - matchPattern: "*.github.com"
@@ -96,6 +97,14 @@ spec:
       toPorts:
         - ports:
             - port: "8000"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+            app.kubernetes.io/name: mcp-unifi
+      toPorts:
+        - ports:
+            - port: "3000"
               protocol: TCP
     # 2b. traefik-internal — playwright (headless chromium MCP) drives the cluster's
     #     own apps for UI/UX testing via their https://<app>.haynesops.com ingress.

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/claude/CLAUDE.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/claude/CLAUDE.md
@@ -35,7 +35,9 @@ in the haynes-ops repo). This file is GitOps-managed — edit it in
 - `grafana-mcp` — PromQL/LogQL, dashboards (cluster-local)
 - `playwright` — headless chromium for UI/UX testing of cluster apps
   (reach them via their `https://<app>.haynesops.com` internal ingress)
-- UniFi MCP: not wired yet (package pending — saga plan 03 stub)
+- `mcp-unifi` — read-only UniFi/UDM introspection (clients, RSSI, topology;
+  cluster-local SSE). Gotcha: per-site tools want the legacy site code `default`
+  (`internalReference`), not the UUID from `list_sites`.
 
 ## Sessions
 

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/claude/mcp.json
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/claude/mcp.json
@@ -8,6 +8,10 @@
       "type": "http",
       "url": "http://mcp-grafana.observability.svc.cluster.local:8000/mcp"
     },
+    "mcp-unifi": {
+      "type": "sse",
+      "url": "http://mcp-unifi.observability.svc.cluster.local:3000/sse"
+    },
     "playwright": {
       "command": "playwright-mcp",
       "args": ["--browser", "chromium", "--headless"]


### PR DESCRIPTION
Tom's pointer was right — the UniFi MCP is already in-cluster (observability/mcp-unifi, unifi-mcp-server 0.2.6). Probing showed SSE transport (/sse 200, /mcp 404), so it registers as `type: sse` at the cluster-local service; CNP gains the endpoint + exact svc-FQDN DNS rules. No client-side secret (UniFi API key is server-side). Completes the plan-03 MCP wave: ha ✔ grafana ✔ playwright ✔ unifi ✔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6