### PR TITLE
feat(dev-env): gh-bot sidecar + auth expiry watch + agent-run dispatcher (plans 04+06)

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/externalsecret.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/externalsecret.yaml
@@ -19,3 +19,45 @@ spec:
   data:
     - secretKey: HA_MCP_SECRET_PATH
       remoteRef: { key: ha-mcp, property: MCP_SECRET_PATH }
+---
+# haynes-ops-bot App credentials — mounted ONLY by the gh-refresher sidecar, which
+# mints short-lived ghs_ tokens to /creds. The PEM NEVER enters the agent (app)
+# container (shepherd pattern, saga Decision #5).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dev-env-bot
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: dev-env-bot-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: GITHUB_BOT_APP_ID
+      remoteRef: { key: github-bot, property: GITHUB_BOT_APP_ID }
+    - secretKey: GITHUB_BOT_APP_CLIENT_ID
+      remoteRef: { key: github-bot, property: GITHUB_BOT_APP_CLIENT_ID }
+    - secretKey: GITHUB_BOT_APP_INSTALLATION_ID
+      remoteRef: { key: github-bot, property: GITHUB_BOT_APP_INSTALLATION_ID }
+    - secretKey: GITHUB_BOT_APP_PRIVATE_KEY
+      remoteRef: { key: github-bot, property: GITHUB_BOT_APP_PRIVATE_KEY }
+---
+# Pushover (same item the upgrade gate pages with) — auth-watch sidecar ONLY.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dev-env-watch
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: dev-env-watch-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: PUSHOVER_TOKEN
+      remoteRef: { key: upgrade-gate, property: PUSHOVER_TOKEN }
+    - secretKey: PUSHOVER_USER_KEY
+      remoteRef: { key: upgrade-gate, property: PUSHOVER_USER_KEY }

--- a/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
@@ -70,6 +70,52 @@ spec:
               readOnlyRootFilesystem: true
               capabilities:
                 drop: ["ALL"]
+          # Mints a fresh haynes-ops-bot ghs_ token to /creds every 40min (1h TTL).
+          # The PEM lives ONLY here; agents read /creds/gh_token per shell (bashrc).
+          gh-refresher:
+            image:
+              repository: ghcr.io/thaynes43/dev-env
+              tag: 0.3.0@sha256:3757e8b185a13b13dbe88f83377c902a60b615c5a95978ff8d3a865e2055b877
+            command: ["/bin/bash", "/opt/dev-env/scripts/gh-token-refresh.sh"]
+            env:
+              # Down-scope the minted token to what agent dev work needs.
+              GITHUB_BOT_TOKEN_PERMISSIONS: '{"contents":"write","pull_requests":"write","checks":"read","actions":"read","issues":"write"}'
+            envFrom:
+              - secretRef:
+                  name: dev-env-bot-secret
+            resources:
+              requests: { cpu: 10m, memory: 32Mi }
+              limits: { memory: 128Mi }
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+          # Daily credential probe (claude/codex/gh) → Pushover page on failure
+          # (saga plan 04 expiry watch).
+          auth-watch:
+            image:
+              repository: ghcr.io/thaynes43/dev-env
+              tag: 0.3.0@sha256:3757e8b185a13b13dbe88f83377c902a60b615c5a95978ff8d3a865e2055b877
+            command: ["/bin/bash", "/opt/dev-env/scripts/auth-check.sh"]
+            env:
+              HOME: /home/dev
+              CLAUDE_CONFIG_DIR: /home/dev/.claude
+              CODEX_HOME: /home/dev/.codex
+              DISABLE_AUTOUPDATER: "1"
+              DISABLE_ERROR_REPORTING: "1"
+              DISABLE_TELEMETRY: "1"
+            envFrom:
+              - secretRef:
+                  name: dev-env-watch-secret
+            resources:
+              requests: { cpu: 10m, memory: 64Mi }
+              limits: { memory: 512Mi }
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
     defaultPodOptions:
       automountServiceAccountToken: true   # in-cluster kubectl via the dev-env SA
       # ndots:1 — external names resolve directly instead of first expanding through
@@ -99,14 +145,27 @@ spec:
           http:
             port: 8443
     persistence:
+      # Container scoping (advancedMounts): the gh-refresher holds the PEM env and
+      # deliberately CANNOT see the home PVC (agent state); agents CANNOT see the
+      # PEM (env-only, no mount). /creds is the only shared surface — the minted
+      # short-lived token.
       home:
         existingClaim: dev-env-home
-        globalMounts:
-          - path: /home/dev
+        advancedMounts:
+          dev-env:
+            app:
+              - path: /home/dev
+            auth-watch:
+              - path: /home/dev
       tmp:
         type: emptyDir
         globalMounts:
           - path: /tmp
