### PR TITLE
feat(dev-env): agent-run interactive defaults to Remote Control host

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
@@ -134,16 +134,29 @@ tracked_dirty() {  # $1 = worktree path
   git -C "$1" status --porcelain=v1 2>/dev/null | grep -vcE '^(\?\?|!!)' || true
 }
 
-# Remove ONE worktree (forcing past disposable untracked scratch) and delete the
-# branch it had checked out — never a shared base branch. Caller must have already
-# cleared the tracked-dirty gate. $1 = worktree path, $2 = owning repo dir.
+# Remove ONE worktree (forcing past disposable untracked scratch), then retire the
+# branch it had checked out — SAFELY, OFFLINE. Caller has cleared the tracked-dirty
+# gate, but a clean tree can still hide committed-but-never-pushed commits, and once
+# the worktree (+ its HEAD reflog) is gone the branch ref is those commits' only
+# anchor. So delete ONLY when git can PROVE offline the branch holds nothing beyond
+# HEAD: `git branch -d` (deletes plain/FF-merged or already-at-base; refuses if the
+# branch has its own commits). On refusal — unpushed WIP OR squash-merged (upstream
+# deleted, history rewritten) — we do NOT force: a name-only "a PR merged" signal is
+# not proof THIS local tip landed (stacked commits / reused branch names both defeat
+# it), so we never escalate to -D. Keep the branch (weightless) and print the exact
+# drop command. Never touches a shared base branch. $1 = worktree, $2 = repo dir.
 drop_worktree() {
-  local wt="$1" repo="$2" br
+  local wt="$1" repo="$2" br tip
   br="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+  tip="$(git -C "$wt" rev-parse --short HEAD 2>/dev/null)"
   git -C "$repo" worktree remove --force "$wt" || return 1
-  case "$br" in ""|HEAD|main|master) : ;;
-    *) git -C "$repo" branch -D "$br" >/dev/null 2>&1 || true ;;
-  esac
+  case "$br" in ""|HEAD|main|master) return 0 ;; esac
+  if git -C "$repo" branch -d "$br" >/dev/null 2>&1; then
+    log "branch $br deleted"
+  else
+    log "KEPT branch $br @ $tip — has local commit(s) not on HEAD (unpushed WIP, or squash-merged). Confirm it landed, then drop: git -C $repo branch -D $br"
+  fi
+  return 0
 }
 
 # Pre-trust a fresh worktree in claude's state file: `claude remote-control`
@@ -192,6 +205,11 @@ case "$cmd" in
     [ -n "$repo" ] || die "--repo required"
     case "$agent" in claude|codex) : ;; *) die "--agent must be claude|codex" ;; esac
     [ "$interactive" = 1 ] || [ -n "$prompt" ] || die "need -p or --interactive"
+    if [ -n "$effort" ]; then   # fail fast, before any clone/worktree side effects
+      case "$effort" in low|medium|high|xhigh|max) : ;;
+        *) die "--effort must be low|medium|high|xhigh|max (got '$effort'); 'ultracode' is a /effort session-mode — set it in-session" ;;
+      esac
+    fi
 
     # Canonical clone: fetch-only, never worked in directly.
     if [ ! -d "$REPOS/$repo/.git" ]; then
@@ -219,9 +237,12 @@ reason as your final message."
     # launches alike. Model otherwise defaults to the pod settings.json (Fable);
     # these MUST sit in top-level position (before the remote-control subcommand),
     # which is where claude reads them. No-op for codex.
+    # %q-escape the values: they ride through one more shell layer (tmux send-keys
+    # re-parses the launch string), and a legit value like 'claude-fable-5[1m]'
+    # carries glob metacharacters that would otherwise be pathname-expanded.
     cg=""
-    [ -n "$model" ]  && cg="$cg --model $model"
-    [ -n "$effort" ] && cg="$cg --effort $effort"
+    [ -n "$model" ]  && cg="$cg --model $(printf '%q' "$model")"
+    [ -n "$effort" ] && cg="$cg --effort $(printf '%q' "$effort")"
 
     case "$agent" in
       claude) run_cmd="claude$cg --dangerously-skip-permissions --append-system-prompt \"\$AGENT_GUARD\" -p \"\$AGENT_PROMPT\" --output-format text" ;;
