### PR TITLE
fix(dev-env): move SSO to the internal outpost (embedded outpost's authentik_host is dead)

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/ingressroute.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/ingressroute.yaml
@@ -25,7 +25,10 @@ spec:
     - kind: Rule
       match: Host(`dev-env.haynesops.com`) && PathPrefix(`/`)
       middlewares:
-        - name: ak-outpost-authentik-embedded-outpost
+        # The INTERNAL outpost (same one headlamp uses). NOT the embedded outpost —
+        # its authentik_host points at the nonexistent authentik.haynesops.com and the
+        # login redirect dead-ends (hit live 2026-07-13).
+        - name: ak-outpost-proxy-provider-internal-outpost
           namespace: network
       services:
         - kind: Service

--- a/kubernetes/main/apps/network/authentik/app/blueprints/50-dev-env.yaml
+++ b/kubernetes/main/apps/network/authentik/app/blueprints/50-dev-env.yaml
@@ -1,12 +1,19 @@
 # dev-env saga (.agents/sagas/dev-env/) — forward-auth SSO for the in-cluster dev
 # environment (code-server at dev-env.haynesops.com), config-as-code.
 #
-# Creates the Proxy Provider (forward_single) + Application and assigns the provider
-# to the EMBEDDED outpost. The embedded outpost carries no providers today (headlamp
-# rides proxy-provider-internal-outpost, paperless the external one — see
-# ../../exports/applications.json), so the `providers` list below clobbers nothing.
-# ⚠ This blueprint now OWNS the embedded outpost's provider list: assign any future
-# provider to it HERE (blueprints re-apply on an interval and will revert UI edits).
+# Creates the Proxy Provider (forward_single) + Application and assigns the provider to
+# the INTERNAL outpost — the same one headlamp rides.
+#
+# ⚠ NOT the embedded outpost (tried first, 2026-07-13, and it FAILED): the embedded
+# outpost's authentik_host points at https://authentik.haynesops.com, which DOES NOT
+# EXIST — Authentik is only served at authentik.haynesnetwork.com — so the login
+# redirect dead-ended in "Safari can't find the server". proxy-provider-internal-outpost
+# is the proven path for *.haynesops.com apps.
+#
+# ⚠ This blueprint OWNS proxy-provider-internal-outpost's provider list, and the list is
+# a FULL REPLACEMENT — "Provider for Headlamp" MUST stay in it or headlamp loses its
+# SSO on the next blueprint apply. Add any future internal-outpost provider HERE, not in
+# the UI (blueprints re-apply on an interval and revert UI edits).
 version: 1
 metadata:
   name: dev-env-proxy
@@ -36,7 +43,9 @@ entries:
 - model: authentik_outposts.outpost
   state: present
   identifiers:
-    managed: goauthentik.io/outposts/embedded
+    name: proxy-provider-internal-outpost
   attrs:
     providers:
+    # FULL REPLACEMENT — keep headlamp, or its SSO breaks on the next apply.
+    - !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Headlamp]]
     - !Find [authentik_providers_proxy.proxyprovider, [name, dev-env]]


### PR DESCRIPTION
Tom's first login attempt dead-ended: the embedded outpost redirects to `https://authentik.haynesops.com`, which **does not exist** — Authentik is only served at `authentik.haynesnetwork.com`. Safari couldn't resolve it.

Fix: ride `proxy-provider-internal-outpost`, the outpost headlamp already uses successfully for `*.haynesops.com`. Ingress middleware updated to match.

⚠️ The blueprint's outpost `providers` list is a **full replacement**, so `Provider for Headlamp` is enumerated explicitly — omitting it would silently break headlamp's SSO on the next blueprint apply. Comment in the file says so loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qG1mqKfvjwBPWjjuTYZX6