### PR TITLE
feat(dev-env): image 0.4.0 — pnpm 11.9.0 + PVC playwright cache (haynesnetwork toolchain)

### DIFF
--- a/.github/workflows/dev-env-build.yml
+++ b/.github/workflows/dev-env-build.yml
@@ -48,7 +48,7 @@ jobs:
           file: ./scripts/dev-env/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/dev-env:0.3.0
+            ghcr.io/${{ github.repository_owner }}/dev-env:0.4.0
             ghcr.io/${{ github.repository_owner }}/dev-env:latest
 
       # Keyless sign by DIGEST (covers both tags — they share the manifest). Verified

--- a/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
@@ -74,6 +74,10 @@ spec:
               # code-server extension marketplace (Open VSX)
               - matchName: "open-vsx.org"
               - matchName: "openvsxorg.blob.core.windows.net"
+              # playwright browser downloads — a repo pinning its own @playwright/test
+              # version fetches a matching chromium revision (haynesnetwork e2e).
+              - matchName: "cdn.playwright.dev"
+              - matchPattern: "*.playwright.dev"
               # our own apps' internal ingress names (playwright UI/UX testing —
               # traffic goes to the traefik-internal pods, rule 2b)
               - matchName: "haynesops.com"
@@ -149,6 +153,8 @@ spec:
         - matchName: "open-vsx.org"
         - matchName: "openvsxorg.blob.core.windows.net"
         - matchName: "api.pushover.net"
+        - matchName: "cdn.playwright.dev"
+        - matchPattern: "*.playwright.dev"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/main/apps/dev/dev-env/app/resources/dev-init.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/dev-init.sh
@@ -45,6 +45,16 @@ git config --global credential."https://github.com".helper \
   '!f() { echo username=x-access-token; echo "password=$(cat /creds/gh_token)"; }; f'
 git config --global --replace-all safe.directory "$HOME/repos/*"
 
+# ── playwright browsers: seed the PVC cache from the image's staging dir ────────
+# PLAYWRIGHT_BROWSERS_PATH is on the PVC so repos can add their OWN pinned chromium
+# revision (readOnlyRootFilesystem forbids writing an image path). Seed once; a repo's
+# `playwright install` then adds revisions next to it.
+mkdir -p "$HOME/.cache/ms-playwright"
+if [ -d /opt/dev-env/ms-playwright ] && [ -z "$(ls -A "$HOME/.cache/ms-playwright" 2>/dev/null)" ]; then
+  cp -a /opt/dev-env/ms-playwright/. "$HOME/.cache/ms-playwright/" 2>/dev/null \
+    && log "seeded playwright browsers from image" || log "WARN playwright seed failed"
+fi
+
 # ── shell defaults + agent-run on PATH ──────────────────────────────────────────
 mkdir -p "$HOME/.local/bin"
 ln -sf /opt/dev-env/scripts/agent-run.sh "$HOME/.local/bin/agent-run"

--- a/scripts/dev-env/Dockerfile
+++ b/scripts/dev-env/Dockerfile
@@ -46,7 +46,9 @@ ARG CODEX_VERSION=0.144.3
 # renovate: datasource=npm depName=tsx
 ARG TSX_VERSION=4.19.2
 # renovate: datasource=npm depName=pnpm
-ARG PNPM_VERSION=10.0.0
+# 11.9.0: haynesnetwork pins packageManager pnpm@11.9.0 + engines pnpm>=11 (pnpm 10
+# hard-refuses to install there). Keep >=11 unless every repo drops the pin.
+ARG PNPM_VERSION=11.9.0
 # renovate: datasource=npm depName=@playwright/mcp
 ARG PLAYWRIGHT_MCP_VERSION=0.0.78
 
@@ -165,11 +167,18 @@ RUN npm install -g \
 # Install the browser via the MCP's OWN playwright-core CLI so the chromium build
 # revision matches what the MCP expects (a bare `npx playwright install` can pull a
 # mismatched playwright version).
+#
+# Browsers are STAGED at /opt/dev-env/ms-playwright, not used in place: at runtime
+# PLAYWRIGHT_BROWSERS_PATH points at the PVC (~/.cache/ms-playwright) so a repo whose
+# own playwright pins a DIFFERENT chromium revision (haynesnetwork: @playwright/test
+# 1.61.x) can `playwright install` it alongside — impossible under
+# readOnlyRootFilesystem if the path lived in an image layer. dev-init seeds the PVC
+# cache from this staging dir on first boot, so the MCP works with zero downloads.
 RUN npm install -g "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" \
- && PLAYWRIGHT_BROWSERS_PATH=/usr/local/lib/ms-playwright \
+ && PLAYWRIGHT_BROWSERS_PATH=/opt/dev-env/ms-playwright \
       node "$(npm root -g)/@playwright/mcp/node_modules/playwright-core/cli.js" \
       install --with-deps chromium \
- && chmod -R a+rX /usr/local/lib/ms-playwright \
+ && chmod -R a+rX /opt/dev-env/ms-playwright \
  && npm cache clean --force && rm -rf /var/lib/apt/lists/*
 
 # github-app-token.sh (single source of truth) — used by the token-refresher
@@ -189,6 +198,6 @@ WORKDIR /home/dev
 ENV HOME=/home/dev \
     CLAUDE_CONFIG_DIR=/home/dev/.claude \
     CODEX_HOME=/home/dev/.codex \
-    PLAYWRIGHT_BROWSERS_PATH=/usr/local/lib/ms-playwright \
+    PLAYWRIGHT_BROWSERS_PATH=/home/dev/.cache/ms-playwright \
     PATH=/opt/dev-env:/usr/local/bin:/usr/bin:/bin
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Makes the pod able to build/run/test **haynesnetwork** (Tom's prerequisite before dispatching backlog work):

- **pnpm 11.9.0** — haynesnetwork pins `packageManager: pnpm@11.9.0` with `engines.pnpm >=11`; pnpm 10 refuses to install (verified live in-pod).
- **Playwright browsers move to the PVC** (`~/.cache/ms-playwright`, seeded on boot from an image staging dir). Reason: haynesnetwork's e2e pins @playwright/test 1.61.x, which needs a *different* chromium revision than the MCP's — and it can't install one into an image path under readOnlyRootFilesystem. The MCP still works with zero downloads.
- **CNP**: cdn.playwright.dev egress for those revision downloads.

Follow-up PR pins the digest + verifies install/build/test/e2e end-to-end in-pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6