### PR TITLE
feat(dev-env): agent-run interactive pickers + detach + nested-tmux attach

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml
@@ -62,6 +62,12 @@ spec:
               - matchPattern: "*.claude.ai"
               - matchName: "claude.com"
               - matchPattern: "*.claude.com"
+              # Remote Control bridge — claude-code 2.1.x dials
+              # wss://bridge.claudeusercontent.com; a refused DNS lookup makes
+              # /remote-control a SILENT no-op (hit live 2026-07-16, second
+              # session; the claude.ai relay only covers already-established
+              # connections).
+              - matchName: "bridge.claudeusercontent.com"
               # OpenAI: Codex API + ChatGPT-plan auth/backend
               - matchName: "openai.com"
               - matchPattern: "*.openai.com"
@@ -146,6 +152,7 @@ spec:
         - matchPattern: "*.claude.ai"
         - matchName: "claude.com"
         - matchPattern: "*.claude.com"
+        - matchName: "bridge.claudeusercontent.com"
         - matchName: "openai.com"
         - matchPattern: "*.openai.com"
         - matchName: "chatgpt.com"

--- a/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
@@ -8,8 +8,15 @@
 #   agent-run run  --repo <name> --agent claude --interactive   # tmux session, no task
 #                                                 [--safe]      # keep permission prompts
 #   agent-run list                                              # live tasks + attach cmds
-#   agent-run attach <task-id>                                  # tmux attach
-#   agent-run reap   <task-id> [--force]                        # kill + cleanup
+#   agent-run attach [<task-id>]                # jump into a session (no id → picker)
+#   agent-run detach [<task-id>]                # kick attached clients off (no id → picker)
+#   agent-run reap   [<task-id>] [--force]      # kill + cleanup (no id → picker)
+#
+# attach/detach/reap without an id open an arrow-key picker (↑/↓ + Enter, q
+# cancels) showing each task's start time; reap's picker also lists STRANDED
+# worktrees (pod restart killed tmux, PVC kept the worktree) so they don't
+# balloon the PVC. attach is nested-tmux aware: from inside tmux it switches
+# clients instead of tripping the "sessions should be nested with care" guard.
 #
 # Agents run YOLO by default (claude --dangerously-skip-permissions / codex
 # --dangerously-bypass-approvals-and-sandbox): the pod IS the sandbox.
@@ -18,6 +25,77 @@ set -uo pipefail
 REPOS="$HOME/repos" WORK="$HOME/work" OWNER="thaynes43"
 log() { printf 'agent-run: %s\n' "$*" >&2; }
 die() { log "ERROR: $*"; exit 1; }
