### PR TITLE
fix(dev-env): raise memory to 24Gi — 8Gi OOMKilled haynesnetwork tests

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
@@ -60,11 +60,16 @@ spec:
               readiness:
                 enabled: true
             resources:
+              # Workhorse sizing: 8Gi OOMKilled haynesnetwork's `pnpm test` (parallel
+              # vitest × embedded Postgres across the monorepo) — and an OOMKill takes
+              # the tmux server with it, killing every in-flight agent session. Nodes
+              # carry ~122Gi, so give real headroom for concurrent agent builds; the
+              # limit is a ceiling, not a reservation.
               requests:
-                cpu: 500m
-                memory: 2Gi
+                cpu: "1"
+                memory: 4Gi
               limits:
-                memory: 8Gi
+                memory: 24Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
Verifying the pod can build/run/test haynesnetwork (Tom's prerequisite) found the real ceiling: `pnpm test` (parallel vitest × embedded Postgres, monorepo-wide) OOMKilled the app container at 8Gi — which also kills the tmux server and every in-flight agent session. Nodes carry ~122Gi allocatable; limits are ceilings, not reservations. Requests 1cpu/4Gi, limit 24Gi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6