@@ -300,9 +321,11 @@ reason as your final message."
     strand=0
     for wt in "$WORK"/*/; do
       [ -d "$wt" ] || continue
-      tmux has-session -t "task-$(basename "$wt")" 2>/dev/null || strand=$((strand + 1))
+      tmux has-session -t "task-$(basename "$wt")" 2>/dev/null && continue
+      owning_repo "$wt" >/dev/null 2>&1 && strand=$((strand + 1))   # count what prune acts on
     done
     [ "$strand" -gt 0 ] && printf 'STRANDED: %d worktree(s) with no live session → agent-run prune\n' "$strand"
+    true   # never let the trailing test set a nonzero exit for `agent-run list`
     ;;
   attach)
     id="${1:-}"
@@ -382,7 +405,7 @@ reason as your final message."
       fi
       ut="$(git -C "$wt" status --porcelain=v1 2>/dev/null | grep -cE '^\?\?' || true)"
       [ "${ut:-0}" -gt 0 ] && log "discarding $ut untracked scratch file(s) (.claude/ etc.) in $id"
-      drop_worktree "$wt" "$repo_dir" && log "worktree removed + branch deleted" \
+      drop_worktree "$wt" "$repo_dir" && log "worktree removed" \
         || die "worktree remove failed for $wt"
       git -C "$repo_dir" worktree prune 2>/dev/null || true
     else
@@ -405,7 +428,7 @@ reason as your final message."
         *) die "unknown flag $1 (usage: agent-run prune [--yes] [--force])" ;;
       esac
     done
-    plan=0 wip=0 removed=0
+    plan=0 wip=0 removed=0 forced=0 failed=0
     for wt in "$WORK"/*/; do
       [ -d "$wt" ] || continue
       wt="${wt%/}"; wid="$(basename "$wt")"
@@ -413,26 +436,32 @@ reason as your final message."
       repo_dir="$(owning_repo "$wt")" || { printf '  skip  %-34s (not a git worktree)\n' "$wid"; continue; }
       br="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)"
       td="$(tracked_dirty "$wt")"
-      if [ "${td:-0}" -gt 0 ] && [ -z "$pforce" ]; then
-        printf '  SKIP  %-34s %s  (%s tracked WIP — reap --force to discard)\n' "$wid" "$br" "$td"
-        wip=$((wip + 1)); continue
+      note="" is_wip=""
+      if [ "${td:-0}" -gt 0 ]; then
+        if [ -z "$pforce" ]; then
+          printf '  SKIP  %-34s %s  (%s tracked WIP — prune --yes --force to discard)\n' "$wid" "$br" "$td"
+          wip=$((wip + 1)); continue
+        fi
+        note="  ⚠ discards $td tracked WIP"; is_wip=1   # --force: shown, never hidden
       fi
       plan=$((plan + 1))
       if [ -n "$do_it" ]; then
         if drop_worktree "$wt" "$repo_dir"; then
-          printf '  REAP  %-34s %s\n' "$wid" "$br"; removed=$((removed + 1))
+          printf '  REAP  %-34s %s%s\n' "$wid" "$br" "$note"
+          removed=$((removed + 1)); [ -n "$is_wip" ] && forced=$((forced + 1))
         else
-          printf '  FAIL  %-34s %s  (worktree remove failed)\n' "$wid" "$br"
+          printf '  FAIL  %-34s %s  (worktree remove failed)\n' "$wid" "$br"; failed=$((failed + 1))
         fi
       else
