### PR TITLE
fix(dev-env): rename CRB to dev-env-operator — roleRef is immutable

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/rbac.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/rbac.yaml
@@ -103,15 +103,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: &app dev-env
+  # Named after the ROLE, not the app: CRB roleRef is immutable, so re-tiering the
+  # SA's power means a NEW binding name (the old one gets pruned) — changing roleRef
+  # in place wedges the Flux apply (hit live 2026-07-13).
+  name: dev-env-operator
   labels:
-    app.kubernetes.io/instance: *app
-    app.kubernetes.io/name: *app
+    app.kubernetes.io/instance: dev-env
+    app.kubernetes.io/name: dev-env
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: dev-env-operator
 subjects:
   - kind: ServiceAccount
-    name: *app
+    name: dev-env
     namespace: dev


### PR DESCRIPTION
Flux couldn't apply the re-tiered binding (`cannot change roleRef`, dry-run Invalid). New binding name; the old one prunes. Comment in rbac.yaml records the trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6