### PR TITLE
fix(dev-env): agent-run — don't splice --model/--effort into the RC subcommand

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
@@ -282,9 +282,18 @@ reason as your final message."
           # API — the reliable path (the in-TUI slash command is not) — and
           # phone/claude.ai-code drives the session; local attach shows the
           # status/QR/URL screen. Failures self-document in the rc log.
+          #
+          # NB: the subcommand takes NO --model/--effort, and top-level flags
+          # placed BEFORE it make it reject its own --name (`claude $cg
+          # remote-control --name …` → "unknown option --name", verified live).
+          # So an RC host takes its model from the pod settings (Fable) and runs
+          # at the default effort — set a different effort with /effort in the
+          # session, or use --local for a flag-controlled TUI. NEVER splice $cg
+          # here.
+          [ -n "$cg" ] && log "note: --model/--effort don't apply to an RC host (model = pod default; use --local, or set /effort in-session)"
           rc_mode="--permission-mode bypassPermissions"
           [ "$safe" = 1 ] && rc_mode="--permission-mode default"
-          launch="claude$cg remote-control --name $id $rc_mode --debug-file $WORK/$id.rc.log"
+          launch="claude remote-control --name $id $rc_mode --debug-file $WORK/$id.rc.log"
         fi
       else
         launch="$agent $yolo_flag"   # codex: RC is claude-only → local TUI

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
@@ -147,9 +147,11 @@ and open a PR when done.
   count of stranded worktrees), and `agent-run prune` clears the whole backlog in one shot
   (`agent-run reap`'s picker still handles them one at a time).
 - **Pick the model/effort per task.** The pod defaults to Fable; add `--model <m>` and/or
-  `--effort low|medium|high|xhigh|max` to `agent-run run` to override for that session
-  (works for `-p`, `--local`, and Remote-Control launches alike). `--effort ultracode` is a
-  harness session-mode, not a launch value — set it with `/effort` once you're in the session.
+  `--effort low|medium|high|xhigh|max` to `agent-run run` to override for a **`-p` or
+  `--local`** session. They do **not** apply to a Remote-Control host — the reliable `claude
+  remote-control` subcommand takes no such flags — so an RC host runs at the pod-default model
+  (Fable) and default effort; set a different effort with `/effort` once you've connected.
+  `--effort ultracode` is likewise a harness session-mode, not a launch value — set it in-session.
 - **haynesnetwork is pre-warmed**: `pnpm install`, `build`, `typecheck`, and all **1,292 tests**
   (embedded Postgres) pass in this pod. Playwright browsers are installed.
 - **Memory is 24Gi.** The monorepo test suite OOM'd at 8Gi — if a build dies mysteriously,


### PR DESCRIPTION
Follow-up to #2096. Live RC-host testing exposed that `claude $cg remote-control --name <id>` makes the real CLI reject `--name` (`unknown option '--name'`) — the reliable `remote-control` subcommand takes no `--model`/`--effort`, and top-level flags before it break its parsing.

**Fix:** the RC (default `--interactive`) launch no longer prepends `$cg`; it takes model from pod settings (Fable) + default effort (set with `/effort` in-session, or use `--local`). `--model`/`--effort` still work for `-p`/`--local` (verified live). A note is logged if they're passed with RC. README corrected.

The default `agent-run run --interactive` (no flags) was never affected (`$cg` was empty).

Offline harness: 23/23. bash -n clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDB5QY7eWnRUjrheD2kACZ