### PR TITLE
fix(dev-env): agent-run RC host launches --spawn=same-dir

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
@@ -293,7 +293,12 @@ reason as your final message."
           [ -n "$cg" ] && log "note: --model/--effort don't apply to an RC host (model = pod default; use --local, or set /effort in-session)"
           rc_mode="--permission-mode bypassPermissions"
           [ "$safe" = 1 ] && rc_mode="--permission-mode default"
-          launch="claude remote-control --name $id $rc_mode --debug-file $WORK/$id.rc.log"
+          # --spawn=same-dir: newer claude prompts "[1] same-dir / [2] worktree"
+          # on startup and BLOCKS there un-registered (not phone-reachable) until
+          # answered. Pin same-dir so the host registers immediately AND so phone/
+          # web sessions reuse this worktree instead of spawning fresh ones (which
+          # would re-grow the very worktree sprawl reap/prune exist to control).
+          launch="claude remote-control --name $id --spawn same-dir $rc_mode --debug-file $WORK/$id.rc.log"
         fi
       else
         launch="$agent $yolo_flag"   # codex: RC is claude-only → local TUI

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
@@ -161,8 +161,11 @@ and open a PR when done.
   Claude mobile app or claude.ai/code; `agent-run attach <id>` shows the status screen
   with the QR code + URL. This uses the standalone `claude remote-control` registration
   path (api.anthropic.com environments API), which is reliable; fresh worktrees are
-  pre-trusted by agent-run so nothing stops at a dialog. If a host ever fails to
-  connect, the reason is in `~/work/<id>.rc.log` — no more silent failures.
+  pre-trusted by agent-run so nothing stops at a dialog, and the host is launched
+  `--spawn=same-dir` so it registers immediately (no spawn-mode prompt) with phone/web
+  sessions reusing this worktree — press `w` in the host to switch to per-session
+  worktrees. If a host ever fails to connect, the reason is in `~/work/<id>.rc.log` — no
+  more silent failures.
 - **Prefer a classic terminal TUI?** Add `--local`. You can still type `/remote-control`
   inside it, but know that the *in-TUI* path is flaky server-side (intermittent 401s on
   the code-session endpoints — anthropics/claude-code#30093 #30102 — and after 3 failed


### PR DESCRIPTION
Follow-up to #2096/#2166. Newer `claude` prompts for a spawn mode (`[1] same-dir / [2] worktree`) on `remote-control` startup and **blocks there un-registered** until answered — so an agent-run RC host wasn't phone-reachable until someone attached and picked a mode. Verified live.

**Fix:** launch with `--spawn=same-dir` → registers immediately (Connected, env id, QR/URL), and phone/web sessions reuse the host's worktree instead of spawning fresh ones per session (avoids re-growing worktree sprawl). `w` in the host toggles to per-session worktrees. README updated.

bash -n + offline harness (23/23) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDB5QY7eWnRUjrheD2kACZ