### PR TITLE
fix(dev-env): write .bash_profile — login shells skipped .bashrc (no skel on PVC home)

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/resources/dev-init.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/dev-init.sh
@@ -51,5 +51,9 @@ ln -sf /opt/dev-env/scripts/agent-run.sh "$HOME/.local/bin/agent-run"
 touch "$HOME/.bashrc"
 grep -q 'dev-env/scripts/bashrc.sh' "$HOME/.bashrc" 2>/dev/null \
   || printf '\n[ -f /opt/dev-env/scripts/bashrc.sh ] && . /opt/dev-env/scripts/bashrc.sh\n' >> "$HOME/.bashrc"
+# The PVC home has no skel files, so login shells (bash -l, ssh-style) would skip
+# .bashrc entirely — standard Debian bridge:
+[ -f "$HOME/.bash_profile" ] \
+  || printf '[ -f ~/.bashrc ] && . ~/.bashrc\n' > "$HOME/.bash_profile"
 
 log "done"


### PR DESCRIPTION
GH_TOKEN was absent in `bash -l` shells: the PVC home was created empty (no /etc/skel copy), so no .bash_profile existed to source .bashrc. dev-init now writes the standard bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6