### PR TITLE
fix(dev-env): 24h session cookie to match headlamp

### DIFF
--- a/kubernetes/main/apps/network/authentik/app/blueprints/50-dev-env.yaml
+++ b/kubernetes/main/apps/network/authentik/app/blueprints/50-dev-env.yaml
@@ -39,6 +39,10 @@ entries:
   attrs:
     external_host: https://dev-env.haynesops.com
     mode: forward_single
+    # Session cookie lifetime. Match headlamp (hours=24) — the authentik default
+    # (hours=1) forces an hourly re-auth redirect, which breaks code-server's
+    # long-lived WebSockets mid-session.
+    access_token_validity: hours=24
     authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
     invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
 - model: authentik_core.application


### PR DESCRIPTION
Follow-up to #2056. Live comparison of the two outposts' Set-Cookie headers showed dev-env sessions expire hourly (authentik default `access_token_validity: hours=1` → `Max-Age=3601`) while headlamp's last 24h (`86401`). An hourly re-auth redirect mid-session would sever code-server's long-lived WebSockets, so align dev-env to `hours=24`.

Pre-merge: blueprint dry-run validated against live Authentik (`Importer.validate()` → VALID: True).

Post-merge check: `curl -sk -D - -o /dev/null https://dev-env.haynesops.com/ | grep -i set-cookie` → `Max-Age=86401`.

Context from Tom's browser test of #2056: the callback now correctly targets dev-env's own host, and the login **did** complete (outpost logs show authenticated `user: thaynes` pass-throughs). The blank page was Safari declining to store/send the brand-new session cookie on the very first cross-site bounce (`haynesnetwork.com` → `haynesops.com`, ITP first-visit behavior) — cookie attributes are identical to headlamp's (`Secure; HttpOnly; SameSite=Lax`), and a curl cookie-jar replay passes the state check, so this is browser-side and self-heals once the domain has cookie history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4qjwEZ9ntRgp9v9k1ULGy