+      creds:
+        type: emptyDir
+        medium: Memory
+        globalMounts:
+          - path: /creds
       # GitOps'd agent configs + init script (auditable in PR diffs, shepherd
       # pattern). dev-init.sh links/copies these into $HOME on every boot.
       scripts:
@@ -118,10 +177,14 @@ spec:
       config-claude:
         type: configMap
         name: dev-env-config-claude
-        globalMounts:
-          - path: /opt/dev-env/config/claude
+        advancedMounts:
+          dev-env:
+            app:
+              - path: /opt/dev-env/config/claude
       config-codex:
         type: configMap
         name: dev-env-config-codex
-        globalMounts:
-          - path: /opt/dev-env/config/codex
+        advancedMounts:
+          dev-env:
+            app:
+              - path: /opt/dev-env/config/codex

--- a/kubernetes/main/apps/dev/dev-env/app/kustomization.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/kustomization.yaml
@@ -17,6 +17,10 @@ configMapGenerator:
   - name: dev-env-scripts
     files:
       - resources/dev-init.sh
+      - resources/bashrc.sh
+      - resources/agent-run.sh
+      - resources/gh-token-refresh.sh
+      - resources/auth-check.sh
   - name: dev-env-config-claude
     files:
       - resources/config/claude/CLAUDE.md

--- a/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
@@ -80,6 +80,8 @@ spec:
               - matchPattern: "*.haynesops.com"
               - matchName: "haynesnetwork.com"
               - matchPattern: "*.haynesnetwork.com"
+              # auth-watch pages via Pushover
+              - matchName: "api.pushover.net"
     # 2a. Cluster-local MCP servers (saga plan 03): HA + Grafana — the agents'
     #     introspection tools, reached via svc FQDNs, never the public ingress.
     - toEndpoints:
@@ -146,6 +148,7 @@ spec:
         - matchName: "files.pythonhosted.org"
         - matchName: "open-vsx.org"
         - matchName: "openvsxorg.blob.core.windows.net"
