### PR TITLE
fix(dev-env): dedicated Authentik outpost — prior blueprint never applied (identifier mismatch)

### DIFF
--- a/.agents/sagas/dev-env/backlog/02-poc-deploy.md
+++ b/.agents/sagas/dev-env/backlog/02-poc-deploy.md
@@ -7,10 +7,18 @@ tmux respawns on boot. Remaining human check: Tom's first browser login through
 Authentik from the LAN.)
 **Depends on:** 01 (image published) — done
 
-**Implementation notes (2026-07-13):** SSO is Authentik forward-auth via the EMBEDDED
-outpost (unused until now — headlamp/paperless ride the named internal/external
-outposts), GitOps'd as blueprint `network/authentik/app/blueprints/50-dev-env.yaml`
-which now OWNS the embedded outpost's provider list. The haynesops wildcard cert
+**Implementation notes (2026-07-13, revised after two failed SSO attempts):** SSO is
+Authentik forward-auth via a DEDICATED outpost (`dev-env-outpost` → middleware
+`ak-outpost-dev-env-outpost`), one outpost per app like headlamp/paperless, GitOps'd
+as blueprint `network/authentik/app/blueprints/50-dev-env.yaml`. Attempt 1 (embedded
+outpost) died on its dead authentik_host (authentik.haynesops.com doesn't exist);
+attempt 2 (piggyback on headlamp's internal outpost) NEVER APPLIED — the blueprint
+identified the outpost by its k8s slug instead of its real name ("Proxy Provider
+Internal Outpost"), turning the entry into an invalid CREATE (missing type/config),
+which put the whole blueprint in status=error and rolled back every entry, while the
+middleware kept routing dev-env logins through an outpost that only knew headlamp.
+Lesson: after editing a blueprint, verify `BlueprintInstance.status` (worker `ak
+shell` or admin UI) — an errored blueprint rolls back silently. The haynesops wildcard cert
 reaches namespace `dev` via the reflector allowlist on certificate-haynesops-prod.
 code-server runs `--auth none` — safe ONLY behind the middleware + the CNP ingress
 rule (traefik-internal pods only); never add another ingress path without auth.

--- a/kubernetes/main/apps/dev/dev-env/app/ingressroute.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/ingressroute.yaml
@@ -1,10 +1,11 @@
 ---
-# code-server, LAN-only (saga Decision #6): traefik-internal + the Authentik
-# embedded-outpost forward-auth middleware (provider/application/outpost assignment
-# is GitOps'd in kubernetes/main/apps/network/authentik/app/blueprints/50-dev-env.yaml).
-# Fail-closed: until the blueprint applies and the provider is on the outpost, the
-# middleware denies everything. NOT published through the Cloudflare Tunnel — remote
-# interaction with running agents is /remote-control (outbound via claude.ai).
+# code-server, LAN-only (saga Decision #6): traefik-internal + Authentik forward-auth
+# via dev-env's DEDICATED outpost (provider/application/outpost are GitOps'd in
+# kubernetes/main/apps/network/authentik/app/blueprints/50-dev-env.yaml, which
+# generates the middleware referenced below). Fail-closed: until the blueprint
+# applies and the outpost pod exists, the route errors. NOT published through the
+# Cloudflare Tunnel — remote interaction with running agents is /remote-control
+# (outbound via claude.ai).
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
@@ -25,10 +26,12 @@ spec:
     - kind: Rule
       match: Host(`dev-env.haynesops.com`) && PathPrefix(`/`)
       middlewares:
-        # The INTERNAL outpost (same one headlamp uses). NOT the embedded outpost —
-        # its authentik_host points at the nonexistent authentik.haynesops.com and the
-        # login redirect dead-ends (hit live 2026-07-13).
-        - name: ak-outpost-proxy-provider-internal-outpost
+        # dev-env's own outpost (one outpost per app, like headlamp/paperless).
+        # NOT the embedded outpost (dead authentik_host) and NOT headlamp's internal
+        # outpost (an outpost only issues callbacks for providers assigned to it —
+        # routing dev-env through headlamp's outpost sent the login callback to
+        # headlamp.haynesops.com, hit live 2026-07-13).
+        - name: ak-outpost-dev-env-outpost
           namespace: network
       services:
         - kind: Service

--- a/kubernetes/main/apps/network/authentik/app/blueprints/50-dev-env.yaml
+++ b/kubernetes/main/apps/network/authentik/app/blueprints/50-dev-env.yaml
@@ -1,24 +1,35 @@
 # dev-env saga (.agents/sagas/dev-env/) — forward-auth SSO for the in-cluster dev
 # environment (code-server at dev-env.haynesops.com), config-as-code.
 #
-# Creates the Proxy Provider (forward_single) + Application and assigns the provider to
-# the INTERNAL outpost — the same one headlamp rides.
+# Creates the Proxy Provider (forward_single) + Application and a DEDICATED proxy
+# outpost (dev-env-outpost), matching the estate's one-outpost-per-app layout
+# (internal → headlamp, external → paperless). The Kubernetes service connection
+# makes Authentik generate the outpost's Deployment/Service/Middleware in the
+# `network` namespace: middleware `ak-outpost-dev-env-outpost`, referenced by the
+# dev-env IngressRoute (kubernetes/main/apps/dev/dev-env/app/ingressroute.yaml).
 #
-# ⚠ NOT the embedded outpost (tried first, 2026-07-13, and it FAILED): the embedded
-# outpost's authentik_host points at https://authentik.haynesops.com, which DOES NOT
-# EXIST — Authentik is only served at authentik.haynesnetwork.com — so the login
-# redirect dead-ended in "Safari can't find the server". proxy-provider-internal-outpost
-# is the proven path for *.haynesops.com apps.
+# ⚠ History — two prior attempts failed, differently than first diagnosed:
+#   1. Embedded outpost (2026-07-13): its authentik_host points at
+#      https://authentik.haynesops.com, which DOES NOT EXIST (Authentik is only
+#      served at authentik.haynesnetwork.com) → login redirect dead-ended. The
+#      entry at the bottom clears that leftover provider assignment.
+#   2. Piggyback on the internal outpost (2026-07-13): the entry identified the
+#      outpost by its k8s SLUG (proxy-provider-internal-outpost) instead of its
+#      real name ("Proxy Provider Internal Outpost"), so Authentik treated it as a
+#      CREATE, which failed serializer validation (type/config required) and left
+#      the whole blueprint status=error — the reassignment NEVER applied, and
+#      dev-env's forward-auth kept hitting an outpost that only knew headlamp
+#      (hence the callback landing on headlamp's host).
 #
-# ⚠ This blueprint OWNS proxy-provider-internal-outpost's provider list, and the list is
-# a FULL REPLACEMENT — "Provider for Headlamp" MUST stay in it or headlamp loses its
-# SSO on the next blueprint apply. Add any future internal-outpost provider HERE, not in
-# the UI (blueprints re-apply on an interval and revert UI edits).
+# A dedicated outpost also keeps this blueprint from owning the provider list of
+# the outpost headlamp rides — an outpost's `providers` list in a blueprint is a
+# FULL REPLACEMENT, so sharing one from here risks silently dropping headlamp's
+# SSO on any future edit.
 version: 1
 metadata:
   name: dev-env-proxy
   labels:
-    blueprints.goauthentik.io/description: 'dev-env forward-auth: proxy provider + application + embedded-outpost assignment for the in-cluster agent dev environment (saga: .agents/sagas/dev-env/).'
+    blueprints.goauthentik.io/description: 'dev-env forward-auth: proxy provider + application + dedicated outpost for the in-cluster agent dev environment (saga: .agents/sagas/dev-env/).'
 context: {}
 entries:
 - model: authentik_providers_proxy.proxyprovider
@@ -40,12 +51,35 @@ entries:
     meta_launch_url: https://dev-env.haynesops.com
     meta_description: In-cluster agent dev environment (code-server)
     open_in_new_tab: true
+# Dedicated outpost. `type` + `config` are REQUIRED on create (omitting them is
+# exactly how attempt 2 above broke). config mirrors the proven internal outpost
+# (authentik_host trailing slash included), swapping only the name-derived bits.
 - model: authentik_outposts.outpost
   state: present
   identifiers:
-    name: proxy-provider-internal-outpost
+    name: dev-env-outpost
   attrs:
+    type: proxy
+    service_connection: !Find [authentik_outposts.kubernetesserviceconnection, [name, Local Kubernetes Cluster]]
     providers:
-    # FULL REPLACEMENT — keep headlamp, or its SSO breaks on the next apply.
-    - !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Headlamp]]
     - !Find [authentik_providers_proxy.proxyprovider, [name, dev-env]]
+    config:
+      authentik_host: https://authentik.haynesnetwork.com/
+      log_level: info
+      kubernetes_replicas: 1
+      kubernetes_namespace: network
+      kubernetes_service_type: ClusterIP
+      # Ingress objects stay disabled like the other outposts — routing is our
+      # IngressRoute; the outpost only provides the forwardAuth middleware.
+      kubernetes_disabled_components:
+      - ingress
+      kubernetes_ingress_class_name: traefik-internal
+      kubernetes_ingress_secret_name: certificate-haynesops
+# Evict dev-env from the embedded outpost (leftover from attempt 1). FULL
+# REPLACEMENT is what we want here: the embedded outpost natively serves nothing.
+- model: authentik_outposts.outpost
+  state: present
+  identifiers:
+    managed: goauthentik.io/outposts/embedded
+  attrs:
+    providers: []

--- a/kubernetes/main/apps/network/authentik/app/kustomization.yaml
+++ b/kubernetes/main/apps/network/authentik/app/kustomization.yaml
@@ -18,7 +18,8 @@ resources:
 #   40-hnet-mfa.yaml PROMOTED 2026-07-10 (PLAN-011 Phase 2, owner-present): native-account
 #   MFA enforcement is live; it owns the order-30 validation stage + binding.
 #   50-dev-env.yaml (2026-07-13, dev-env saga): forward-auth proxy provider +
-#   application + embedded-outpost assignment for dev-env.haynesops.com.
+#   application + dedicated outpost (ak-outpost-dev-env-outpost) for
+#   dev-env.haynesops.com.
 configMapGenerator:
   - name: authentik-hnet-blueprints
     options:


### PR DESCRIPTION
## What broke — corrected root cause

`https://dev-env.haynesops.com` logins completed against **headlamp's** callback (blank page). The handoff diagnosed "two `forward_single` providers colliding on one outpost", but live introspection shows that state never existed:

- `BlueprintInstance dev-env-proxy` has been in **`status=error`** since #2055 merged. Its outpost entry identified the internal outpost by the k8s **slug** `proxy-provider-internal-outpost`; the outpost's real name is `Proxy Provider Internal Outpost`. No match → Authentik treated the entry as a **create** → serializer rejected it (`type`/`config` required) → **the whole blueprint rolled back on every apply**.
- So live: internal outpost = headlamp only (never got dev-env); dev-env's provider still sat on the **embedded** outpost from the first attempt. The IngressRoute sent forward-auth through headlamp's outpost, which only knew headlamp → headlamp's callback. Headlamp was never actually at risk.

Verified via worker `ak shell`: outpost/provider state, blueprint status, and `Importer.from_string(...).validate()` reproducing the exact serializer error.

## Fix (handoff Option 1 — one outpost per app)

- **`50-dev-env.yaml`**: dedicated outpost `dev-env-outpost` (`type: proxy`, `Local Kubernetes Cluster` service connection, config mirroring the proven internal outpost — `authentik_host: https://authentik.haynesnetwork.com/`, namespace `network`, ingress component disabled). Providers list = dev-env only. Also clears the leftover dev-env assignment from the embedded outpost.
- **No entry for the internal outpost at all**: the failed entry never applied, so there is nothing to restore, and headlamp's outpost stops being blueprint-shared state (the full-replacement landmine goes away).
- **`ingressroute.yaml`**: middleware → `ak-outpost-dev-env-outpost` (namespace `network`).
- Stale comments/saga notes updated with the corrected post-mortem.

## Pre-merge validation

- New blueprint dry-run against **live** Authentik (`Importer.validate()`, transaction rolled back): **VALID: True**.
- `kubectl kustomize` builds clean for both touched apps.

## Post-merge verification plan (definition of done from the handoff)

1. `curl` dev-env → `redirect_uri` contains `dev-env.haynesops.com%2Foutpost.goauthentik.io%2Fcallback`
2. `curl` headlamp → unchanged (canary)
3. `ak-outpost-dev-env-outpost` Deployment Running + Middleware exists in `network`
4. Tom confirms a real browser login on the LAN (the only proof that counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4qjwEZ9ntRgp9v9k1ULGy