### PR TITLE
feat(dev-env): operator-tier RBAC (saga plan 05)

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/rbac.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/rbac.yaml
@@ -1,9 +1,105 @@
 ---
-# PoC tier (saga backlog 02): READ-ONLY cluster access via the gate's shared
-# ClusterRole (get/list/watch; no secrets/exec/log/write) — the same reuse the
-# shepherd does. The decided end-state is the OPERATOR tier (read-all + targeted
-# writes: pod delete, rollout-restart patch, Flux reconcile annotations, Job create,
-# CronJob suspend) — that lands as its own reviewed change in backlog 05, NOT here.
+# OPERATOR tier (saga Decision #1, plan 05) — the breadth Claude actually uses from
+# the Mac, minus the dangerous parts. Two halves:
+#   READ: core group ENUMERATED WITHOUT SECRETS (RBAC can't except a resource from a
+#         wildcard, and secrets-read is explicitly withheld) + wildcard read of every
+#         NON-core group (secrets live only in core, so this is safe breadth — and it
+#         passes restrict-rbac-escalation, which only denies '*' verbs + '*' resources
+#         together).
+#   WRITE: the targeted GitOps-legal mutations ONLY — restart pods, rollout-restart
+#         workloads, Flux reconcile/suspend (patch = annotations + spec.suspend),
+#         create/delete Jobs (volsync unlock), suspend CronJobs. NO exec, NO secrets,
+#         NO RBAC/node/namespace/CRD mutation. Writes go through git; this is the
+#         "restart/reconcile/verify" loop, not a deploy path.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dev-env-operator
+  labels:
+    app.kubernetes.io/name: dev-env
+rules:
+  # Core group read — everything an operator inspects, EXCEPT secrets.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - pods/status
+      - events
+      - nodes
+      - namespaces
+      - services
+      - endpoints
+      - configmaps
+      - persistentvolumeclaims
+      - persistentvolumes
+      - serviceaccounts
+      - resourcequotas
+      - limitranges
+    verbs: [get, list, watch]
+  # Non-core groups: wildcard READ (no secrets outside core; add groups as the
+  # cluster grows — unknown-group denials are the signal).
+  - apiGroups:
+      - admissionregistration.k8s.io
+      - apiextensions.k8s.io
+      - apps
+      - apps.emqx.io
+      - autoscaling
+      - batch
+      - ceph.rook.io
+      - cert-manager.io
+      - cilium.io
+      - coordination.k8s.io
+      - discovery.k8s.io
+      - dragonflydb.io
+      - external-secrets.io
+      - gateway.networking.k8s.io
+      - helm.toolkit.fluxcd.io
+      - kustomize.toolkit.fluxcd.io
+      - kyverno.io
+      - metrics.k8s.io
+      - monitoring.coreos.com
+      - networking.k8s.io
+      - node.k8s.io
+      - notification.toolkit.fluxcd.io
+      - objectbucket.io
+      - policy
+      - postgresql.cnpg.io
+      - rbac.authorization.k8s.io
+      - snapshot.storage.k8s.io
+      - source.toolkit.fluxcd.io
+      - storage.k8s.io
+      - traefik.io
+      - volsync.backube
+    resources: ["*"]
+    verbs: [get, list, watch]
+  # ── Targeted writes ──
+  # Restart a wedged/stale pod (the delete-and-let-the-controller-recreate loop).
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [delete]
+  # `kubectl rollout restart` = patching the restartedAt annotation.
+  - apiGroups: [apps]
+    resources: [deployments, statefulsets, daemonsets]
+    verbs: [patch]
+  # `flux reconcile` = annotating; suspend/resume = spec.suspend patch. Sources too
+  # (--with-source).
+  - apiGroups: [kustomize.toolkit.fluxcd.io]
+    resources: [kustomizations]
+    verbs: [patch]
+  - apiGroups: [helm.toolkit.fluxcd.io]
+    resources: [helmreleases]
+    verbs: [patch]
+  - apiGroups: [source.toolkit.fluxcd.io]
+    resources: [gitrepositories, ocirepositories, helmrepositories, helmcharts, buckets]
+    verbs: [patch]
+  # Manual Jobs (volsync unlock/restore runbooks) + CronJob suspend kill-switches.
+  - apiGroups: [batch]
+    resources: [jobs]
+    verbs: [create, delete]
+  - apiGroups: [batch]
+    resources: [cronjobs]
+    verbs: [patch]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,7 +110,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: upgrade-health-gate # the shared read-only role (defined by the gate)
+  name: dev-env-operator
 subjects:
   - kind: ServiceAccount
     name: *app

--- a/kubernetes/main/apps/dev/dev-env/ks.yaml
+++ b/kubernetes/main/apps/dev/dev-env/ks.yaml
@@ -11,8 +11,8 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: upgrade-health-gate # PoC reuses its read-only ClusterRole (backlog 05 = operator tier)
-      namespace: upgrade-agent
+    - name: external-secrets-stores # dev-env-mcp ExternalSecret needs the 1P store
+      namespace: external-secrets
   path: ./kubernetes/main/apps/dev/dev-env/app
   prune: true
   sourceRef:


### PR DESCRIPTION
Implements Decision #1's operator tier: broad read (core group enumerated WITHOUT secrets; non-core groups wildcard-read — Kyverno's restrict-rbac-escalation only denies *-verbs+*-resources together) plus exactly the targeted writes the Mac workflow uses: pod delete (restart), rollout-restart patches, Flux reconcile/suspend patches (incl. sources for --with-source), Job create/delete (volsync runbooks), CronJob suspend. Explicitly withheld: exec, secrets, RBAC/node/namespace/CRD mutation. Post-merge verification: allow+deny matrix from inside the pod + Kyverno PolicyReport check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6