+        - matchName: "api.pushover.net"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# agent-run — worktree-per-task agent dispatcher (saga plan 06). Isolation by
+# construction: every task gets its own git worktree + branch + tmux session + log;
+# concurrent agents in the same repo never collide. GitOps-managed — edit in
+# kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh.
+#
+#   agent-run run  --repo <name> --agent claude|codex [--base <ref>] -p "<task>"
+#   agent-run run  --repo <name> --agent claude --interactive   # tmux session, no task
+#   agent-run list                                              # live tasks
+#   agent-run attach <task-id>                                  # tmux attach
+#   agent-run reap   <task-id> [--force]                        # kill + cleanup
+set -uo pipefail
+
+REPOS="$HOME/repos" WORK="$HOME/work" OWNER="thaynes43"
+log() { printf 'agent-run: %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+# Every task shell needs the fresh bot token (bashrc handles interactive shells;
+# tmux run-shell strings need it inline).
+token_env='export GH_TOKEN="$(cat /creds/gh_token 2>/dev/null)"'
+
+cmd="${1:-help}"; shift || true
+
+case "$cmd" in
+  run)
+    repo="" agent="" base="" prompt="" interactive=0
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --repo) repo="$2"; shift 2 ;;
+        --agent) agent="$2"; shift 2 ;;
+        --base) base="$2"; shift 2 ;;
+        -p|--prompt) prompt="$2"; shift 2 ;;
+        --interactive) interactive=1; shift ;;
+        *) die "unknown flag $1" ;;
+      esac
+    done
+    [ -n "$repo" ] || die "--repo required"
+    case "$agent" in claude|codex) : ;; *) die "--agent must be claude|codex" ;; esac
+    [ "$interactive" = 1 ] || [ -n "$prompt" ] || die "need -p or --interactive"
+
+    # Canonical clone: fetch-only, never worked in directly.
+    if [ ! -d "$REPOS/$repo/.git" ]; then
+      log "cloning $OWNER/$repo…"
+      GIT_TERMINAL_PROMPT=0 git clone "https://github.com/$OWNER/$repo" "$REPOS/$repo" \
+        || die "clone failed (private repo not granted to haynes-ops-bot?)"
+    fi
+    git -C "$REPOS/$repo" fetch origin --prune || die "fetch failed"
+    [ -n "$base" ] || base="origin/$(git -C "$REPOS/$repo" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | cut -d/ -f2 || echo main)"
+
+    id="${repo}-$(date +%m%d-%H%M%S)"
+    wt="$WORK/$id"
+    git -C "$REPOS/$repo" worktree add "$wt" -b "agent/$id" "$base" >/dev/null \
+      || die "worktree add failed"
+    log "task $id  worktree=$wt  branch=agent/$id  base=$base"
+
+    guard="You are working in an isolated git worktree ($wt) on branch agent/$id. \
+Stay inside it. NEVER push to main — commit to agent/$id, push that branch, and \
+open a PR with 'gh pr create' when the task is complete. If blocked, write \
+BLOCKED and the reason as your final message."
+
+    case "$agent" in
+      claude) run_cmd="claude --dangerously-skip-permissions --append-system-prompt \"\$AGENT_GUARD\" -p \"\$AGENT_PROMPT\" --output-format text" ;;
+      codex)  run_cmd="codex exec --dangerously-bypass-approvals-and-sandbox \"\$AGENT_GUARD \$AGENT_PROMPT\"" ;;
+    esac
+
+    tmux new-session -d -s "task-$id" -c "$wt" || die "tmux session failed"
+    if [ "$interactive" = 1 ]; then
+      tmux send-keys -t "task-$id" "$token_env; cd $wt; $agent" Enter
+      log "interactive session ready: agent-run attach $id"
+    else
+      # Env-var indirection keeps the prompt out of shell-quoting hell; log to
+      # $WORK/<id>.log for post-hoc review (reap keeps the log).
+      tmux send-keys -t "task-$id" "AGENT_GUARD=$(printf '%q' "$guard") AGENT_PROMPT=$(printf '%q' "$prompt"); $token_env" Enter
+      tmux send-keys -t "task-$id" "$run_cmd 2>&1 | tee $WORK/$id.log; echo TASK-EXIT:\$? >> $WORK/$id.log" Enter
+      log "dispatched. follow: agent-run attach $id   log: $WORK/$id.log"
+    fi
+    printf '%s\n' "$id"
+    ;;
+  list)
+    printf 'TMUX SESSIONS:\n'; tmux ls 2>/dev/null | grep '^task-' || printf '  (none)\n'
+    printf 'WORKTREES:\n'
+    for r in "$REPOS"/*/; do [ -d "$r/.git" ] && git -C "$r" worktree list | grep "$WORK" || true; done
+    ;;
+  attach)
+    [ -n "${1:-}" ] || die "attach <task-id>"
+    exec tmux attach -t "task-$1"
+    ;;
+  reap)
+    id="${1:-}"; [ -n "$id" ] || die "reap <task-id> [--force]"
+    force=""; [ "${2:-}" = "--force" ] && force="--force"
+    tmux kill-session -t "task-$id" 2>/dev/null && log "session killed" || log "no session"
+    repo="${id%%-[0-9]*}"
+    if [ -d "$WORK/$id" ]; then
+      git -C "$REPOS/$repo" worktree remove $force "$WORK/$id" \
+        && log "worktree removed" \
+        || die "worktree dirty — commit/push first or reap --force"
+    fi
+    git -C "$REPOS/$repo" branch -D "agent/$id" 2>/dev/null || true
+    log "reaped $id (log kept at $WORK/$id.log)"
+    ;;
+  *)
+    sed -n '3,10p' "$0"; exit 1
+    ;;
+esac

--- a/kubernetes/main/apps/dev/dev-env/app/resources/auth-check.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/auth-check.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# auth-watch sidecar — daily credential-freshness probe (saga plan 04): pages
+# Pushover BEFORE an expired credential strands a dispatched agent. Distinguishes
+# auth failure (page) from rate-limit (expected on a busy plan — NOT a page).
+set -uo pipefail
+log() { printf 'auth-watch: %s %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+page() { # $1 title, $2 message — priority 0, best-effort
+  curl -sf --max-time 10 https://api.pushover.net/1/messages.json \
+    --form-string "token=${PUSHOVER_TOKEN}" \
+    --form-string "user=${PUSHOVER_USER_KEY}" \
+    --form-string "title=$1" \
+    --form-string "message=$2" >/dev/null \
+    && log "paged: $1" || log "WARN pushover send failed"
+}
+
+while true; do
+  sleep 60   # let the pod settle on boot before the first probe
+  fails=""
+
+  # Claude (Max plan): a minimal real call. Auth errors mention login/OAuth/401;
+  # rate-limit output mentions limit — treat only the former as failure.
+  out="$(timeout 120 claude -p 'ok' --model haiku --max-turns 1 2>&1)" || true
+  if printf '%s' "$out" | grep -qiE 'not logged in|/login|oauth|401|invalid.*(token|api key)'; then
+    fails="${fails}claude: auth invalid — rerun the ceremony in .agents/sagas/dev-env/backlog/04-auth.md\n"
+  fi
+
+  # Codex (ChatGPT plan)
+  codex login status >/dev/null 2>&1 \
+    || fails="${fails}codex: not logged in — device-auth ceremony needed\n"
+
+  # gh bot token: file freshness (refresher alive) + a real API round-trip.
+  if [ ! -s /creds/gh_token ] || [ -n "$(find /creds/gh_token -mmin +120 2>/dev/null)" ]; then
+    fails="${fails}gh: /creds/gh_token missing or stale (>2h) — refresher sidecar dead?\n"
+  elif ! curl -sf --max-time 10 -H "Authorization: Bearer $(cat /creds/gh_token)" \
+         https://api.github.com/installation/repositories >/dev/null; then
+    fails="${fails}gh: bot token rejected by the GitHub API\n"
+  fi
+
+  if [ -n "$fails" ]; then
+    page "dev-env credential failure" "$(printf '%b' "$fails")"
+  else
+    log "all credentials healthy (claude/codex/gh)"
+  fi
+  sleep 86340
+done

--- a/kubernetes/main/apps/dev/dev-env/app/resources/bashrc.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/bashrc.sh
@@ -1,0 +1,8 @@
+# dev-env shell defaults — sourced from ~/.bashrc (dev-init wires this up).
+# GitOps-managed: kubernetes/main/apps/dev/dev-env/app/resources/bashrc.sh
+
+# Fresh bot token per shell (the refresher sidecar re-mints every 40min; each Bash
+# tool call / tmux pane is a new shell, so agents never hold a stale token long).
+[ -s /creds/gh_token ] && export GH_TOKEN="$(cat /creds/gh_token)"
+
+export PATH="$HOME/.local/bin:$PATH"

--- a/kubernetes/main/apps/dev/dev-env/app/resources/dev-init.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/dev-init.sh
@@ -36,4 +36,20 @@ fi
 # ── Codex: declarative config, auth untouched ───────────────────────────────────
 cp -f "$CFG/codex/config.toml" "$HOME/.codex/config.toml"
 
+# ── git identity + credentials (saga Decision #5: haynes-ops-bot everywhere) ────
+# Commits author as the bot; pushes/clones read the fresh minted token per call via
+# the credential helper (never a static token in .gitconfig).
+git config --global user.name  "haynes-ops-bot[bot]"
+git config --global user.email "haynes-ops-bot[bot]@users.noreply.github.com"
+git config --global credential."https://github.com".helper \
+  '!f() { echo username=x-access-token; echo "password=$(cat /creds/gh_token)"; }; f'
+git config --global --replace-all safe.directory "$HOME/repos/*"
+
+# ── shell defaults + agent-run on PATH ──────────────────────────────────────────
+mkdir -p "$HOME/.local/bin"
+ln -sf /opt/dev-env/scripts/agent-run.sh "$HOME/.local/bin/agent-run"
+touch "$HOME/.bashrc"
+grep -q 'dev-env/scripts/bashrc.sh' "$HOME/.bashrc" 2>/dev/null \
+  || printf '\n[ -f /opt/dev-env/scripts/bashrc.sh ] && . /opt/dev-env/scripts/bashrc.sh\n' >> "$HOME/.bashrc"
+
 log "done"

--- a/kubernetes/main/apps/dev/dev-env/app/resources/gh-token-refresh.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/gh-token-refresh.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# gh-refresher sidecar — keeps a short-lived (1h) haynes-ops-bot installation token
+# fresh at /creds/gh_token for the app container (saga Decision #5). The PEM lives
+# ONLY in THIS container's env; the agents only ever see the minted ghs_ token.
+# Refresh at 40min < 60min TTL so a token read by a shell is always ≥20min from expiry.
+set -uo pipefail
+log() { printf 'gh-refresher: %s %s\n' "$(date -u +%FT%TZ)" "$*"; }
+
+while true; do
+  if /opt/dev-env/github-app-token.sh > /creds/.gh_token.tmp 2>/tmp/mint.err \
+       && [ -s /creds/.gh_token.tmp ]; then
+    mv /creds/.gh_token.tmp /creds/gh_token
+    log "token refreshed"
+  else
+    log "WARN mint failed: $(tail -c 200 /tmp/mint.err 2>/dev/null)"
+  fi
+  sleep 2400
+done


### PR DESCRIPTION
Makes the pod fully dispatch-ready:

- **gh-refresher sidecar**: mints haynes-ops-bot ghs_ tokens (1h TTL) to /creds every 40min. PEM env lives only in this container, which deliberately has NO home-PVC mount; agents get the token per-shell (bashrc) and via a git credential helper — commits/PRs author as the bot.
- **auth-watch sidecar**: daily claude/codex/gh probe → Pushover page on credential failure (reuses the upgrade-gate 1P item; rate-limits deliberately don't page).
- **agent-run** (plan 06): `agent-run run --repo X --agent claude|codex -p '…'` → fresh worktree + agent/<id> branch + tmux session + log; list/attach/reap lifecycle; yolo agents get an injected worktree-boundary/never-push-main guard prompt. Reap refuses to remove dirty worktrees without --force.
- advancedMounts scoping, two new ExternalSecrets, Pushover egress.

Post-merge verify: token file appears + gh api round-trip as bot, then a real end-to-end dispatch smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6