+
+usage() {
+  cat >&2 <<'EOF'
+agent-run — worktree-per-task agent dispatcher
+  agent-run run  --repo <name> --agent claude|codex [--base <ref>] -p "<task>"
+  agent-run run  --repo <name> --agent claude --interactive [--safe]
+  agent-run list
+  agent-run attach [<task-id>]                # no id → arrow-key picker
+  agent-run detach [<task-id>]                # no id → picker (attached sessions only)
+  agent-run reap   [<task-id>] [--force]      # no id → picker (incl. stranded worktrees)
+EOF
+}
+
+# "haynesnetwork-0714-230456" → "07-14 23:04:56"; falls back to the worktree
+# dir mtime, then "?". (The id embeds creation time, so no tmux query needed —
+# works for stranded worktrees whose session is long gone.)
+when_of() {
+  local id="$1"
+  if [[ "$id" =~ ([0-9]{2})([0-9]{2})-([0-9]{2})([0-9]{2})([0-9]{2})$ ]]; then
+    printf '%s-%s %s:%s:%s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" \
+      "${BASH_REMATCH[3]}" "${BASH_REMATCH[4]}" "${BASH_REMATCH[5]}"
+  elif [ -e "$WORK/$id" ]; then
+    date -d "@$(stat -c %Y "$WORK/$id")" '+%m-%d %H:%M:%S'
+  else
+    printf '?'
+  fi
+}
+
+# pick "title" row… — arrow-key menu drawn on /dev/tty (stdout stays clean so
+# callers can command-substitute the result). Echoes the selected row's first
+# field (the task id). Returns 1 on cancel or when there's nothing to show.
+pick() {
+  local title="$1"; shift
+  local rows=("$@") n=$# cur=0 j key seq
+  [ "$n" -gt 0 ] || { log "nothing to select"; return 1; }
+  { exec 3</dev/tty 4>/dev/tty; } 2>/dev/null \
+    || { log "no TTY for the picker — pass an explicit <task-id>"; return 1; }
+  draw() {
+    for ((j = 0; j < n; j++)); do
+      if [ "$j" -eq "$cur" ]; then printf '\033[K \033[7m▸ %s\033[0m\n' "${rows[j]}"
+      else printf '\033[K   %s\n' "${rows[j]}"; fi
+    done >&4
+  }
+  printf '%s  (↑/↓ or j/k, Enter selects, q cancels)\n' "$title" >&4
+  printf '\033[?25l' >&4
+  while :; do
+    draw
+    IFS= read -rsn1 key <&3 || key=q
+    case "$key" in
+      $'\x1b')
+        IFS= read -rsn2 -t 0.05 seq <&3 || seq=""
+        case "$seq" in
+          '[A') ((cur > 0)) && ((cur--)) ;;
+          '[B') ((cur < n - 1)) && ((cur++)) ;;
+          '') key=q ;;   # bare ESC = cancel
+        esac ;;
+      k) ((cur > 0)) && ((cur--)) ;;
+      j) ((cur < n - 1)) && ((cur++)) ;;
+      ''|$'\r') break ;; # Enter = select ('' when the tty maps CR→NL, \r when raw)
+    esac
+    [ "$key" = q ] && { printf '\033[?25h\n' >&4; return 1; }
+    printf '\033[%dA' "$n" >&4
+  done
+  printf '\033[?25h' >&4
+  printf '%s\n' "${rows[cur]%% *}"
+}
+
+# Emit "id|attached-count" for every live task session.
+live_tasks() {
+  tmux ls -F '#{session_name}|#{session_attached}' 2>/dev/null | sed -n 's/^task-//p'
+}
 
 # Every task shell needs the fresh bot token (bashrc handles interactive shells;
 # tmux run-shell strings need it inline).
@@ -99,26 +177,81 @@ BLOCKED and the reason as your final message."
     # The old version printed 'task-<id>', which people then passed to `attach` — and
     # attach re-prefixed it into 'task-task-<id>' and failed. Show exactly what to type.
     printf 'LIVE TASKS:\n'
