### PR TITLE
feat(dev-env): switch to haynes-dev-bot identity (Decision #5 revised)

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/externalsecret.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/externalsecret.yaml
@@ -20,9 +20,11 @@ spec:
     - secretKey: HA_MCP_SECRET_PATH
       remoteRef: { key: ha-mcp, property: MCP_SECRET_PATH }
 ---
-# haynes-ops-bot App credentials — mounted ONLY by the gh-refresher sidecar, which
+# haynes-DEV-bot App credentials (Decision #5 REVISED: split identity — the ops bot
+# haynes-ops-bot never enters this pod; dev agents author as haynes-dev-bot, which
+# is installed on ALL repositories). Mounted ONLY by the gh-refresher sidecar, which
 # mints short-lived ghs_ tokens to /creds. The PEM NEVER enters the agent (app)
-# container (shepherd pattern, saga Decision #5).
+# container (shepherd pattern).
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -36,13 +38,13 @@ spec:
     creationPolicy: Owner
   data:
     - secretKey: GITHUB_BOT_APP_ID
-      remoteRef: { key: github-bot, property: GITHUB_BOT_APP_ID }
+      remoteRef: { key: github-dev-bot, property: GITHUB_BOT_APP_ID }
     - secretKey: GITHUB_BOT_APP_CLIENT_ID
-      remoteRef: { key: github-bot, property: GITHUB_BOT_APP_CLIENT_ID }
+      remoteRef: { key: github-dev-bot, property: GITHUB_BOT_APP_CLIENT_ID }
     - secretKey: GITHUB_BOT_APP_INSTALLATION_ID
-      remoteRef: { key: github-bot, property: GITHUB_BOT_APP_INSTALLATION_ID }
+      remoteRef: { key: github-dev-bot, property: GITHUB_BOT_APP_INSTALLATION_ID }
     - secretKey: GITHUB_BOT_APP_PRIVATE_KEY
-      remoteRef: { key: github-bot, property: GITHUB_BOT_APP_PRIVATE_KEY }
+      remoteRef: { key: github-dev-bot, property: GITHUB_BOT_APP_PRIVATE_KEY }
 ---
 # Pushover (same item the upgrade gate pages with) — auth-watch sidecar ONLY.
 apiVersion: external-secrets.io/v1

--- a/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
@@ -70,7 +70,8 @@ spec:
               readOnlyRootFilesystem: true
               capabilities:
                 drop: ["ALL"]
-          # Mints a fresh haynes-ops-bot ghs_ token to /creds every 40min (1h TTL).
+          # Mints a fresh haynes-DEV-bot ghs_ token to /creds every 40min (1h TTL) —
+          # the dev identity, installed on All Repositories (Decision #5 revised).
           # The PEM lives ONLY here; agents read /creds/gh_token per shell (bashrc).
           gh-refresher:
             image:
@@ -80,9 +81,9 @@ spec:
             env:
               # Down-scope the minted token. NOTE: may only name permissions the App
               # itself was GRANTED — requesting ungranted ones (e.g. actions/issues,
-              # tried 2026-07-13) makes the token mint 422. Extend the App's grants
-              # in GitHub settings first, then widen here.
-              GITHUB_BOT_TOKEN_PERMISSIONS: '{"contents":"write","pull_requests":"write","checks":"read"}'
+              # tried 2026-07-13) makes the token mint 422. haynes-dev-bot grants:
+              # contents/PRs/workflows write + checks read.
+              GITHUB_BOT_TOKEN_PERMISSIONS: '{"contents":"write","pull_requests":"write","workflows":"write","checks":"read"}'
             envFrom:
               - secretRef:
                   name: dev-env-bot-secret

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/claude/CLAUDE.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/claude/CLAUDE.md
@@ -24,7 +24,7 @@ in the haynes-ops repo). This file is GitOps-managed — edit it in
 | claude | ✅ Max plan | credential on PVC, self-refreshes |
 | codex | ✅ ChatGPT plan | `~/.codex/auth.json`, self-refreshes |
 | kubectl / flux | ✅ in-cluster SA | READ-ONLY (get/list/watch) |
-| gh / git push | ❌ NOT YET | haynes-ops-bot wiring is saga plan 04 — `gh` calls will 401 |
+| gh / git push | ✅ haynes-dev-bot | App token, all repos, refreshed every 40min; commits/PRs author as the dev bot |
 | sops / age | ❌ deliberately absent | the age key never enters this pod without an explicit decision |
 | talosctl / omnictl | ❌ absent | node/Omni ops happen elsewhere (omni-service-account runbook) |
 | terraform/tofu providers | ❌ no cloud creds | plan/validate only |

--- a/kubernetes/main/apps/dev/dev-env/app/resources/dev-init.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/dev-init.sh
@@ -39,8 +39,8 @@ cp -f "$CFG/codex/config.toml" "$HOME/.codex/config.toml"
 # ── git identity + credentials (saga Decision #5: haynes-ops-bot everywhere) ────
 # Commits author as the bot; pushes/clones read the fresh minted token per call via
 # the credential helper (never a static token in .gitconfig).
-git config --global user.name  "haynes-ops-bot[bot]"
-git config --global user.email "haynes-ops-bot[bot]@users.noreply.github.com"
+git config --global user.name  "haynes-dev-bot[bot]"
+git config --global user.email "haynes-dev-bot[bot]@users.noreply.github.com"
 git config --global credential."https://github.com".helper \
   '!f() { echo username=x-access-token; echo "password=$(cat /creds/gh_token)"; }; f'
 git config --global --replace-all safe.directory "$HOME/repos/*"


### PR DESCRIPTION
The dev pod's GitHub identity becomes the new haynes-dev-bot App (All Repositories; contents/PRs/workflows write, checks read) via the github-dev-bot 1Password item Tom just provisioned. The ops bot's credential leaves the dev pod entirely — haynes-ops-bot stays scoped to haynes-ops failure-reaction work (Shepherd). Post-merge verify: ES syncs, token mints, installation repo count > 1, git identity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6