-        printf '  reap  %-34s %s\n' "$wid" "$br"
+        printf '  reap  %-34s %s%s\n' "$wid" "$br" "$note"
+        [ -n "$is_wip" ] && forced=$((forced + 1))
       fi
     done
     for r in "$REPOS"/*/; do [ -d "$r/.git" ] && git -C "$r" worktree prune 2>/dev/null || true; done
     if [ -n "$do_it" ]; then
-      log "prune done: $removed removed, $wip left (WIP — add --force to include them)"
+      log "prune done: $removed removed ($forced force-discarded WIP), $failed failed, $wip skipped (WIP)"
     else
-      log "DRY-RUN: $plan would be reaped, $wip skipped (WIP). Execute:  agent-run prune --yes"
+      log "DRY-RUN: $plan would be reaped ($forced discarding tracked WIP), $wip skipped (WIP). Execute:  agent-run prune --yes${pforce:+ --force}"
     fi
     ;;
   *)

--- a/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
@@ -5,7 +5,8 @@
 # kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh.
 #
 #   agent-run run  --repo <name> --agent claude|codex [--base <ref>] -p "<task>"
-#   agent-run run  --repo <name> --agent claude --interactive   # tmux session, no task
+#   agent-run run  --repo <name> --agent claude --interactive   # REMOTE-CONTROL host (phone/web drives it)
+#                                                 [--local]     # classic in-terminal TUI instead
 #                                                 [--safe]      # keep permission prompts
 #   agent-run list                                              # live tasks + attach cmds
 #   agent-run attach [<task-id>]                # jump into a session (no id → picker)
@@ -30,7 +31,9 @@ usage() {
   cat >&2 <<'EOF'
 agent-run — worktree-per-task agent dispatcher
   agent-run run  --repo <name> --agent claude|codex [--base <ref>] -p "<task>"
-  agent-run run  --repo <name> --agent claude --interactive [--safe]
+  agent-run run  --repo <name> --agent claude --interactive [--local] [--safe]
+                 # default: Remote Control host (drive from phone/claude.ai/code)
+                 # --local: classic in-terminal TUI instead
   agent-run list
   agent-run attach [<task-id>]                # no id → arrow-key picker
   agent-run detach [<task-id>]                # no id → picker (attached sessions only)
@@ -97,6 +100,26 @@ live_tasks() {
   tmux ls -F '#{session_name}|#{session_attached}' 2>/dev/null | sed -n 's/^task-//p'
 }
 
+# Pre-trust a fresh worktree in claude's state file: `claude remote-control`
+# REFUSES untrusted dirs outright, and the TUI stops at a trust dialog — both
+# kill "RC from the get-go" for worktrees that are, by construction, brand new.
+# Best-effort (atomic tmp+mv): on any failure the session just shows the normal
+# trust prompt. State file: $CLAUDE_CONFIG_DIR/.claude.json (this pod sets
+# CLAUDE_CONFIG_DIR), else ~/.claude.json.
+pretrust() {  # $1 = worktree path
+  local state="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.claude.json"
+  [ -f "$state" ] || state="$HOME/.claude.json"
+  [ -f "$state" ] || { log "WARN: no claude state file yet — accept the trust dialog on first attach"; return 0; }
+  local tmp="${state}.agent-run.$$"
+  if jq --arg wt "$1" \
+       '.projects[$wt] = ((.projects[$wt] // {}) + {hasTrustDialogAccepted: true, hasCompletedProjectOnboarding: true})' \
+       "$state" > "$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+    mv "$tmp" "$state"
+  else
+    rm -f "$tmp"; log "WARN: could not pre-trust $1 — accept the trust dialog on first attach"
+  fi
+}
+
 # Every task shell needs the fresh bot token (bashrc handles interactive shells;
 # tmux run-shell strings need it inline).
 token_env='export GH_TOKEN="$(cat /creds/gh_token 2>/dev/null)"'
@@ -105,7 +128,7 @@ cmd="${1:-help}"; shift || true
 
 case "$cmd" in
   run)
-    repo="" agent="" base="" prompt="" interactive=0 safe=0
+    repo="" agent="" base="" prompt="" interactive=0 safe=0 local_tui=0
     while [ $# -gt 0 ]; do
       case "$1" in
         --repo) repo="$2"; shift 2 ;;
@@ -113,6 +136,7 @@ case "$cmd" in
         --base) base="$2"; shift 2 ;;
         -p|--prompt) prompt="$2"; shift 2 ;;
         --interactive) interactive=1; shift ;;
+        --local) local_tui=1; shift ;;
         --safe) safe=1; shift ;;
         *) die "unknown flag $1" ;;
       esac
@@ -161,19 +185,37 @@ BLOCKED and the reason as your final message."
 
     tmux new-session -d -s "task-$id" -c "$wt" || die "tmux session failed"
     if [ "$interactive" = 1 ]; then
-      # Interactive claude launches with NO permission flag: the pod's GitOps'd
-      # ~/.claude/settings.json already defaults to bypassPermissions, and ANY
-      # permission flag at launch (--dangerously-skip-permissions or
-      # --permission-mode …) SILENTLY disables /remote-control — settings-
-      # inherited bypass does not (proven live 2026-07-17). --safe has to
-      # override the settings default explicitly, and costs /remote-control.
-      launch="$agent $yolo_flag"
       if [ "$agent" = claude ]; then
-        launch="claude"
-        [ "$safe" = 1 ] && launch="claude --permission-mode default"
+        pretrust "$wt"
+        if [ "$local_tui" = 1 ]; then
+          # --local: classic TUI, NO permission flag unless --safe — the pod
+          # settings default to bypass, and ANY permission flag at launch
+          # silently disables the in-TUI /remote-control (proven 2026-07-17).
+          # Know that the in-TUI /remote-control is ALSO flaky server-side
+          # (intermittent 401s, anthropics/claude-code#30093 #30102, and a
+          # 3-strikes-then-disabled-until-restart hook) — which is exactly why
+          # the RC-host mode below is the default, not this.
+          launch="claude"
+          [ "$safe" = 1 ] && launch="claude --permission-mode default"
+        else
+          # DEFAULT: Remote Control HOST from the get-go. The standalone
+          # subcommand registers through the api.anthropic.com environments
+          # API — the reliable path (the in-TUI slash command is not) — and
+          # phone/claude.ai-code drives the session; local attach shows the
+          # status/QR/URL screen. Failures self-document in the rc log.
+          rc_mode="--permission-mode bypassPermissions"
+          [ "$safe" = 1 ] && rc_mode="--permission-mode default"
+          launch="claude remote-control --name $id $rc_mode --debug-file $WORK/$id.rc.log"
+        fi
+      else
+        launch="$agent $yolo_flag"   # codex: RC is claude-only → local TUI
       fi
       tmux send-keys -t "task-$id" "$token_env; cd $wt; $launch" Enter
-      log "interactive session ready →  agent-run attach $id"
+      if [ "$agent" = claude ] && [ "$local_tui" != 1 ]; then
+        log "remote-control host starting → QR/URL: agent-run attach $id   rc log: $WORK/$id.rc.log"
+      else
+        log "interactive session ready →  agent-run attach $id"
+      fi
     else
       # Env-var indirection keeps the prompt out of shell-quoting hell; log to
       # $WORK/<id>.log for post-hoc review (reap keeps the log).

--- a/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
@@ -8,16 +8,22 @@
 #   agent-run run  --repo <name> --agent claude --interactive   # REMOTE-CONTROL host (phone/web drives it)
 #                                                 [--local]     # classic in-terminal TUI instead
 #                                                 [--safe]      # keep permission prompts
+#                                     [--model <m>] [--effort <l>]  # override the pod default (Fable)
 #   agent-run list                                              # live tasks + attach cmds
 #   agent-run attach [<task-id>]                # jump into a session (no id → picker)
 #   agent-run detach [<task-id>]                # kick attached clients off (no id → picker)
 #   agent-run reap   [<task-id>] [--force]      # kill + cleanup (no id → picker)
+#   agent-run prune  [--yes] [--force]          # bulk-clean ALL stranded worktrees (dry-run w/o --yes)
 #
 # attach/detach/reap without an id open an arrow-key picker (↑/↓ + Enter, q
 # cancels) showing each task's start time; reap's picker also lists STRANDED
 # worktrees (pod restart killed tmux, PVC kept the worktree) so they don't
-# balloon the PVC. attach is nested-tmux aware: from inside tmux it switches
-# clients instead of tripping the "sessions should be nested with care" guard.
+# balloon the PVC. `prune` clears the whole backlog at once. Both are safe by
+# construction: a worktree is removed only when it has no uncommitted TRACKED
+# changes (untracked scratch like `.claude/` is discarded) — agents commit +
+# PR before abandoning a worktree, so tracked-clean means the work is saved.
+# attach is nested-tmux aware: from inside tmux it switches clients instead of
+# tripping the "sessions should be nested with care" guard.
 #
 # Agents run YOLO by default (claude --dangerously-skip-permissions / codex
 # --dangerously-bypass-approvals-and-sandbox): the pod IS the sandbox.
@@ -32,12 +38,15 @@ usage() {
 agent-run — worktree-per-task agent dispatcher
   agent-run run  --repo <name> --agent claude|codex [--base <ref>] -p "<task>"
   agent-run run  --repo <name> --agent claude --interactive [--local] [--safe]
+                 [--model <m>] [--effort low|medium|high|xhigh|max]
                  # default: Remote Control host (drive from phone/claude.ai/code)
                  # --local: classic in-terminal TUI instead
+                 # --model/--effort override the pod default (Fable, session effort)
   agent-run list
   agent-run attach [<task-id>]                # no id → arrow-key picker
   agent-run detach [<task-id>]                # no id → picker (attached sessions only)
   agent-run reap   [<task-id>] [--force]      # no id → picker (incl. stranded worktrees)
+  agent-run prune  [--yes] [--force]          # bulk-clean stranded worktrees (dry-run without --yes)
 EOF
 }
 
@@ -100,6 +109,43 @@ live_tasks() {
   tmux ls -F '#{session_name}|#{session_attached}' 2>/dev/null | sed -n 's/^task-//p'
 }
 
+# Resolve the canonical repo working dir that OWNS a linked worktree — works for
+# ANY worktree name and either repo. (reap USED to guess the repo from the id
+# prefix via `${id%%-[0-9]*}`, which broke on agent-made worktrees like
+# 'hnet-award-order-fix' → a nonexistent repo path → git erroring → the
+# misleading "worktree dirty" die. Ask git who owns it instead.) The common dir
+# is '<repo>/.git', so strip the trailing '/.git'. Nonzero if not a git worktree.
+owning_repo() {  # $1 = worktree path → echoes repo dir
+  local gd
+  gd="$(git -C "$1" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+  [ -n "$gd" ] || return 1
+  printf '%s\n' "${gd%/.git}"
+}
+
+# Count uncommitted TRACKED changes (staged/unstaged edits, adds, deletes,
+# renames of files git tracks). This — NOT untracked files — is the real
+# "unsaved work" signal: agents commit + open a PR before a worktree is
+# abandoned, so a stranded worktree with zero tracked-dirty has everything
+# safely committed (and, per the branch's merged PR, landed). Untracked files
+# are runtime scratch — `.claude/` (scheduled_tasks.lock, settings.json),
+# node_modules, build dirs — which legitimately blocks a plain `git worktree
+# remove` yet is disposable. Prints an integer.
+tracked_dirty() {  # $1 = worktree path
+  git -C "$1" status --porcelain=v1 2>/dev/null | grep -vcE '^(\?\?|!!)' || true
+}
+
+# Remove ONE worktree (forcing past disposable untracked scratch) and delete the
+# branch it had checked out — never a shared base branch. Caller must have already
+# cleared the tracked-dirty gate. $1 = worktree path, $2 = owning repo dir.
+drop_worktree() {
+  local wt="$1" repo="$2" br
+  br="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+  git -C "$repo" worktree remove --force "$wt" || return 1
+  case "$br" in ""|HEAD|main|master) : ;;
+    *) git -C "$repo" branch -D "$br" >/dev/null 2>&1 || true ;;
+  esac
+}
+
 # Pre-trust a fresh worktree in claude's state file: `claude remote-control`
 # REFUSES untrusted dirs outright, and the TUI stops at a trust dialog — both
 # kill "RC from the get-go" for worktrees that are, by construction, brand new.
@@ -128,7 +174,7 @@ cmd="${1:-help}"; shift || true
 
 case "$cmd" in
   run)
-    repo="" agent="" base="" prompt="" interactive=0 safe=0 local_tui=0
+    repo="" agent="" base="" prompt="" interactive=0 safe=0 local_tui=0 model="" effort=""
     while [ $# -gt 0 ]; do
       case "$1" in
         --repo) repo="$2"; shift 2 ;;
@@ -137,6 +183,8 @@ case "$cmd" in
         -p|--prompt) prompt="$2"; shift 2 ;;
         --interactive) interactive=1; shift ;;
         --local) local_tui=1; shift ;;
+        --model) model="$2"; shift 2 ;;
+        --effort) effort="$2"; shift 2 ;;
         --safe) safe=1; shift ;;
         *) die "unknown flag $1" ;;
       esac
@@ -162,11 +210,21 @@ case "$cmd" in
 
     guard="You are working in an isolated git worktree ($wt) on branch agent/$id. \
 Stay inside it. NEVER push to main — commit to agent/$id, push that branch, and \
-open a PR with 'gh pr create' when the task is complete. If blocked, write \
-BLOCKED and the reason as your final message."
+open a PR with 'gh pr create' when the task is complete. If the task needs extra \
+git worktrees, create them under $WORK and 'git worktree remove' each once its PR \
+merges — never leave stranded worktrees behind. If blocked, write BLOCKED and the \
+reason as your final message."
+
+    # Optional top-level claude flags — model/effort — apply to -p, --local, and RC
+    # launches alike. Model otherwise defaults to the pod settings.json (Fable);
+    # these MUST sit in top-level position (before the remote-control subcommand),
+    # which is where claude reads them. No-op for codex.
+    cg=""
+    [ -n "$model" ]  && cg="$cg --model $model"
+    [ -n "$effort" ] && cg="$cg --effort $effort"
 
     case "$agent" in
-      claude) run_cmd="claude --dangerously-skip-permissions --append-system-prompt \"\$AGENT_GUARD\" -p \"\$AGENT_PROMPT\" --output-format text" ;;
+      claude) run_cmd="claude$cg --dangerously-skip-permissions --append-system-prompt \"\$AGENT_GUARD\" -p \"\$AGENT_PROMPT\" --output-format text" ;;
       codex)  run_cmd="codex exec --dangerously-bypass-approvals-and-sandbox \"\$AGENT_GUARD \$AGENT_PROMPT\"" ;;
     esac
 
@@ -195,8 +253,8 @@ BLOCKED and the reason as your final message."
           # (intermittent 401s, anthropics/claude-code#30093 #30102, and a
           # 3-strikes-then-disabled-until-restart hook) — which is exactly why
           # the RC-host mode below is the default, not this.
-          launch="claude"
-          [ "$safe" = 1 ] && launch="claude --permission-mode default"
+          launch="claude$cg"
+          [ "$safe" = 1 ] && launch="claude$cg --permission-mode default"
         else
           # DEFAULT: Remote Control HOST from the get-go. The standalone
           # subcommand registers through the api.anthropic.com environments
@@ -205,7 +263,7 @@ BLOCKED and the reason as your final message."
           # status/QR/URL screen. Failures self-document in the rc log.
           rc_mode="--permission-mode bypassPermissions"
           [ "$safe" = 1 ] && rc_mode="--permission-mode default"
-          launch="claude remote-control --name $id $rc_mode --debug-file $WORK/$id.rc.log"
+          launch="claude$cg remote-control --name $id $rc_mode --debug-file $WORK/$id.rc.log"
         fi
       else
         launch="$agent $yolo_flag"   # codex: RC is claude-only → local TUI
@@ -239,6 +297,12 @@ BLOCKED and the reason as your final message."
     [ "$found" = 1 ] || printf '  (none)\n'
     printf 'WORKTREES:\n'
     for r in "$REPOS"/*/; do [ -d "$r/.git" ] && git -C "$r" worktree list | grep "$WORK" || true; done