-    ids="$(tmux ls -F '#{session_name}' 2>/dev/null | sed -n 's/^task-//p')"
-    if [ -z "$ids" ]; then
-      printf '  (none)\n'
-    else
-      for i in $ids; do printf '  %s\n      attach:  agent-run attach %s\n' "$i" "$i"; done
-    fi
+    found=0
+    while IFS='|' read -r sid att; do
+      found=1
+      printf '  %s  (started %s%s)\n      attach:  agent-run attach %s\n' \
+        "$sid" "$(when_of "$sid")" "$([ "${att:-0}" -gt 0 ] && echo ', attached')" "$sid"
+    done < <(live_tasks)
+    [ "$found" = 1 ] || printf '  (none)\n'
     printf 'WORKTREES:\n'
     for r in "$REPOS"/*/; do [ -d "$r/.git" ] && git -C "$r" worktree list | grep "$WORK" || true; done
     ;;
   attach)
-    id="${1:-}"; [ -n "$id" ] || die "attach <task-id>   (see: agent-run list)"
+    id="${1:-}"
+    if [ -z "$id" ]; then
+      rows=()
+      while IFS='|' read -r sid att; do
+        rows+=("$sid  started $(when_of "$sid")  $([ "${att:-0}" -gt 0 ] && echo '[attached]' || echo '[detached]')")
+      done < <(live_tasks)
+      id="$(pick 'attach to task:' ${rows[@]+"${rows[@]}"})" || exit 1
+    fi
     id="${id#task-}"   # tolerate pasting the tmux session name by mistake
     tmux has-session -t "task-$id" 2>/dev/null \
       || die "no live session '$id' — run 'agent-run list' to see what's running"
+    # Nested-tmux aware: inside tmux, attach would die with "sessions should be
+    # nested with care" — switch this client instead.
+    if [ -n "${TMUX:-}" ]; then
+      [ "$(tmux display-message -p '#S')" = "task-$id" ] \
+        && { log "you are already inside task-$id"; exit 0; }
+      exec tmux switch-client -t "task-$id"
+    fi
     exec tmux attach -t "task-$id"
     ;;
+  detach)
+    # Detach every client from a task's session — the session (and the agent in
+    # it) keeps running. This exists because code-server swallows Ctrl+B (its
+    # sidebar shortcut), so the in-tmux detach keystroke never arrives there.
+    id="${1:-}"
+    if [ -z "$id" ]; then
+      rows=()
+      while IFS='|' read -r sid att; do
+        [ "${att:-0}" -gt 0 ] || continue
+        rows+=("$sid  started $(when_of "$sid")  [$att attached]")
+      done < <(live_tasks)
+      id="$(pick 'detach clients from task:' ${rows[@]+"${rows[@]}"})" || exit 1
+    fi
+    id="${id#task-}"
+    tmux has-session -t "task-$id" 2>/dev/null \
+      || die "no live session '$id' — run 'agent-run list' to see what's running"
+    tmux detach-client -s "task-$id"
+    log "detached clients from task-$id (session keeps running)"
+    ;;
   reap)
-    id="${1:-}"; [ -n "$id" ] || die "reap <task-id> [--force]"
+    id="${1:-}" force="" picked=0
+    if [ "$id" = "--force" ]; then force="--force"; id=""; fi
+    [ "${2:-}" = "--force" ] && force="--force"
+    if [ -z "$id" ]; then
+      rows=()
+      while IFS='|' read -r sid _att; do
+        rows+=("$sid  started $(when_of "$sid")  [live session]")
+      done < <(live_tasks)
+      for wt in "$WORK"/*/; do
+        [ -d "$wt" ] || continue
+        wid="$(basename "$wt")"
+        tmux has-session -t "task-$wid" 2>/dev/null && continue
+        rows+=("$wid  started $(when_of "$wid")  [stranded — worktree only]")
+      done
+      id="$(pick 'reap task (kills session + deletes worktree; log kept):' ${rows[@]+"${rows[@]}"})" || exit 1
+      picked=1
+    fi
     id="${id#task-}"   # same tolerance as attach
-    force=""; [ "${2:-}" = "--force" ] && force="--force"
+    if [ "$picked" = 1 ]; then
+      # Picker mode reaps whatever Enter landed on — confirm before deleting.
+      printf 'reap %s? [y/N] ' "$id" >/dev/tty
+      IFS= read -r ans </dev/tty || ans=n
+      case "$ans" in y|Y|yes) : ;; *) log "aborted"; exit 1 ;; esac
+    fi
     tmux kill-session -t "task-$id" 2>/dev/null && log "session killed" || log "no session"
     repo="${id%%-[0-9]*}"
     if [ -d "$WORK/$id" ]; then
@@ -130,6 +263,6 @@ BLOCKED and the reason as your final message."
     log "reaped $id (log kept at $WORK/$id.log)"
     ;;
   *)
-    sed -n '3,10p' "$0"; exit 1
+    usage; exit 1
     ;;
 esac

--- a/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
@@ -161,7 +161,18 @@ BLOCKED and the reason as your final message."
 
     tmux new-session -d -s "task-$id" -c "$wt" || die "tmux session failed"
     if [ "$interactive" = 1 ]; then
