### PR TITLE
fix(shepherd): mount the plan token on the triage container too

### DIFF
--- a/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
+++ b/kubernetes/main/apps/upgrade-agent/shepherd/app/helmrelease.yaml
@@ -245,11 +245,25 @@ spec:
               UPGRADE_AGENT_MODEL: sonnet
               TRIAGE_MERGE_LOOKBACK_HOURS: "3"
               # ANTHROPIC_API_KEY needed only if triage decides to summon remediate.
+              # Now the FALLBACK — triage runs run-shepherd.sh IN THIS CONTAINER (it
+              # does not spawn a Job), so the plan token must be mounted here too or
+              # the most EXPENSIVE path (remediate: opus, $5/run) would keep billing
+              # the API while the scheduled vets ran free.
               ANTHROPIC_API_KEY:
                 valueFrom:
                   secretKeyRef:
                     name: upgrade-shepherd-llm-secret
                     key: ANTHROPIC_API_KEY
+            envFrom:
+              # Plan-first for remediate too. Safe for the time-critical case
+              # (Decision #2 worried a rate-limited plan would stall a regression
+              # fix): run-shepherd.sh auto-falls-back to the metered key on a
+              # rate-limit/auth failure, so the fix still lands — it just costs money
+              # when the plan is exhausted. remediate keeps opus on BOTH paths;
+              # diagnosis quality is worth more than the quota.
+              - secretRef:
+                  name: upgrade-shepherd-plan-secret
+                  optional: true
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
Gap found while verifying plan 07: triage invokes `run-shepherd.sh` **inside its own container** rather than spawning a Job, so the plan secret has to be mounted there as well. Without it, the *most expensive* path — `remediate` (opus, $5/run) — would keep billing the API key while the cheap scheduled vets ran free on the plan.

Plan-first is safe for remediate despite Decision #2's concern about a rate-limited plan stalling a regression fix: run-shepherd.sh falls back to the metered key automatically on rate-limit/auth failure, so the fix still lands — it just costs money when the plan is exhausted. remediate keeps opus on both paths (diagnosis quality > quota).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6