### PR TITLE
feat(shepherd): mount the Max-plan token (saga plan 07 Option A — live)

### DIFF
--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/externalsecret.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/externalsecret.yaml
@@ -42,3 +42,23 @@ spec:
   data:
     - secretKey: ANTHROPIC_API_KEY
       remoteRef: { key: anthropic, property: ANTHROPIC_API_KEY }
+---
+# Max-plan credential (saga plan 07 Option A) — `claude setup-token` on Tom's Mac,
+# stored in 1Password. run-shepherd.sh PREFERS this and demotes ANTHROPIC_API_KEY to
+# a rate-limit/auth fallback, so scheduled vets cost $0 in API spend. Mounted
+# optional:true in the HR, so a missing/rotated item degrades to the metered key
+# rather than wedging the run.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: upgrade-shepherd-plan
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: upgrade-shepherd-plan-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: CLAUDE_CODE_OAUTH_TOKEN
+      remoteRef: { key: claude-code, property: CLAUDE_CODE_OAUTH_TOKEN }

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/networkpolicy.yaml
@@ -37,6 +37,15 @@ spec:
               - matchPattern: "*.github.com"
               - matchPattern: "*.githubusercontent.com"
               - matchName: "api.anthropic.com"
+              # Max-plan auth (2026-07-13, saga plan 07): a subscription-authenticated
+              # claude-code ALSO talks to claude.com (platform.claude.com) — with only
+              # api.anthropic.com allowed, the plan path fails and silently falls back
+              # to the metered key (proven in the dev-env pod earlier tonight). Same
+              # vendor, no new trust boundary.
+              - matchName: "claude.com"
+              - matchPattern: "*.claude.com"
+              - matchName: "claude.ai"
+              - matchPattern: "*.claude.ai"
     # 2. Kube API server — read-only diagnosis (kubectl get/describe, flux get).
     - toEntities: [kube-apiserver]
       toPorts:
@@ -65,9 +74,14 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
-    # 5. Anthropic — the LLM API.
+    # 5. Anthropic — the LLM API, plus the Max-plan auth endpoints (claude.com /
+    #    claude.ai) used when the run is served by the subscription token.
     - toFQDNs:
         - matchName: api.anthropic.com
+        - matchName: "claude.com"
+        - matchPattern: "*.claude.com"
+        - matchName: "claude.ai"
+        - matchPattern: "*.claude.ai"
       toPorts:
         - ports:
             - port: "443"

--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/run-shepherd.sh
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/resources/run-shepherd.sh
@@ -341,15 +341,14 @@ case "$MODE" in
     ;;
 esac
 
-# MODEL on the plan path (2026-07-13): Max meters Opus in its OWN weekly bucket,
-# separate from the all-other-models bucket that Tom's interactive work draws from —
-# so running the shepherd on opus protects his interactive weekly headroom. (The
-# rolling 5-hour session window is shared across every model, but the scheduled runs
-# are 4-hourly and mostly land while he's away.) On the API fallback we stay on the
-# cheaper UPGRADE_AGENT_MODEL (sonnet) — opus there costs real money. remediate
-# already picks its own (opus) model and is left alone.
-if [ "$AUTH_PATH" = "plan" ] && [ "$MODE" != "remediate" ]; then
-  MODEL="${UPGRADE_AGENT_PLAN_MODEL:-opus}"
+# MODEL on the plan path (CORRECTED 2026-07-13 by Tom — verified against his account):
+# there is NO separate Opus quota bucket. All models draw the SAME pool, and a heavier
+# model simply eats MORE of the quota Tom's interactive work needs. So the plan path
+# keeps the CHEAP model (UPGRADE_AGENT_MODEL, sonnet) — the goal is the smallest
+# possible bite out of his headroom, not the biggest model we can get away with.
+# UPGRADE_AGENT_PLAN_MODEL can still override per-run if a vet ever needs more.
+if [ "$AUTH_PATH" = "plan" ] && [ "$MODE" != "remediate" ] && [ -n "${UPGRADE_AGENT_PLAN_MODEL:-}" ]; then
+  MODEL="$UPGRADE_AGENT_PLAN_MODEL"
 fi
 
 # Spend guard governs the METERED path only — a plan-served run costs $0 in API spend,


### PR DESCRIPTION
Turns on plan-first auth now that the 1Password `claude-code` item exists.

- **ExternalSecret** → `upgrade-shepherd-plan-secret`; mounted `optional: true` so a rotated or missing item degrades to the metered key instead of wedging a run.
- **Model correction**: Tom verified there is **no separate Opus quota bucket** on his plan — all models draw one pool, so a heavier model simply eats more of the headroom his interactive work needs. The plan path therefore keeps **sonnet** (my earlier opus rationale was based on a wrong premise; the code comment records the correction).
- **CNP**: a subscription-authenticated claude-code also talks to `claude.com` — with only `api.anthropic.com` allowed, the plan path would fail and *silently fall back to the API key*, i.e. the exact opposite of the goal. Same vendor, no new trust boundary.

Verification after merge: summon a dryrun and confirm the log shows `auth=plan` and `spend: $0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6