-      tmux send-keys -t "task-$id" "$token_env; cd $wt; $agent $yolo_flag" Enter
+      # Interactive claude launches with NO permission flag: the pod's GitOps'd
+      # ~/.claude/settings.json already defaults to bypassPermissions, and ANY
+      # permission flag at launch (--dangerously-skip-permissions or
+      # --permission-mode …) SILENTLY disables /remote-control — settings-
+      # inherited bypass does not (proven live 2026-07-17). --safe has to
+      # override the settings default explicitly, and costs /remote-control.
+      launch="$agent $yolo_flag"
+      if [ "$agent" = claude ]; then
+        launch="claude"
+        [ "$safe" = 1 ] && launch="claude --permission-mode default"
+      fi
+      tmux send-keys -t "task-$id" "$token_env; cd $wt; $launch" Enter
       log "interactive session ready →  agent-run attach $id"
     else
       # Env-var indirection keeps the prompt out of shell-quoting hell; log to

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
@@ -47,19 +47,33 @@ key: you tap **Ctrl+B**, *release*, then press one more key.
 
 That's it. Everything else is optional.
 
+> **⚠️ code-server steals Ctrl+B** (it's VS Code's "toggle sidebar" shortcut), so in the
+> integrated terminal here the detach keystroke usually never reaches tmux. Detach from
+> any *other* terminal instead: **`agent-run detach`** (picker) or
+> `tmux detach-client -s task-<task-id>`. Closing the browser tab also just detaches —
+> the agent keeps running either way. The only thing that actually *kills* a session is
+> `exit`/`Ctrl+D` at its shell prompt (or `agent-run reap`).
+
 ---
 
 ## 3. Managing tasks
 
 ```bash
-agent-run list              # what's running + the exact attach command to copy
-agent-run attach <task-id>  # jump back into a live session (scrollback intact)
-agent-run reap <task-id>    # kill it + delete the worktree (the log is kept)
+agent-run list               # what's running + start times + the attach command to copy
+agent-run attach [task-id]   # jump back into a live session (scrollback intact)
+agent-run detach [task-id]   # kick attached clients off — the session keeps running
+agent-run reap [task-id]     # kill it + delete the worktree (the log is kept)
 ```
+
+**Skip the id and you get an arrow-key picker** (↑/↓ or j/k, Enter selects, `q` cancels)
+showing each task's start time. `reap`'s picker also lists **stranded worktrees** — a pod
+restart kills tmux but the PVC keeps the worktree, so reap those leftovers before they
+balloon the PVC (it asks `y/N` before deleting).
 
 `list` prints the **task id** (e.g. `haynesnetwork-0714-010301`) and the ready-to-paste
 `agent-run attach …` line under it. If you paste the tmux session name (`task-…`) by
-mistake, `attach` strips the prefix for you.
+mistake, `attach` strips the prefix for you. `attach` is nested-tmux aware: from inside
+another task's session it switches you over instead of erroring.
 
 `reap` refuses to delete a worktree with uncommitted work — add `--force` if you mean it.
 
@@ -111,7 +125,8 @@ and open a PR when done.
 ## 7. Gotchas worth knowing
 
 - **A pod restart kills tmux** (image roll, node drain, OOM). Worktrees, branches, and logs
-  survive on the PVC — only the live pane is lost. `agent-run list` shows what's left.
+  survive on the PVC — only the live pane is lost. `agent-run list` shows what's left, and
+  the `agent-run reap` picker flags the stranded worktrees so you can clean them up.
 - **haynesnetwork is pre-warmed**: `pnpm install`, `build`, `typecheck`, and all **1,292 tests**
   (embedded Postgres) pass in this pod. Playwright browsers are installed.
 - **Memory is 24Gi.** The monorepo test suite OOM'd at 8Gi — if a build dies mysteriously,

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
@@ -132,10 +132,15 @@ and open a PR when done.
 - **Memory is 24Gi.** The monorepo test suite OOM'd at 8Gi — if a build dies mysteriously,
   check `kubectl top pod -n dev` before blaming the code.
 - **Driving an agent from your phone:** start it here with `--interactive`, then use