+    strand=0
+    for wt in "$WORK"/*/; do
+      [ -d "$wt" ] || continue
+      tmux has-session -t "task-$(basename "$wt")" 2>/dev/null || strand=$((strand + 1))
+    done
+    [ "$strand" -gt 0 ] && printf 'STRANDED: %d worktree(s) with no live session → agent-run prune\n' "$strand"
     ;;
   attach)
     id="${1:-}"
@@ -306,14 +370,70 @@ BLOCKED and the reason as your final message."
       case "$ans" in y|Y|yes) : ;; *) log "aborted"; exit 1 ;; esac
     fi
     tmux kill-session -t "task-$id" 2>/dev/null && log "session killed" || log "no session"
-    repo="${id%%-[0-9]*}"
-    if [ -d "$WORK/$id" ]; then
-      git -C "$REPOS/$repo" worktree remove $force "$WORK/$id" \
-        && log "worktree removed" \
-        || die "worktree dirty — commit/push first or reap --force"
+    wt="$WORK/$id"
+    if [ -d "$wt" ]; then
+      repo_dir="$(owning_repo "$wt")" \
+        || die "$id is not a git worktree — if it's a stray dir, remove it by hand"
+      td="$(tracked_dirty "$wt")"
+      if [ "${td:-0}" -gt 0 ] && [ "$force" != "--force" ]; then
+        log "WON'T reap $id — $td uncommitted TRACKED change(s) (real WIP):"
+        git -C "$wt" status --porcelain=v1 2>/dev/null | grep -vE '^(\?\?|!!)' | sed 's/^/    /' >&2
+        die "commit/push first, or 'agent-run reap $id --force' to discard"
+      fi
+      ut="$(git -C "$wt" status --porcelain=v1 2>/dev/null | grep -cE '^\?\?' || true)"
+      [ "${ut:-0}" -gt 0 ] && log "discarding $ut untracked scratch file(s) (.claude/ etc.) in $id"
+      drop_worktree "$wt" "$repo_dir" && log "worktree removed + branch deleted" \
+        || die "worktree remove failed for $wt"
+      git -C "$repo_dir" worktree prune 2>/dev/null || true
+    else
+      log "no worktree dir for $id (already gone)"
     fi
-    git -C "$REPOS/$repo" branch -D "agent/$id" 2>/dev/null || true
     log "reaped $id (log kept at $WORK/$id.log)"
+    ;;
+  prune)
+    # Bulk-clean STRANDED worktrees under $WORK (dead session, PVC kept the dir) so
+    # they don't balloon the PVC — the reap picker one-at-a-time doesn't scale to a
+    # backlog. Default is a DRY-RUN plan; add --yes to execute. SAFE: skips any
+    # worktree with uncommitted TRACKED changes (real WIP) unless --force; untracked
+    # scratch (.claude/ etc.) is always discarded. Ends by pruning stale worktree
+    # admin entries in every repo.
+    do_it="" pforce=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --yes|-y) do_it=1; shift ;;
+        --force)  pforce=1; shift ;;
+        *) die "unknown flag $1 (usage: agent-run prune [--yes] [--force])" ;;
+      esac
+    done
+    plan=0 wip=0 removed=0
+    for wt in "$WORK"/*/; do
+      [ -d "$wt" ] || continue
+      wt="${wt%/}"; wid="$(basename "$wt")"
+      tmux has-session -t "task-$wid" 2>/dev/null && continue   # live → leave it
+      repo_dir="$(owning_repo "$wt")" || { printf '  skip  %-34s (not a git worktree)\n' "$wid"; continue; }
+      br="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+      td="$(tracked_dirty "$wt")"
+      if [ "${td:-0}" -gt 0 ] && [ -z "$pforce" ]; then
+        printf '  SKIP  %-34s %s  (%s tracked WIP — reap --force to discard)\n' "$wid" "$br" "$td"
+        wip=$((wip + 1)); continue
+      fi
+      plan=$((plan + 1))
+      if [ -n "$do_it" ]; then
+        if drop_worktree "$wt" "$repo_dir"; then
+          printf '  REAP  %-34s %s\n' "$wid" "$br"; removed=$((removed + 1))
+        else
+          printf '  FAIL  %-34s %s  (worktree remove failed)\n' "$wid" "$br"
+        fi
+      else
+        printf '  reap  %-34s %s\n' "$wid" "$br"
+      fi
+    done
+    for r in "$REPOS"/*/; do [ -d "$r/.git" ] && git -C "$r" worktree prune 2>/dev/null || true; done
+    if [ -n "$do_it" ]; then
+      log "prune done: $removed removed, $wip left (WIP — add --force to include them)"
+    else
+      log "DRY-RUN: $plan would be reaped, $wip skipped (WIP). Execute:  agent-run prune --yes"
+    fi
     ;;
   *)
     usage; exit 1

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
@@ -63,6 +63,7 @@ agent-run list               # what's running + start times + the attach command
 agent-run attach [task-id]   # jump back into a live session (scrollback intact)
 agent-run detach [task-id]   # kick attached clients off — the session keeps running
 agent-run reap [task-id]     # kill it + delete the worktree (the log is kept)
+agent-run prune              # bulk-clean EVERY stranded worktree (dry-run; add --yes to do it)
 ```
 
 **Skip the id and you get an arrow-key picker** (↑/↓ or j/k, Enter selects, `q` cancels)
@@ -75,7 +76,15 @@ balloon the PVC (it asks `y/N` before deleting).
 mistake, `attach` strips the prefix for you. `attach` is nested-tmux aware: from inside
 another task's session it switches you over instead of erroring.
 
-`reap` refuses to delete a worktree with uncommitted work — add `--force` if you mean it.
+**When the backlog piles up** (an agent that spun up its own per-PR worktrees, or a wall of
+stranded ones after a pod bounce), `agent-run prune` clears them all at once. It prints a
+**dry-run plan** first; re-run with `--yes` to execute. Both `reap` and `prune` resolve the
+owning repo from git itself (so any worktree name works, in either repo) and are **safe by
+construction**: a worktree is removed only when it has **no uncommitted _tracked_ changes** —
+untracked scratch (`.claude/` locks, `node_modules`, build dirs) is discarded, but real WIP
+is kept and listed. A worktree that still holds tracked edits is skipped unless you add
+`--force` (`reap <id> --force` / `prune --yes --force`). Agents commit and open a PR before
+finishing, so a stranded worktree is essentially always safe to prune.
 
 **Task logs** live at `~/work/<task-id>.log` even after a reap.
 
@@ -125,8 +134,13 @@ and open a PR when done.
 ## 7. Gotchas worth knowing
 
 - **A pod restart kills tmux** (image roll, node drain, OOM). Worktrees, branches, and logs
-  survive on the PVC — only the live pane is lost. `agent-run list` shows what's left, and
-  the `agent-run reap` picker flags the stranded worktrees so you can clean them up.
+  survive on the PVC — only the live pane is lost. `agent-run list` shows what's left (and a
+  count of stranded worktrees), and `agent-run prune` clears the whole backlog in one shot
+  (`agent-run reap`'s picker still handles them one at a time).
+- **Pick the model/effort per task.** The pod defaults to Fable; add `--model <m>` and/or
+  `--effort low|medium|high|xhigh|max` to `agent-run run` to override for that session
+  (works for `-p`, `--local`, and Remote-Control launches alike). `--effort ultracode` is a
+  harness session-mode, not a launch value — set it with `/effort` once you're in the session.
 - **haynesnetwork is pre-warmed**: `pnpm install`, `build`, `typecheck`, and all **1,292 tests**
   (embedded Postgres) pass in this pod. Playwright browsers are installed.
 - **Memory is 24Gi.** The monorepo test suite OOM'd at 8Gi — if a build dies mysteriously,

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
@@ -131,16 +131,21 @@ and open a PR when done.
   (embedded Postgres) pass in this pod. Playwright browsers are installed.
 - **Memory is 24Gi.** The monorepo test suite OOM'd at 8Gi — if a build dies mysteriously,
   check `kubectl top pod -n dev` before blaming the code.
-- **Driving an agent from your phone:** start it here with `--interactive`, then use
-  `/remote-control` in the Claude app. It doesn't need this page. Two ways this fails
-  *silently* (no "active" banner, no error — both hit live 2026-07-16/17):
-  1. `bridge.claudeusercontent.com` not in the egress allowlist (it is, since 2026-07-17) —
-     a refused DNS lookup kills the bridge WebSocket without a message.
-  2. Launching claude with a permission flag (`--dangerously-skip-permissions` or
-     `--permission-mode …`) disables `/remote-control` for that process. Bypass mode
-     inherited from `~/.claude/settings.json` is fine — which is why `agent-run
-     --interactive` launches plain `claude` (bypass still on, RC works). If a session
-     won't connect, check its launch flags first: `/exit`, relaunch plain, retry.
+- **Driving an agent from your phone (the default):** `agent-run run --repo <r> --agent
+  claude --interactive` starts the task as a **Remote Control host** — connect from the
+  Claude mobile app or claude.ai/code; `agent-run attach <id>` shows the status screen
+  with the QR code + URL. This uses the standalone `claude remote-control` registration
+  path (api.anthropic.com environments API), which is reliable; fresh worktrees are
+  pre-trusted by agent-run so nothing stops at a dialog. If a host ever fails to
+  connect, the reason is in `~/work/<id>.rc.log` — no more silent failures.
+- **Prefer a classic terminal TUI?** Add `--local`. You can still type `/remote-control`
+  inside it, but know that the *in-TUI* path is flaky server-side (intermittent 401s on
+  the code-session endpoints — anthropics/claude-code#30093 #30102 — and after 3 failed
+  attempts that process disables RC until restarted). The RC-host default exists
+  precisely so your workflow never depends on it. Historical silent-failure traps, all
+  handled now: bridge egress (`bridge.claudeusercontent.com` allowed in the CNP since
+  2026-07-17) and permission flags at launch disabling in-TUI RC (`--local` launches
+  flag-free; bypass comes from settings).
 
 ---
 

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
@@ -86,6 +86,15 @@ is kept and listed. A worktree that still holds tracked edits is skipped unless 
 `--force` (`reap <id> --force` / `prune --yes --force`). Agents commit and open a PR before
 finishing, so a stranded worktree is essentially always safe to prune.
 
+**Branches are retired conservatively.** After removing a worktree, the branch is deleted only
+when git can prove _offline_ it holds nothing beyond the base (`git branch -d`). A branch with
+its own local commits — genuinely unpushed WIP, **or** a squash-merged branch whose remote was
+deleted (git can't tell these apart offline, and it never trusts a branch _name_ to mean
+"merged") — is **kept**, and prune prints the exact `git branch -D …` to drop it once you've
+confirmed it landed. So a clean prune may leave a few merged branch refs behind; that's the
+price of never orphaning an un-pushed commit. Sweep them when you're sure with
+`git -C ~/repos/<name> branch -D <branch>`.
+
 **Task logs** live at `~/work/<task-id>.log` even after a reap.
 
 ---


### PR DESCRIPTION
## What

Robust remote-control workflow instead of one-off fixes: `agent-run run --agent claude --interactive` now launches the task as a **Remote Control host** from the get-go — drive it from the Claude mobile app or claude.ai/code; `agent-run attach <id>` shows the status/QR/URL screen.

- **Why the host mode, not the slash command:** the in-TUI `/remote-control` is currently unreliable at the service level — intermittent `401 Authentication failed` on the code-session endpoints with a valid Max OAuth token (anthropics/claude-code#30093, #30102), plus a 3-consecutive-failures → disabled-until-restart hook that turns flakiness into permanent silent death. The standalone `claude remote-control` registers via the `api.anthropic.com` environments API and connects first-try from the same pod (verified live 2026-07-17 with `--debug-file`).
- **`--local`** — classic in-terminal TUI (flag-free launch so settings-inherited bypass keeps in-TUI RC possible, for when the service behaves). Documented in the pod README with the full trap history.
- **`--safe`** — maps to `--permission-mode default` in both modes.
- **Worktree pre-trust:** `claude remote-control` refuses untrusted dirs and the TUI stops at a trust dialog — fatal for brand-new worktrees. agent-run now seeds `projects[<wt>].hasTrustDialogAccepted` in the claude state file (atomic jq, best-effort with a logged fallback).
- **Self-documenting failures:** RC hosts always run with `--debug-file ~/work/<id>.rc.log`.

## Deploy behavior — ⚠️ merging BOUNCES the pod

`reloader.stakater.com/auto` is live: the `dev-env-scripts` ConfigMap change rolls the pod (Recreate → tmux + all agent sessions die). **Merge only when no agent is mid-task.** The README copy refreshes on the same restart via dev-init.

## Testing

Offline harness (stub tmux, local git origin, fake `$HOME` + `CLAUDE_CONFIG_DIR`):
- default → `claude remote-control --name <id> --permission-mode bypassPermissions --debug-file ~/work/<id>.rc.log`
- `--local` → `claude` · `--safe` → `--permission-mode default` (both modes)
- trust seeding: 4/4 fresh worktrees marked trusted, pre-existing entries preserved
- `bash -n` + shellcheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6LjdhGvT6YmK2RmBrYM4W