-  `/remote-control` in the Claude app. It doesn't need this page. If the command does
-  *nothing* (no "active" banner, no error), the bridge WebSocket couldn't connect —
-  `bridge.claudeusercontent.com` must be in the egress allowlist (it is, since 2026-07-17;
-  a refused DNS lookup fails this silently).
+  `/remote-control` in the Claude app. It doesn't need this page. Two ways this fails
+  *silently* (no "active" banner, no error — both hit live 2026-07-16/17):
+  1. `bridge.claudeusercontent.com` not in the egress allowlist (it is, since 2026-07-17) —
+     a refused DNS lookup kills the bridge WebSocket without a message.
+  2. Launching claude with a permission flag (`--dangerously-skip-permissions` or
+     `--permission-mode …`) disables `/remote-control` for that process. Bypass mode
+     inherited from `~/.claude/settings.json` is fine — which is why `agent-run
+     --interactive` launches plain `claude` (bypass still on, RC works). If a session
+     won't connect, check its launch flags first: `/exit`, relaunch plain, retry.
 
 ---
 

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
@@ -132,7 +132,10 @@ and open a PR when done.
 - **Memory is 24Gi.** The monorepo test suite OOM'd at 8Gi — if a build dies mysteriously,
   check `kubectl top pod -n dev` before blaming the code.
 - **Driving an agent from your phone:** start it here with `--interactive`, then use
-  `/remote-control` in the Claude app. It doesn't need this page.
+  `/remote-control` in the Claude app. It doesn't need this page. If the command does
+  *nothing* (no "active" banner, no error), the bridge WebSocket couldn't connect —
+  `bridge.claudeusercontent.com` must be in the egress allowlist (it is, since 2026-07-17;
+  a refused DNS lookup fails this silently).
 
 ---
 


### PR DESCRIPTION
## What

Builds the interactive UX into `agent-run` (dev-env pod) and documents it in the pod README:

- **`agent-run attach` / `detach` / `reap` with no id → arrow-key picker** (↑/↓ or j/k, Enter selects, `q` cancels), each row showing the task's start datetime (parsed from the id).
- **`reap`'s picker also lists stranded worktrees** (pod restart kills tmux; the PVC keeps the worktree) tagged `[stranded — worktree only]`, with a `y/N` confirm before deleting — so leftovers stop ballooning the PVC.
- **New `agent-run detach [id]`** — code-server swallows `Ctrl+B` (its sidebar shortcut), so tmux's detach keystroke never arrives in the integrated terminal. This wraps `tmux detach-client -s task-<id>`; the session and the agent in it keep running.
- **Nested-tmux-aware `attach`** — from inside tmux it `switch-client`s instead of dying on `sessions should be nested with care`; friendly no-op if you're already inside the target.
- `list` now shows start time + attached marker; help text is a heredoc (the old `sed -n '3,10p'` help broke whenever the header comment moved).
- Pod `~/README.md`: pickers, `detach`, the Ctrl+B/code-server gotcha, stranded-worktree cleanup.

## Deploy behavior (why merging is safe, whenever you're ready)

`dev-env-scripts` is a **fixed-name** ConfigMap (`disableNameSuffixHash: true`) dir-mounted at `/opt/dev-env/scripts` — **no pod template change, no rollout, no bounce**. The kubelet syncs the mounted file in place (~1 min after Flux reconciles) and `~/.local/bin/agent-run` is a symlink to it, so the new script is live immediately. The `~/README.md` copy refreshes on the next natural pod restart (dev-init copies it at boot).

**Keeping this open as draft until you're ready to deploy and test.**

## Testing

Exercised under a pseudo-TTY (`script(1)`) with a fake `$HOME` (real git repo + worktrees):
- picker renders rows with datetimes; `q` cancels without touching anything (rc=1)
- Enter + `y` reaps a stranded worktree end-to-end (worktree removed, `agent/…` branch deleted, log kept)
- ↓ moves the selection (confirm prompt showed the 2nd row's id); `n` aborts
- empty pickers (`detach` with nothing attached) exit 1 with "nothing to select"
- explicit-id forms and `run`/`list` untouched paths still behave (`bash -n` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5NYaz2N7tBEe5PBMnE4WC