### PR TITLE
feat(dev-env): picker-driven agent-run run + deterministic xhigh effort

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
@@ -9,7 +9,8 @@
 #   agent-run run                               # bare → walks you through it: repo picker
 #                                               # (my repos, newest activity first) → agent
 #                                               # picker → interactive? [Y/n] (n → task
-#                                               # prompt) → effort picker (claude)
+#                                               # prompt; claude Y → remote-control host?
+#                                               # [Y/n]) → effort picker (claude)
 #   agent-run list                                              # live tasks + attach cmds
 #   agent-run attach [<task-id>]                # jump into a session (no id → picker)
 #   agent-run detach [<task-id>]                # kick attached clients off (no id → picker)
@@ -19,8 +20,9 @@
 # `run` fills every omitted choice interactively (so nobody has to remember exact
 # repo names): the repo picker lists the owner's GitHub repos newest-pushed first
 # (offline fallback: local canonical clones by last fetch), the agent picker offers
-# claude|codex, with neither -p nor --interactive it asks which mode you want, and
-# claude runs get an effort picker. Flags always win — scripted/agent callers pass
+# claude|codex, with neither -p nor --interactive it asks which mode you want (and,
+# for a claude interactive session, remote-control host vs local TUI), and claude
+# runs get an effort picker. Flags always win — scripted/agent callers pass
 # them and see no prompts (and get the same defaults, e.g. effort=xhigh).
 # --interactive default is a REMOTE-CONTROL host (phone/web drives it); --local is
 # the classic in-terminal TUI; --safe keeps permission prompts. Claude effort
@@ -53,6 +55,7 @@ agent-run — worktree-per-task agent dispatcher
                                               #   repo   → picker, my repos by latest activity
                                               #   agent  → picker, claude | codex
                                               #   mode   → interactive? [Y/n] (n → type a task prompt)
+                                              #   drive  → remote-control host? [Y/n] (claude interactive)
                                               #   effort → picker (claude only)
       --repo <name>                           # same as the positional <repo>
       --agent claude|codex
@@ -289,7 +292,16 @@ case "$cmd" in
             IFS= read -r prompt </dev/tty || prompt=""
             [ -n "$prompt" ] || die "a fire-and-forget run needs a task prompt"
             ;;
-          *) interactive=1 ;;
+          *) interactive=1
+             # RC host (the default) vs classic in-terminal TUI (--local). Only
+             # claude has an RC host — codex interactive is always a local TUI —
+             # so ask for claude only, and skip if --local already pinned it.
+             if [ "$agent" = claude ] && [ "$local_tui" != 1 ]; then
+               printf 'remote-control host — drive from phone/web? [Y/n] ' >/dev/tty
+               IFS= read -r rc </dev/tty || rc=""
+               case "$rc" in n|N|no|NO) local_tui=1 ;; esac
+             fi
+             ;;
         esac
       else
         die "need -p or --interactive"

--- a/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
@@ -6,29 +6,40 @@
 #
 #   agent-run run  [<repo>] [--agent claude|codex] [--base <ref>] [-p "<task>"]
 #                  [--interactive] [--local] [--safe] [--model <m>] [--effort <l>]
-#   agent-run run                               # bare → walks you through it: repo picker
-#                                               # (my repos, newest activity first) → agent
-#                                               # picker → interactive? [Y/n] (n → task
-#                                               # prompt; claude Y → remote-control host?
-#                                               # [Y/n]) → effort picker (claude)
+#   agent-run run                               # bare → walks you through it, TOOL-FIRST:
+#                                               # repo → agent (claude|codex) → interactive?
+#                                               # [Y/n] (n → task prompt; claude Y →
+#                                               # remote-control host? [Y/n]) → model →
+#                                               # effort. Each step shows that tool's options.
 #   agent-run list                                              # live tasks + attach cmds
 #   agent-run attach [<task-id>]                # jump into a session (no id → picker)
 #   agent-run detach [<task-id>]                # kick attached clients off (no id → picker)
 #   agent-run reap   [<task-id>] [--force]      # kill + cleanup (no id → picker)
 #   agent-run prune  [--yes] [--force]          # bulk-clean ALL stranded worktrees (dry-run w/o --yes)
 #
-# `run` fills every omitted choice interactively (so nobody has to remember exact
-# repo names): the repo picker lists the owner's GitHub repos newest-pushed first
-# (offline fallback: local canonical clones by last fetch), the agent picker offers
-# claude|codex, with neither -p nor --interactive it asks which mode you want (and,
-# for a claude interactive session, remote-control host vs local TUI), and claude
-# runs get an effort picker. Flags always win — scripted/agent callers pass
-# them and see no prompts (and get the same defaults, e.g. effort=xhigh).
-# --interactive default is a REMOTE-CONTROL host (phone/web drives it); --local is
-# the classic in-terminal TUI; --safe keeps permission prompts. Claude effort
-# DEFAULTS TO xhigh in every mode (-p / --local via the --effort flag, RC hosts via
-# CLAUDE_CODE_EFFORT_LEVEL in the launch env); --model applies to -p/--local only —
-# an RC host's model is the pod settings default (Fable).
+# `run` fills every omitted choice interactively, TOOL-FIRST: pick the repo, then
+# the agent (claude|codex), and every later step shows only that tool's options.
+# repo picker = owner's GitHub repos newest-pushed first (offline fallback: local
+# clones by last fetch). With neither -p nor --interactive it asks the mode; a
+# claude interactive session then asks remote-control-host vs local TUI. Then a
+# MODEL picker (claude: fable/opus/sonnet/haiku; codex: gpt-5.6 sol/terra/luna,
+# 5.5, 5.2) and an EFFORT picker filtered to that model's levels (claude's are
+# uniform; codex's vary — only gpt-5.6 has max, only sol/terra add ultra). Flags
+# always win — scripted callers pass them and see no prompts (defaults: effort
+# xhigh, model = each tool's own default).
+#
+# model/effort plumbing: claude reads --model/--effort (top-level); codex reads
+# -m <model> + -c model_reasoning_effort=<level>. Effort DEFAULTS TO xhigh in every
+# mode. Exceptions: a claude RC host takes neither top-level flag (the subcommand
+# rejects them) so its model is the pod default (fable-5[1m]) and its effort rides
+# CLAUDE_CODE_EFFORT_LEVEL in the launch env. --local is the classic in-terminal
+# TUI; --safe keeps permission prompts.
+#
+# NB codex remote-control: codex DOES have an in-pod RC equivalent (codex
+# remote-control / app-server), but it needs the STANDALONE codex install
+# (~/.codex/packages/standalone) and this pod ships the npm install, so it can't
+# start here. Deferred until the image bakes the standalone in — codex interactive
+# stays a local TUI for now.
 #
 # attach/detach/reap without an id open an arrow-key picker (↑/↓ + Enter, q
 # cancels) showing each task's start time; reap's picker also lists STRANDED
@@ -51,21 +62,27 @@ die() { log "ERROR: $*"; exit 1; }
 usage() {
   cat >&2 <<'EOF'
 agent-run — worktree-per-task agent dispatcher
-  agent-run run [<repo>] [flags]              # every omitted choice is asked interactively:
+  agent-run run [<repo>] [flags]              # every omitted choice is asked interactively,
+                                              # TOOL-FIRST (each step shows that tool's options):
                                               #   repo   → picker, my repos by latest activity
                                               #   agent  → picker, claude | codex
                                               #   mode   → interactive? [Y/n] (n → type a task prompt)
                                               #   drive  → remote-control host? [Y/n] (claude interactive)
-                                              #   effort → picker (claude only)
+                                              #   model  → picker (claude: fable/opus/sonnet/haiku;
+                                              #            codex: gpt-5.6 sol/terra/luna, 5.5, 5.2)
+                                              #   effort → picker, filtered to the model's levels
       --repo <name>                           # same as the positional <repo>
       --agent claude|codex
       --base <ref>                            # branch the worktree off this (default: origin/HEAD)
       -p "<task>"                             # fire-and-forget; log at ~/work/<id>.log
-      --interactive                           # Remote Control host (drive from phone/claude.ai/code)
-      --local                                 # classic in-terminal TUI instead of RC host
+      --interactive                           # claude: Remote Control host (drive from phone/web);
+                                              #   codex: local TUI (its RC host needs the standalone install)
+      --local                                 # claude: classic in-terminal TUI instead of the RC host
       --safe                                  # keep permission prompts (default: skipped — pod is the sandbox)
-      --effort low|medium|high|xhigh|max      # claude only; DEFAULT xhigh (RC hosts get it via env var)
-      --model <m>                             # override the pod default model; -p/--local only, not RC
+      --model <m>                             # claude alias/id (fable|opus|sonnet|haiku|…) or codex slug;
+                                              #   claude -p/--local only (an RC host runs the pod default)
+      --effort <level>                        # claude: low|medium|high|xhigh|max; codex: +ultra (model-dependent)
+                                              #   DEFAULT xhigh (claude RC hosts get it via env var)
   agent-run list
   agent-run attach [<task-id>]                # no id → arrow-key picker
   agent-run detach [<task-id>]                # no id → picker (attached sessions only)
@@ -234,6 +251,22 @@ pretrust() {  # $1 = worktree path
   fi
 }
 
+# Codex reasoning-effort picker rows for the given model, xhigh first (the dev-env
+# default — every current codex model supports xhigh). The set differs by model:
+# only the gpt-5.6 family adds `max`, and only sol/terra add `ultra` (codex's
+# per-model supported_reasoning_levels in models.json). Blank/unknown model → the
+# common low|medium|high|xhigh set. pick() returns each row's first token as the value.
+codex_effort_rows() {
+  case "$1" in
+    gpt-5.6-sol|gpt-5.6-terra)
+      printf '%s\n' 'xhigh   (dev-env default)' 'ultra   (max reasoning + auto-delegation)' 'max' 'high' 'medium' 'low' ;;
+    gpt-5.6-luna)
+      printf '%s\n' 'xhigh   (dev-env default)' 'max' 'high' 'medium' 'low' ;;
+    *)
+      printf '%s\n' 'xhigh   (dev-env default)' 'high' 'medium' 'low' ;;
+  esac
+}
+
 # Every task shell needs the fresh bot token (bashrc handles interactive shells;
 # tmux run-shell strings need it inline).
 token_env='export GH_TOKEN="$(cat /creds/gh_token 2>/dev/null)"'
@@ -259,12 +292,6 @@ case "$cmd" in
            repo="$1"; shift ;;   # positional shorthand: agent-run run <repo>
       esac
     done
-    if [ -n "$effort" ]; then   # fail fast, before pickers and clone/worktree side effects
-      case "$effort" in low|medium|high|xhigh|max) : ;;
-        *) die "--effort must be low|medium|high|xhigh|max (got '$effort'); 'ultracode' is a /effort session-mode — set it in-session" ;;
-      esac
-    fi
-
     # Anything not pinned by a flag is asked interactively — bare `agent-run run`
     # walks repo → agent → mode → effort, so nobody has to remember exact repo
     # names. Pickers need a TTY; scripted callers pass flags and never see a prompt.
@@ -281,6 +308,19 @@ case "$cmd" in
         'codex   Codex CLI (ChatGPT plan)')" || die "--agent must be claude|codex"
     fi
     case "$agent" in claude|codex) : ;; *) die "--agent must be claude|codex" ;; esac
+    # Validate --effort against the SELECTED tool's levels — fail fast, before any
+    # clone/worktree side effects (the repo/agent pickers above are read-only).
+    # claude: low|medium|high|xhigh|max (harness levels, uniform across models).
+    # codex adds `ultra` (gpt-5.6 sol/terra only); a level a given model doesn't
+    # advertise is clamped server-side, so we don't hard-fail per-model here.
+    if [ -n "$effort" ]; then
+      case "$agent" in
+        claude) case "$effort" in low|medium|high|xhigh|max) : ;;
+          *) die "claude --effort must be low|medium|high|xhigh|max (got '$effort'); 'ultracode' is a /effort session-mode — set it in-session" ;; esac ;;
+        codex)  case "$effort" in low|medium|high|xhigh|max|ultra) : ;;
+          *) die "codex --effort must be low|medium|high|xhigh|max|ultra (got '$effort')" ;; esac ;;
+      esac
+    fi
     if [ "$interactive" != 1 ] && [ -z "$prompt" ]; then
       if { : </dev/tty; } 2>/dev/null; then
         asked=1
@@ -307,20 +347,53 @@ case "$cmd" in
         die "need -p or --interactive"
       fi
     fi
-    # Effort is DETERMINISTIC now: claude runs default to xhigh unless --effort
-    # says otherwise. (Historically NOTHING set it — no flag reached RC hosts, no
-    # settings key, no env var — so every session silently ran at the model
-    # default, high for Fable.) In menu mode it's one more picker; a fully-
-    # flagged call stays prompt-free and just gets the xhigh default. Codex has
-    # no effort dial — skipped.
-    if [ "$agent" = claude ] && [ -z "$effort" ]; then
+    # --- model picker (menu mode) ---
+    # Skip for a claude RC host: `claude remote-control` rejects a top-level
+    # --model, so an RC host always runs the pod-default model (fable-5[1m]).
+    # Every other tool+mode honors a chosen model, and the effort picker below
+    # then filters to that model's supported levels (only varies for codex).
+    claude_rc=0
+    [ "$interactive" = 1 ] && [ "$agent" = claude ] && [ "$local_tui" != 1 ] && claude_rc=1
+    if [ -z "$model" ] && [ "$asked" = 1 ] && [ "$claude_rc" != 1 ]; then
+      if [ "$agent" = claude ]; then
+        model="$(pick 'model:' \
+          'fable   Fable 5 · 1M ctx (dev-env default)' \
+          'opus    Opus 4.8' \
+          'sonnet  Sonnet 5' \
+          'haiku   Haiku 4.5')" || model=""
+        # The 'fable' alias resolves to the 200k-ctx model; the pod default is the
+        # 1M variant (settings.json → claude-fable-5[1m]). Keep the default choice
+        # as "leave unset" so the pod default stands; only a real switch sets --model.
+        [ "$model" = fable ] && model=""
+      else
+        model="$(pick 'model:' \
+          'gpt-5.6-sol    frontier agentic coding (default)' \
+          'gpt-5.6-terra  balanced everyday' \
+          'gpt-5.6-luna   fast & affordable' \
+          'gpt-5.5        prior frontier' \
+          'gpt-5.2        long-running agents')" || model=""
+      fi
+    fi
+
+    # --- effort (deterministic default xhigh; menu filters to the model's set) ---
+    # Historically NOTHING set effort — no flag reached RC hosts, no settings key,
+    # no env var — so every session silently ran at the model default. Now every
+    # run gets a level: a menu shows a picker (claude's levels are uniform across
+    # models; codex's are filtered to the selected model), a flagged call takes the
+    # xhigh default. xhigh is valid for every current claude AND codex model.
+    if [ -z "$effort" ]; then
       if [ "$asked" = 1 ]; then
-        effort="$(pick 'effort:' \
-          'xhigh   (dev-env default)' \
-          'max     (hardest problems, slowest)' \
-          "high    (claude's stock default)" \
-          'medium' \
-          'low')" || effort=xhigh
+        if [ "$agent" = claude ]; then
+          effort="$(pick 'effort:' \
+            'xhigh   (dev-env default)' \
+            'max     (hardest problems, slowest)' \
+            "high    (claude's stock default)" \
+            'medium' \
+            'low')" || effort=xhigh
+        else
+          mapfile -t erows < <(codex_effort_rows "$model")
+          effort="$(pick 'effort:' "${erows[@]}")" || effort=xhigh
+        fi
       else
         effort=xhigh
       fi
@@ -348,21 +421,22 @@ git worktrees, create them under $WORK and 'git worktree remove' each once its P
 merges — never leave stranded worktrees behind. If blocked, write BLOCKED and the \
 reason as your final message."
 
-    # Top-level claude flags — model/effort — for -p and --local launches; they
-    # MUST sit in top-level position (before any subcommand), which is where
-    # claude reads them. RC hosts can't take them (see the NB below): there,
-    # effort rides the CLAUDE_CODE_EFFORT_LEVEL env var instead and model stays
-    # the pod settings.json default (Fable). No-op for codex.
+    # Model/effort ride into the launch differently per tool. CLAUDE reads them as
+    # TOP-LEVEL flags (--model/--effort, before any subcommand — that's where claude
+    # looks); a claude RC host is the exception (see the NB below) and takes neither
+    # there. CODEX reads them as `-m <model>` + `-c model_reasoning_effort=<level>`,
+    # on both `codex exec` and the interactive TUI. Build each tool's flag string
+    # from the same resolved $model/$effort; the other stays empty.
     # %q-escape the values: they ride through one more shell layer (tmux send-keys
     # re-parses the launch string), and a legit value like 'claude-fable-5[1m]'
     # carries glob metacharacters that would otherwise be pathname-expanded.
-    cg=""
-    [ -n "$model" ]  && cg="$cg --model $(printf '%q' "$model")"
-    [ -n "$effort" ] && cg="$cg --effort $(printf '%q' "$effort")"
+    cg="" xc=""
+    if [ -n "$model" ];  then cg="$cg --model $(printf '%q' "$model")";  xc="$xc -m $(printf '%q' "$model")"; fi
+    if [ -n "$effort" ]; then cg="$cg --effort $(printf '%q' "$effort")"; xc="$xc -c model_reasoning_effort=$(printf '%q' "$effort")"; fi
 
     case "$agent" in
       claude) run_cmd="claude$cg --dangerously-skip-permissions --append-system-prompt \"\$AGENT_GUARD\" -p \"\$AGENT_PROMPT\" --output-format text" ;;
-      codex)  run_cmd="codex exec --dangerously-bypass-approvals-and-sandbox \"\$AGENT_GUARD \$AGENT_PROMPT\"" ;;
+      codex)  run_cmd="codex exec$xc --dangerously-bypass-approvals-and-sandbox \"\$AGENT_GUARD \$AGENT_PROMPT\"" ;;
     esac
 
     # YOLO BY DEFAULT — interactive too. The whole point of this pod is that the
@@ -419,11 +493,17 @@ reason as your final message."
           [ -n "$effort" ] && launch="CLAUDE_CODE_EFFORT_LEVEL=$(printf '%q' "$effort") $launch"
         fi
       else
-        launch="$agent $yolo_flag"   # codex: RC is claude-only → local TUI
+        # codex interactive = local in-terminal TUI. Its remote-control host
+        # (codex remote-control / app-server) needs the STANDALONE codex install
+        # this pod lacks (npm install → no ~/.codex/packages/standalone/current),
+        # so RC is deferred; model/effort still apply via -m / -c on the TUI.
+        launch="codex$xc $yolo_flag"
       fi
       tmux send-keys -t "task-$id" "$token_env; cd $wt; $launch" Enter
       if [ "$agent" = claude ] && [ "$local_tui" != 1 ]; then
         log "remote-control host starting (effort=${effort:-model-default}) → QR/URL: agent-run attach $id   rc log: $WORK/$id.rc.log"
+      elif [ "$agent" = codex ]; then
+        log "codex local TUI ready (model=${model:-default} effort=${effort:-default}; remote-control needs the standalone install — deferred) →  agent-run attach $id"
       else
         log "interactive session ready →  agent-run attach $id"
       fi

--- a/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh
@@ -4,16 +4,29 @@
 # concurrent agents in the same repo never collide. GitOps-managed — edit in
 # kubernetes/main/apps/dev/dev-env/app/resources/agent-run.sh.
 #
-#   agent-run run  --repo <name> --agent claude|codex [--base <ref>] -p "<task>"
-#   agent-run run  --repo <name> --agent claude --interactive   # REMOTE-CONTROL host (phone/web drives it)
-#                                                 [--local]     # classic in-terminal TUI instead
-#                                                 [--safe]      # keep permission prompts
-#                                     [--model <m>] [--effort <l>]  # override the pod default (Fable)
+#   agent-run run  [<repo>] [--agent claude|codex] [--base <ref>] [-p "<task>"]
+#                  [--interactive] [--local] [--safe] [--model <m>] [--effort <l>]
+#   agent-run run                               # bare → walks you through it: repo picker
+#                                               # (my repos, newest activity first) → agent
+#                                               # picker → interactive? [Y/n] (n → task
+#                                               # prompt) → effort picker (claude)
 #   agent-run list                                              # live tasks + attach cmds
 #   agent-run attach [<task-id>]                # jump into a session (no id → picker)
 #   agent-run detach [<task-id>]                # kick attached clients off (no id → picker)
 #   agent-run reap   [<task-id>] [--force]      # kill + cleanup (no id → picker)
 #   agent-run prune  [--yes] [--force]          # bulk-clean ALL stranded worktrees (dry-run w/o --yes)
+#
+# `run` fills every omitted choice interactively (so nobody has to remember exact
+# repo names): the repo picker lists the owner's GitHub repos newest-pushed first
+# (offline fallback: local canonical clones by last fetch), the agent picker offers
+# claude|codex, with neither -p nor --interactive it asks which mode you want, and
+# claude runs get an effort picker. Flags always win — scripted/agent callers pass
+# them and see no prompts (and get the same defaults, e.g. effort=xhigh).
+# --interactive default is a REMOTE-CONTROL host (phone/web drives it); --local is
+# the classic in-terminal TUI; --safe keeps permission prompts. Claude effort
+# DEFAULTS TO xhigh in every mode (-p / --local via the --effort flag, RC hosts via
+# CLAUDE_CODE_EFFORT_LEVEL in the launch env); --model applies to -p/--local only —
+# an RC host's model is the pod settings default (Fable).
 #
 # attach/detach/reap without an id open an arrow-key picker (↑/↓ + Enter, q
 # cancels) showing each task's start time; reap's picker also lists STRANDED
@@ -36,12 +49,20 @@ die() { log "ERROR: $*"; exit 1; }
 usage() {
   cat >&2 <<'EOF'
 agent-run — worktree-per-task agent dispatcher
-  agent-run run  --repo <name> --agent claude|codex [--base <ref>] -p "<task>"
-  agent-run run  --repo <name> --agent claude --interactive [--local] [--safe]
-                 [--model <m>] [--effort low|medium|high|xhigh|max]
-                 # default: Remote Control host (drive from phone/claude.ai/code)
-                 # --local: classic in-terminal TUI instead
-                 # --model/--effort override the pod default (Fable, session effort)
+  agent-run run [<repo>] [flags]              # every omitted choice is asked interactively:
+                                              #   repo   → picker, my repos by latest activity
+                                              #   agent  → picker, claude | codex
+                                              #   mode   → interactive? [Y/n] (n → type a task prompt)
+                                              #   effort → picker (claude only)
+      --repo <name>                           # same as the positional <repo>
+      --agent claude|codex
+      --base <ref>                            # branch the worktree off this (default: origin/HEAD)
+      -p "<task>"                             # fire-and-forget; log at ~/work/<id>.log
+      --interactive                           # Remote Control host (drive from phone/claude.ai/code)
+      --local                                 # classic in-terminal TUI instead of RC host
+      --safe                                  # keep permission prompts (default: skipped — pod is the sandbox)
+      --effort low|medium|high|xhigh|max      # claude only; DEFAULT xhigh (RC hosts get it via env var)
+      --model <m>                             # override the pod default model; -p/--local only, not RC
   agent-run list
   agent-run attach [<task-id>]                # no id → arrow-key picker
   agent-run detach [<task-id>]                # no id → picker (attached sessions only)
@@ -107,6 +128,37 @@ pick() {
 # Emit "id|attached-count" for every live task session.
 live_tasks() {
   tmux ls -F '#{session_name}|#{session_attached}' 2>/dev/null | sed -n 's/^task-//p'
+}
+
+# Rows for the repo picker: "name  pushed MM-DD HH:MM", newest activity first.
+# GitHub is the source of truth (it shows repos not yet cloned to this pod). Two
+# lookup paths because the pod credential is a GitHub App installation token:
+# `gh repo list` (GraphQL) covers PATs and app tokens that can search, and REST
+# /installation/repositories is the endpoint purpose-built for app tokens. If
+# both fail (offline / no token) fall back to the local canonical clones,
+# ordered by last fetch — degraded but never empty on a working pod.
+repo_rows() {
+  local out name ts
+  [ -n "${GH_TOKEN:-}" ] || { [ -s /creds/gh_token ] && export GH_TOKEN="$(cat /creds/gh_token)"; }
+  out="$(gh repo list "$OWNER" --limit 100 --no-archived --json name,pushedAt \
+           --jq 'sort_by(.pushedAt) | reverse | .[] | "\(.name)|\(.pushedAt)"' 2>/dev/null)"
+  [ -n "$out" ] || out="$(gh api --paginate /installation/repositories \
+           --jq '.repositories[] | select(.archived | not) | "\(.name)|\(.pushed_at)"' 2>/dev/null \
+         | sort -t'|' -k2,2 -r)"
+  if [ -n "$out" ]; then
+    while IFS='|' read -r name ts; do
+      [ -n "$name" ] || continue
+      printf '%s  pushed %s\n' "$name" "$(date -d "$ts" '+%m-%d %H:%M' 2>/dev/null || printf '%s' "${ts%%T*}")"
+    done <<<"$out"
+  else
+    log "GitHub repo list unavailable — showing local clones only"
+    for r in "$REPOS"/*/; do
+      [ -d "$r/.git" ] || continue
+      printf '%s|%s\n' "$(stat -c %Y "$r/.git/FETCH_HEAD" 2>/dev/null || stat -c %Y "$r/.git")" "$(basename "$r")"
+    done | sort -t'|' -k1,1 -rn | while IFS='|' read -r _ name; do
+      printf '%s  (local clone)\n' "$name"
+    done
+  fi
 }
 
 # Resolve the canonical repo working dir that OWNS a linked worktree — works for
@@ -199,16 +251,67 @@ case "$cmd" in
         --model) model="$2"; shift 2 ;;
         --effort) effort="$2"; shift 2 ;;
         --safe) safe=1; shift ;;
-        *) die "unknown flag $1" ;;
+        -*) die "unknown flag $1" ;;
+        *) [ -z "$repo" ] || die "unexpected argument '$1' (repo already '$repo')"
+           repo="$1"; shift ;;   # positional shorthand: agent-run run <repo>
       esac
     done
-    [ -n "$repo" ] || die "--repo required"
-    case "$agent" in claude|codex) : ;; *) die "--agent must be claude|codex" ;; esac
-    [ "$interactive" = 1 ] || [ -n "$prompt" ] || die "need -p or --interactive"
-    if [ -n "$effort" ]; then   # fail fast, before any clone/worktree side effects
+    if [ -n "$effort" ]; then   # fail fast, before pickers and clone/worktree side effects
       case "$effort" in low|medium|high|xhigh|max) : ;;
         *) die "--effort must be low|medium|high|xhigh|max (got '$effort'); 'ultracode' is a /effort session-mode — set it in-session" ;;
       esac
+    fi
+
+    # Anything not pinned by a flag is asked interactively — bare `agent-run run`
+    # walks repo → agent → mode → effort, so nobody has to remember exact repo
+    # names. Pickers need a TTY; scripted callers pass flags and never see a prompt.
+    asked=0
+    if [ -z "$repo" ]; then
+      asked=1
+      mapfile -t rows < <(repo_rows)
+      repo="$(pick 'run an agent in repo:' ${rows[@]+"${rows[@]}"})" || die "--repo required"
+    fi
+    if [ -z "$agent" ]; then
+      asked=1
+      agent="$(pick 'agent:' \
+        'claude  Claude Code (Max plan)' \
+        'codex   Codex CLI (ChatGPT plan)')" || die "--agent must be claude|codex"
+    fi
+    case "$agent" in claude|codex) : ;; *) die "--agent must be claude|codex" ;; esac
+    if [ "$interactive" != 1 ] && [ -z "$prompt" ]; then
+      if { : </dev/tty; } 2>/dev/null; then
+        asked=1
+        printf 'interactive session (you drive it)? [Y/n] ' >/dev/tty
+        IFS= read -r ans </dev/tty || ans=""
+        case "$ans" in
+          n|N|no|NO)
+            printf 'task prompt> ' >/dev/tty
+            IFS= read -r prompt </dev/tty || prompt=""
+            [ -n "$prompt" ] || die "a fire-and-forget run needs a task prompt"
+            ;;
+          *) interactive=1 ;;
+        esac
+      else
+        die "need -p or --interactive"
+      fi
+    fi
+    # Effort is DETERMINISTIC now: claude runs default to xhigh unless --effort
+    # says otherwise. (Historically NOTHING set it — no flag reached RC hosts, no
+    # settings key, no env var — so every session silently ran at the model
+    # default, high for Fable.) In menu mode it's one more picker; a fully-
+    # flagged call stays prompt-free and just gets the xhigh default. Codex has
+    # no effort dial — skipped.
+    if [ "$agent" = claude ] && [ -z "$effort" ]; then
+      if [ "$asked" = 1 ]; then
+        effort="$(pick 'effort:' \
+          'xhigh   (dev-env default)' \
+          'max     (hardest problems, slowest)' \
+          "high    (claude's stock default)" \
+          'medium' \
+          'low')" || effort=xhigh
+      else
+        effort=xhigh
+      fi
     fi
 
     # Canonical clone: fetch-only, never worked in directly.
@@ -233,10 +336,11 @@ git worktrees, create them under $WORK and 'git worktree remove' each once its P
 merges — never leave stranded worktrees behind. If blocked, write BLOCKED and the \
 reason as your final message."
 
-    # Optional top-level claude flags — model/effort — apply to -p, --local, and RC
-    # launches alike. Model otherwise defaults to the pod settings.json (Fable);
-    # these MUST sit in top-level position (before the remote-control subcommand),
-    # which is where claude reads them. No-op for codex.
+    # Top-level claude flags — model/effort — for -p and --local launches; they
+    # MUST sit in top-level position (before any subcommand), which is where
+    # claude reads them. RC hosts can't take them (see the NB below): there,
+    # effort rides the CLAUDE_CODE_EFFORT_LEVEL env var instead and model stays
+    # the pod settings.json default (Fable). No-op for codex.
     # %q-escape the values: they ride through one more shell layer (tmux send-keys
     # re-parses the launch string), and a legit value like 'claude-fable-5[1m]'
     # carries glob metacharacters that would otherwise be pathname-expanded.
@@ -286,11 +390,12 @@ reason as your final message."
           # NB: the subcommand takes NO --model/--effort, and top-level flags
           # placed BEFORE it make it reject its own --name (`claude $cg
           # remote-control --name …` → "unknown option --name", verified live).
-          # So an RC host takes its model from the pod settings (Fable) and runs
-          # at the default effort — set a different effort with /effort in the
-          # session, or use --local for a flag-controlled TUI. NEVER splice $cg
-          # here.
-          [ -n "$cg" ] && log "note: --model/--effort don't apply to an RC host (model = pod default; use --local, or set /effort in-session)"
+          # NEVER splice $cg here. Model therefore comes from the pod settings
+          # (Fable). Effort DOES apply now: CLAUDE_CODE_EFFORT_LEVEL is set in
+          # the launch env below and sessions the host spawns inherit it (env
+          # precedence: /effort > --effort flag > this var > settings.json —
+          # code.claude.com/docs/en/env-vars). /effort in-session still wins.
+          [ -n "$model" ] && log "note: --model doesn't apply to an RC host (model = pod settings default; use --local for a flag-controlled TUI)"
           rc_mode="--permission-mode bypassPermissions"
           [ "$safe" = 1 ] && rc_mode="--permission-mode default"
           # --spawn=same-dir: newer claude prompts "[1] same-dir / [2] worktree"
@@ -299,13 +404,14 @@ reason as your final message."
           # web sessions reuse this worktree instead of spawning fresh ones (which
           # would re-grow the very worktree sprawl reap/prune exist to control).
           launch="claude remote-control --name $id --spawn same-dir $rc_mode --debug-file $WORK/$id.rc.log"
+          [ -n "$effort" ] && launch="CLAUDE_CODE_EFFORT_LEVEL=$(printf '%q' "$effort") $launch"
         fi
       else
         launch="$agent $yolo_flag"   # codex: RC is claude-only → local TUI
       fi
       tmux send-keys -t "task-$id" "$token_env; cd $wt; $launch" Enter
       if [ "$agent" = claude ] && [ "$local_tui" != 1 ]; then
-        log "remote-control host starting → QR/URL: agent-run attach $id   rc log: $WORK/$id.rc.log"
+        log "remote-control host starting (effort=${effort:-model-default}) → QR/URL: agent-run attach $id   rc log: $WORK/$id.rc.log"
       else
         log "interactive session ready →  agent-run attach $id"
       fi

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
@@ -1,43 +1,35 @@
 # dev-env — your in-cluster agent workspace
 
-You're in a 24/7 pod in the `main` cluster (namespace `dev`). Everything here is
-GitOps-managed: this README lives at
-`kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md` in **haynes-ops** —
-edit it there, not here (a pod restart overwrites this copy).
+You're in a 24/7 pod in the `main` cluster (namespace `dev`). Everything here is GitOps-managed: this README lives at `kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md` in **haynes-ops** — edit it there, not here (a pod restart overwrites this copy).
 
 > **Tip:** `Ctrl+Shift+V` renders this markdown. `` Ctrl+` `` opens a terminal.
 
----
-
-## 1. Start an agent (the 30-second version)
+## Quick start
 
 Open a terminal and run:
 
 ```bash
-agent-run run --repo haynesnetwork --agent claude --interactive
+agent-run run
 ```
 
-That drops you into a live Claude session inside a **fresh git worktree** on its own branch.
-Talk to it like you would anywhere else. Swap `--agent codex` for the ChatGPT plan.
+That's the whole command. Everything you don't specify is asked with an arrow-key picker: **repo** (your GitHub repos, newest activity first — no need to remember exact names), **agent** (`claude` or `codex`), **mode** (interactive session, or type a task prompt for fire-and-forget), and **effort** for claude runs (default `xhigh`). The agent then starts in a **fresh git worktree** on its own branch, inside tmux.
 
-**Permissions are skipped by default** — `claude --dangerously-skip-permissions` /
-`codex --dangerously-bypass-approvals-and-sandbox`. You don't need to type those; the pod
-*is* the sandbox (isolated worktree, scoped ServiceAccount, default-deny egress), so
-approving every edit inside it would be theater. Add **`--safe`** if you want the normal
-permission prompts back for a particular task.
-
-To fire off a task and walk away instead:
+Know what you want? Flags skip the pickers, and `agent-run run <repo>` is a positional shorthand:
 
 ```bash
-agent-run run --repo haynes-ops --agent claude -p "Bump the coredns chart and open a PR"
+agent-run run haynesnetwork --agent claude --interactive
+agent-run run --repo haynes-ops --agent claude --effort max -p "Bump the coredns chart and open a PR"
 ```
 
----
+An interactive run starts a **Remote Control host** by default — connect from the Claude mobile app or claude.ai/code; `agent-run attach <id>` shows the status screen with the QR code + URL. Add `--local` for a classic in-terminal TUI instead.
 
-## 2. tmux — the only 3 keys you need
+**Permissions are skipped by default** (`claude --dangerously-skip-permissions` / `codex --dangerously-bypass-approvals-and-sandbox` — you don't type those). The pod *is* the sandbox: isolated worktree, scoped ServiceAccount, default-deny egress. Add **`--safe`** to keep the normal permission prompts for a task you want to babysit.
 
-Agents run inside **tmux** so they survive you closing the browser. tmux uses a "prefix"
-key: you tap **Ctrl+B**, *release*, then press one more key.
+**Effort defaults to `xhigh`** for claude runs — deterministically, in every mode. Override with `--effort low|medium|high|xhigh|max` (or the picker), or mid-session with `/effort`. Details in [Model & effort](#model--effort) below.
+
+## tmux — the only 3 keys you need
+
+Agents run inside **tmux** so they survive you closing the browser. tmux uses a "prefix" key: you tap **Ctrl+B**, *release*, then press one more key.
 
 | Keys | What it does |
 |---|---|
@@ -45,18 +37,9 @@ key: you tap **Ctrl+B**, *release*, then press one more key.
 | **Ctrl+B**, then **[** | **Scroll back.** Arrows/PageUp to read history, **q** to stop scrolling. *(Mouse scroll won't work — this is the one that trips everyone.)* |
 | **Ctrl+B**, then **c** | New window (a second shell in the same session). |
 
-That's it. Everything else is optional.
+> **⚠️ code-server steals Ctrl+B** (it's VS Code's "toggle sidebar" shortcut), so in the integrated terminal here the detach keystroke usually never reaches tmux. Detach from any *other* terminal instead: **`agent-run detach`** (picker) or `tmux detach-client -s task-<task-id>`. Closing the browser tab also just detaches — the agent keeps running either way. The only thing that actually *kills* a session is `exit`/`Ctrl+D` at its shell prompt (or `agent-run reap`).
 
-> **⚠️ code-server steals Ctrl+B** (it's VS Code's "toggle sidebar" shortcut), so in the
-> integrated terminal here the detach keystroke usually never reaches tmux. Detach from
-> any *other* terminal instead: **`agent-run detach`** (picker) or
-> `tmux detach-client -s task-<task-id>`. Closing the browser tab also just detaches —
-> the agent keeps running either way. The only thing that actually *kills* a session is
-> `exit`/`Ctrl+D` at its shell prompt (or `agent-run reap`).
-
----
-
-## 3. Managing tasks
+## Managing tasks
 
 ```bash
 agent-run list               # what's running + start times + the attach command to copy
@@ -66,51 +49,58 @@ agent-run reap [task-id]     # kill it + delete the worktree (the log is kept)
 agent-run prune              # bulk-clean EVERY stranded worktree (dry-run; add --yes to do it)
 ```
 
-**Skip the id and you get an arrow-key picker** (↑/↓ or j/k, Enter selects, `q` cancels)
-showing each task's start time. `reap`'s picker also lists **stranded worktrees** — a pod
-restart kills tmux but the PVC keeps the worktree, so reap those leftovers before they
-balloon the PVC (it asks `y/N` before deleting).
+**Skip the id and you get an arrow-key picker** (↑/↓ or j/k, Enter selects, `q` cancels) showing each task's start time. `reap`'s picker also lists **stranded worktrees** — a pod restart kills tmux but the PVC keeps the worktree — and asks `y/N` before deleting.
 
-`list` prints the **task id** (e.g. `haynesnetwork-0714-010301`) and the ready-to-paste
-`agent-run attach …` line under it. If you paste the tmux session name (`task-…`) by
-mistake, `attach` strips the prefix for you. `attach` is nested-tmux aware: from inside
-another task's session it switches you over instead of erroring.
+`list` prints the **task id** (e.g. `haynesnetwork-0714-010301`) and the ready-to-paste `agent-run attach …` line under it. If you paste the tmux session name (`task-…`) by mistake, `attach` strips the prefix for you. `attach` is nested-tmux aware: from inside another task's session it switches you over instead of erroring.
 
-**When the backlog piles up** (an agent that spun up its own per-PR worktrees, or a wall of
-stranded ones after a pod bounce), `agent-run prune` clears them all at once. It prints a
-**dry-run plan** first; re-run with `--yes` to execute. Both `reap` and `prune` resolve the
-owning repo from git itself (so any worktree name works, in either repo) and are **safe by
-construction**: a worktree is removed only when it has **no uncommitted _tracked_ changes** —
-untracked scratch (`.claude/` locks, `node_modules`, build dirs) is discarded, but real WIP
-is kept and listed. A worktree that still holds tracked edits is skipped unless you add
-`--force` (`reap <id> --force` / `prune --yes --force`). Agents commit and open a PR before
-finishing, so a stranded worktree is essentially always safe to prune.
-
-**Branches are retired conservatively.** After removing a worktree, the branch is deleted only
-when git can prove _offline_ it holds nothing beyond the base (`git branch -d`). A branch with
-its own local commits — genuinely unpushed WIP, **or** a squash-merged branch whose remote was
-deleted (git can't tell these apart offline, and it never trusts a branch _name_ to mean
-"merged") — is **kept**, and prune prints the exact `git branch -D …` to drop it once you've
-confirmed it landed. So a clean prune may leave a few merged branch refs behind; that's the
-price of never orphaning an un-pushed commit. Sweep them when you're sure with
-`git -C ~/repos/<name> branch -D <branch>`.
-
-**Task logs** live at `~/work/<task-id>.log` even after a reap.
+**Task logs** live at `~/work/<task-id>.log` even after a reap; Remote-Control host diagnostics land in `~/work/<task-id>.rc.log`.
 
 ---
 
-## 4. How isolation works (why you won't get collisions)
+# Reference
+
+## agent-run flag reference
+
+```
+agent-run run [<repo>] [flags]              # every omitted choice becomes a picker/prompt
+    --repo <name>                           # same as the positional <repo>
+    --agent claude|codex
+    --base <ref>                            # branch the worktree off this (default: origin/HEAD)
+    -p "<task>"                             # fire-and-forget; log at ~/work/<id>.log
+    --interactive                           # Remote Control host (drive from phone/claude.ai/code)
+    --local                                 # classic in-terminal TUI instead of the RC host
+    --safe                                  # keep permission prompts (default: skipped)
+    --effort low|medium|high|xhigh|max      # claude only; default xhigh
+    --model <m>                             # -p/--local only (an RC host always runs the pod default)
+agent-run list
+agent-run attach [<task-id>]                # no id → picker
+agent-run detach [<task-id>]                # no id → picker (attached sessions only)
+agent-run reap   [<task-id>] [--force]      # no id → picker (incl. stranded worktrees)
+agent-run prune  [--yes] [--force]          # bulk-clean stranded worktrees (dry-run without --yes)
+```
+
+The repo picker asks GitHub for your repos (newest-pushed first) via the bot token; if that's unreachable it falls back to the local clones in `~/repos`, most recently fetched first.
+
+## Model & effort
+
+- **Model:** the pod default is **Fable** (`~/.claude/settings.json` on the PVC). `--model` overrides it for `-p` and `--local` runs only — the `claude remote-control` subcommand takes no top-level flags, so an RC host always runs the pod default.
+- **Effort:** `agent-run` pins claude runs to **`xhigh`** unless you choose otherwise. `-p`/`--local` runs get the top-level `--effort` flag; an RC host gets `CLAUDE_CODE_EFFORT_LEVEL` exported into its environment, which the sessions it hosts inherit. Precedence (high → low): in-session `/effort` → `--effort` flag → env var → settings.json → model default. `--effort ultracode` is not a launch value — ultracode is a harness session-mode; set it with `/effort` in-session.
+- **History:** before 2026-07 nothing set effort at all — no flag reached RC hosts and no settings key existed — so every session silently ran at the model default (`high` for Fable). It's now deterministically `xhigh`.
+
+## How isolation works
 
 - `~/repos/<name>` — the **canonical clone**. Fetch-only. *Never work here directly.*
 - `~/work/<task-id>` — a **git worktree** per task, on branch `agent/<task-id>`.
 
-Every agent gets its own worktree, so two agents in the same repo never step on each other.
-Agents are told (via `~/.claude/CLAUDE.md`) to stay in their worktree, **never push to `main`**,
-and open a PR when done.
+Every agent gets its own worktree, so two agents in the same repo never step on each other. Agents are told (via `~/.claude/CLAUDE.md`) to stay in their worktree, **never push to `main`**, and open a PR when done.
 
----
+## Cleanup: reap, prune, and branch retirement
 
-## 5. What's installed, and what's authenticated
+**When the backlog piles up** (an agent that spun up its own per-PR worktrees, or a wall of stranded ones after a pod bounce), `agent-run prune` clears them all at once. It prints a **dry-run plan** first; re-run with `--yes` to execute. Both `reap` and `prune` resolve the owning repo from git itself (so any worktree name works, in either repo) and are **safe by construction**: a worktree is removed only when it has **no uncommitted _tracked_ changes** — untracked scratch (`.claude/` locks, `node_modules`, build dirs) is discarded, but real WIP is kept and listed. A worktree that still holds tracked edits is skipped unless you add `--force` (`reap <id> --force` / `prune --yes --force`). Agents commit and open a PR before finishing, so a stranded worktree is essentially always safe to prune.
+
+**Branches are retired conservatively.** After removing a worktree, the branch is deleted only when git can prove _offline_ it holds nothing beyond the base (`git branch -d`). A branch with its own local commits — genuinely unpushed WIP, **or** a squash-merged branch whose remote was deleted (git can't tell these apart offline, and it never trusts a branch _name_ to mean "merged") — is **kept**, and prune prints the exact `git branch -D …` to drop it once you've confirmed it landed. So a clean prune may leave a few merged branch refs behind; that's the price of never orphaning an un-pushed commit. Sweep them when you're sure with `git -C ~/repos/<name> branch -D <branch>`.
+
+## What's installed, and what's authenticated
 
 | Tool | Auth | Notes |
 |---|---|---|
@@ -123,61 +113,23 @@ and open a PR when done.
 | `talosctl` / `omnictl` | ❌ absent | node/Omni work happens on the Mac |
 | SOPS **age key** | ❌ deliberately absent | never leaves your machine without an explicit decision |
 
-**MCP servers** (already wired into `claude`, no setup): `home-assistant`, `grafana-mcp`,
-`mcp-unifi`, `playwright` (headless chromium — it can drive your own apps at
-`https://<app>.haynesops.com` for UI testing).
+**MCP servers** (already wired into `claude`, no setup): `home-assistant`, `grafana-mcp`, `mcp-unifi`, `playwright` (headless chromium — it can drive your own apps at `https://<app>.haynesops.com` for UI testing).
 
----
+## Rules the agents follow (and you should too)
 
-## 6. Rules the agents follow (and you should too)
-
-- **GitOps.** Cluster changes go through a PR to `haynes-ops` and Flux applies them. The
-  kubectl SA can restart and reconcile things, but it can't deploy — that's on purpose.
+- **GitOps.** Cluster changes go through a PR to `haynes-ops` and Flux applies them. The kubectl SA can restart and reconcile things, but it can't deploy — that's on purpose.
 - **Never push to `main`.** Branch + PR.
-- **Egress is a default-deny allowlist.** If a `curl`/`npm install` hangs, the domain probably
-  isn't allowlisted — that's the CiliumNetworkPolicy doing its job, not a network glitch. Fix it
-  in git (`kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml`), don't hunt for a proxy.
+- **Egress is a default-deny allowlist.** If a `curl`/`npm install` hangs, the domain probably isn't allowlisted — that's the CiliumNetworkPolicy doing its job, not a network glitch. Fix it in git (`kubernetes/main/apps/dev/dev-env/app/networkpolicy.yaml`), don't hunt for a proxy.
 
----
+## Gotchas worth knowing
 
-## 7. Gotchas worth knowing
+- **A pod restart kills tmux** (image roll, node drain, OOM). Worktrees, branches, and logs survive on the PVC — only the live pane is lost. `agent-run list` shows what's left (and a count of stranded worktrees), and `agent-run prune` clears the whole backlog in one shot.
+- **Remote Control host mechanics (the `--interactive` default):** registration uses the standalone `claude remote-control` path (api.anthropic.com environments API), which is reliable; fresh worktrees are pre-trusted by agent-run so nothing stops at a dialog, and the host launches `--spawn=same-dir` so it registers immediately (no spawn-mode prompt) with phone/web sessions reusing the task's worktree — press `w` in the host to switch to per-session worktrees. If a host fails to connect, the reason is in `~/work/<id>.rc.log`.
+- **Prefer a classic terminal TUI?** Add `--local`. You can still type `/remote-control` inside it, but the *in-TUI* path is flaky server-side (intermittent 401s on the code-session endpoints — anthropics/claude-code#30093 #30102 — and after 3 failed attempts that process disables RC until restarted). The RC-host default exists precisely so your workflow never depends on it. Historical silent-failure traps, all handled now: bridge egress (`bridge.claudeusercontent.com` allowed in the CNP since 2026-07-17) and permission flags at launch disabling in-TUI RC (`--local` launches flag-free; bypass comes from settings).
+- **haynesnetwork is pre-warmed**: `pnpm install`, `build`, `typecheck`, and all **1,292 tests** (embedded Postgres) pass in this pod. Playwright browsers are installed.
+- **Memory is 24Gi.** The monorepo test suite OOM'd at 8Gi — if a build dies mysteriously, check `kubectl top pod -n dev` before blaming the code.
 
-- **A pod restart kills tmux** (image roll, node drain, OOM). Worktrees, branches, and logs
-  survive on the PVC — only the live pane is lost. `agent-run list` shows what's left (and a
-  count of stranded worktrees), and `agent-run prune` clears the whole backlog in one shot
-  (`agent-run reap`'s picker still handles them one at a time).
-- **Pick the model/effort per task.** The pod defaults to Fable; add `--model <m>` and/or
-  `--effort low|medium|high|xhigh|max` to `agent-run run` to override for a **`-p` or
-  `--local`** session. They do **not** apply to a Remote-Control host — the reliable `claude
-  remote-control` subcommand takes no such flags — so an RC host runs at the pod-default model
-  (Fable) and default effort; set a different effort with `/effort` once you've connected.
-  `--effort ultracode` is likewise a harness session-mode, not a launch value — set it in-session.
-- **haynesnetwork is pre-warmed**: `pnpm install`, `build`, `typecheck`, and all **1,292 tests**
-  (embedded Postgres) pass in this pod. Playwright browsers are installed.
-- **Memory is 24Gi.** The monorepo test suite OOM'd at 8Gi — if a build dies mysteriously,
-  check `kubectl top pod -n dev` before blaming the code.
-- **Driving an agent from your phone (the default):** `agent-run run --repo <r> --agent
-  claude --interactive` starts the task as a **Remote Control host** — connect from the
-  Claude mobile app or claude.ai/code; `agent-run attach <id>` shows the status screen
-  with the QR code + URL. This uses the standalone `claude remote-control` registration
-  path (api.anthropic.com environments API), which is reliable; fresh worktrees are
-  pre-trusted by agent-run so nothing stops at a dialog, and the host is launched
-  `--spawn=same-dir` so it registers immediately (no spawn-mode prompt) with phone/web
-  sessions reusing this worktree — press `w` in the host to switch to per-session
-  worktrees. If a host ever fails to connect, the reason is in `~/work/<id>.rc.log` — no
-  more silent failures.
-- **Prefer a classic terminal TUI?** Add `--local`. You can still type `/remote-control`
-  inside it, but know that the *in-TUI* path is flaky server-side (intermittent 401s on
-  the code-session endpoints — anthropics/claude-code#30093 #30102 — and after 3 failed
-  attempts that process disables RC until restarted). The RC-host default exists
-  precisely so your workflow never depends on it. Historical silent-failure traps, all
-  handled now: bridge egress (`bridge.claudeusercontent.com` allowed in the CNP since
-  2026-07-17) and permission flags at launch disabling in-TUI RC (`--local` launches
-  flag-free; bypass comes from settings).
-
----
-
-## 8. Where things live
+## Where things live
 
 | | |
 |---|---|

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
@@ -12,7 +12,7 @@ Open a terminal and run:
 agent-run run
 ```
 
-That's the whole command. Everything you don't specify is asked with an arrow-key picker: **repo** (your GitHub repos, newest activity first — no need to remember exact names), **agent** (`claude` or `codex`), **mode** (interactive session, or type a task prompt for fire-and-forget), and **effort** for claude runs (default `xhigh`). The agent then starts in a **fresh git worktree** on its own branch, inside tmux.
+That's the whole command. Everything you don't specify is asked with an arrow-key picker: **repo** (your GitHub repos, newest activity first — no need to remember exact names), **agent** (`claude` or `codex`), **mode** (interactive session, or type a task prompt for fire-and-forget), **how to drive an interactive claude session** (a *remote-control host* you drive from your phone/web — the default — or a *local TUI* you type to in the terminal), and **effort** for claude runs (default `xhigh`). The agent then starts in a **fresh git worktree** on its own branch, inside tmux.
 
 Know what you want? Flags skip the pickers, and `agent-run run <repo>` is a positional shorthand:
 
@@ -21,7 +21,7 @@ agent-run run haynesnetwork --agent claude --interactive
 agent-run run --repo haynes-ops --agent claude --effort max -p "Bump the coredns chart and open a PR"
 ```
 
-An interactive run starts a **Remote Control host** by default — connect from the Claude mobile app or claude.ai/code; `agent-run attach <id>` shows the status screen with the QR code + URL. Add `--local` for a classic in-terminal TUI instead.
+**Two ways to drive an interactive claude session.** The default is a **Remote Control host** — headless in the pod, driven from the Claude mobile app or claude.ai/code (`agent-run attach <id>` shows the status screen with the QR code + URL). The alternative is a **classic in-terminal TUI you type to directly** — pass the **`--local`** flag, or answer *n* to the menu's `remote-control host? [Y/n]` question. (Codex is always a local TUI — it has no remote-control host.)
 
 **Permissions are skipped by default** (`claude --dangerously-skip-permissions` / `codex --dangerously-bypass-approvals-and-sandbox` — you don't type those). The pod *is* the sandbox: isolated worktree, scoped ServiceAccount, default-deny egress. Add **`--safe`** to keep the normal permission prompts for a task you want to babysit.
 
@@ -67,8 +67,8 @@ agent-run run [<repo>] [flags]              # every omitted choice becomes a pic
     --agent claude|codex
     --base <ref>                            # branch the worktree off this (default: origin/HEAD)
     -p "<task>"                             # fire-and-forget; log at ~/work/<id>.log
-    --interactive                           # Remote Control host (drive from phone/claude.ai/code)
-    --local                                 # classic in-terminal TUI instead of the RC host
+    --interactive                           # interactive session; default = Remote Control host (drive from phone/claude.ai/code)
+    --local                                 # classic in-terminal TUI you type to directly, instead of the RC host
     --safe                                  # keep permission prompts (default: skipped)
     --effort low|medium|high|xhigh|max      # claude only; default xhigh
     --model <m>                             # -p/--local only (an RC host always runs the pod default)
@@ -125,7 +125,7 @@ Every agent gets its own worktree, so two agents in the same repo never step on 
 
 - **A pod restart kills tmux** (image roll, node drain, OOM). Worktrees, branches, and logs survive on the PVC — only the live pane is lost. `agent-run list` shows what's left (and a count of stranded worktrees), and `agent-run prune` clears the whole backlog in one shot.
 - **Remote Control host mechanics (the `--interactive` default):** registration uses the standalone `claude remote-control` path (api.anthropic.com environments API), which is reliable; fresh worktrees are pre-trusted by agent-run so nothing stops at a dialog, and the host launches `--spawn=same-dir` so it registers immediately (no spawn-mode prompt) with phone/web sessions reusing the task's worktree — press `w` in the host to switch to per-session worktrees. If a host fails to connect, the reason is in `~/work/<id>.rc.log`.
-- **Prefer a classic terminal TUI?** Add `--local`. You can still type `/remote-control` inside it, but the *in-TUI* path is flaky server-side (intermittent 401s on the code-session endpoints — anthropics/claude-code#30093 #30102 — and after 3 failed attempts that process disables RC until restarted). The RC-host default exists precisely so your workflow never depends on it. Historical silent-failure traps, all handled now: bridge egress (`bridge.claudeusercontent.com` allowed in the CNP since 2026-07-17) and permission flags at launch disabling in-TUI RC (`--local` launches flag-free; bypass comes from settings).
+- **Prefer a classic terminal TUI you type to directly?** Add `--local` (or answer *n* to the menu's `remote-control host? [Y/n]` question). You can still type `/remote-control` inside it, but the *in-TUI* path is flaky server-side (intermittent 401s on the code-session endpoints — anthropics/claude-code#30093 #30102 — and after 3 failed attempts that process disables RC until restarted). The RC-host default exists precisely so your workflow never depends on it. Historical silent-failure traps, all handled now: bridge egress (`bridge.claudeusercontent.com` allowed in the CNP since 2026-07-17) and permission flags at launch disabling in-TUI RC (`--local` launches flag-free; bypass comes from settings).
 - **haynesnetwork is pre-warmed**: `pnpm install`, `build`, `typecheck`, and all **1,292 tests** (embedded Postgres) pass in this pod. Playwright browsers are installed.
 - **Memory is 24Gi.** The monorepo test suite OOM'd at 8Gi — if a build dies mysteriously, check `kubectl top pod -n dev` before blaming the code.
 

--- a/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
+++ b/kubernetes/main/apps/dev/dev-env/app/resources/config/home/README.md
@@ -12,7 +12,7 @@ Open a terminal and run:
 agent-run run
 ```
 
-That's the whole command. Everything you don't specify is asked with an arrow-key picker: **repo** (your GitHub repos, newest activity first — no need to remember exact names), **agent** (`claude` or `codex`), **mode** (interactive session, or type a task prompt for fire-and-forget), **how to drive an interactive claude session** (a *remote-control host* you drive from your phone/web — the default — or a *local TUI* you type to in the terminal), and **effort** for claude runs (default `xhigh`). The agent then starts in a **fresh git worktree** on its own branch, inside tmux.
+That's the whole command. Everything you don't specify is asked with an arrow-key picker, **tool-first** — you pick the **agent** (`claude` or `codex`) and every later step shows only that tool's options: **repo** (your GitHub repos, newest activity first — no need to remember exact names), **mode** (interactive session, or type a task prompt for fire-and-forget), **how to drive an interactive claude session** (a *remote-control host* you drive from your phone/web — the default — or a *local TUI* you type to in the terminal), **model** (claude: fable/opus/sonnet/haiku; codex: gpt-5.6 sol/terra/luna, 5.5, 5.2), and **effort** (filtered to the model you picked; default `xhigh`). The agent then starts in a **fresh git worktree** on its own branch, inside tmux.
 
 Know what you want? Flags skip the pickers, and `agent-run run <repo>` is a positional shorthand:
 
@@ -21,11 +21,11 @@ agent-run run haynesnetwork --agent claude --interactive
 agent-run run --repo haynes-ops --agent claude --effort max -p "Bump the coredns chart and open a PR"
 ```
 
-**Two ways to drive an interactive claude session.** The default is a **Remote Control host** — headless in the pod, driven from the Claude mobile app or claude.ai/code (`agent-run attach <id>` shows the status screen with the QR code + URL). The alternative is a **classic in-terminal TUI you type to directly** — pass the **`--local`** flag, or answer *n* to the menu's `remote-control host? [Y/n]` question. (Codex is always a local TUI — it has no remote-control host.)
+**Two ways to drive an interactive claude session.** The default is a **Remote Control host** — headless in the pod, driven from the Claude mobile app or claude.ai/code (`agent-run attach <id>` shows the status screen with the QR code + URL). The alternative is a **classic in-terminal TUI you type to directly** — pass the **`--local`** flag, or answer *n* to the menu's `remote-control host? [Y/n]` question. **Codex** currently runs only as a local in-terminal TUI: its remote-control equivalent (`codex remote-control`) needs the standalone Codex install this pod doesn't ship yet, so it's deferred — details in [Model & effort](#model--effort).
 
 **Permissions are skipped by default** (`claude --dangerously-skip-permissions` / `codex --dangerously-bypass-approvals-and-sandbox` — you don't type those). The pod *is* the sandbox: isolated worktree, scoped ServiceAccount, default-deny egress. Add **`--safe`** to keep the normal permission prompts for a task you want to babysit.
 
-**Effort defaults to `xhigh`** for claude runs — deterministically, in every mode. Override with `--effort low|medium|high|xhigh|max` (or the picker), or mid-session with `/effort`. Details in [Model & effort](#model--effort) below.
+**Model & effort are picked per tool.** Effort defaults to **`xhigh`** for both claude and codex — deterministically, in every mode. The menu lets you pick the model, then shows only that model's effort levels (claude's are the same across models; codex's differ — only gpt-5.6 has `max`, only sol/terra add `ultra`). Override with `--model`/`--effort`, or mid-session with `/effort`. Details in [Model & effort](#model--effort) below.
 
 ## tmux — the only 3 keys you need
 
@@ -62,16 +62,17 @@ agent-run prune              # bulk-clean EVERY stranded worktree (dry-run; add 
 ## agent-run flag reference
 
 ```
-agent-run run [<repo>] [flags]              # every omitted choice becomes a picker/prompt
+agent-run run [<repo>] [flags]              # every omitted choice becomes a picker/prompt (tool-first)
     --repo <name>                           # same as the positional <repo>
     --agent claude|codex
     --base <ref>                            # branch the worktree off this (default: origin/HEAD)
     -p "<task>"                             # fire-and-forget; log at ~/work/<id>.log
-    --interactive                           # interactive session; default = Remote Control host (drive from phone/claude.ai/code)
-    --local                                 # classic in-terminal TUI you type to directly, instead of the RC host
+    --interactive                           # claude: Remote Control host (drive from phone/claude.ai/code); codex: local TUI
+    --local                                 # claude: classic in-terminal TUI you type to directly, instead of the RC host
     --safe                                  # keep permission prompts (default: skipped)
-    --effort low|medium|high|xhigh|max      # claude only; default xhigh
-    --model <m>                             # -p/--local only (an RC host always runs the pod default)
+    --model <m>                             # claude alias/id (fable|opus|sonnet|haiku|…) or codex slug (gpt-5.6-sol|…)
+                                            #   claude -p/--local only (an RC host always runs the pod default)
+    --effort <level>                        # claude: low|medium|high|xhigh|max; codex adds ultra (model-dependent); default xhigh
 agent-run list
 agent-run attach [<task-id>]                # no id → picker
 agent-run detach [<task-id>]                # no id → picker (attached sessions only)
@@ -81,10 +82,13 @@ agent-run prune  [--yes] [--force]          # bulk-clean stranded worktrees (dry
 
 The repo picker asks GitHub for your repos (newest-pushed first) via the bot token; if that's unreachable it falls back to the local clones in `~/repos`, most recently fetched first.
 
-## Model & effort
+The menu picks the **model** first, then shows only that model's **effort** levels. Both apply to `-p` and the local TUI via each tool's own flags; the one exception is a claude RC host (below).
 
-- **Model:** the pod default is **Fable** (`~/.claude/settings.json` on the PVC). `--model` overrides it for `-p` and `--local` runs only — the `claude remote-control` subcommand takes no top-level flags, so an RC host always runs the pod default.
-- **Effort:** `agent-run` pins claude runs to **`xhigh`** unless you choose otherwise. `-p`/`--local` runs get the top-level `--effort` flag; an RC host gets `CLAUDE_CODE_EFFORT_LEVEL` exported into its environment, which the sessions it hosts inherit. Precedence (high → low): in-session `/effort` → `--effort` flag → env var → settings.json → model default. `--effort ultracode` is not a launch value — ultracode is a harness session-mode; set it with `/effort` in-session.
+- **claude models:** `fable` (pod default — the 1M-ctx `claude-fable-5[1m]` from `~/.claude/settings.json`), `opus`, `sonnet`, `haiku`, passed as `--model`. Effort levels are the same for all: `low|medium|high|xhigh|max`.
+- **codex models:** `gpt-5.6-sol` (default), `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.2`, passed as `-m`. Effort levels **differ by model**: every model has `low|medium|high|xhigh`; only the gpt-5.6 family adds `max`; only `sol`/`terra` add `ultra`. Effort is passed as `-c model_reasoning_effort=<level>`.
+- **Effort defaults to `xhigh`** for both tools, in every mode (valid for every current model). `-p`/local runs get the flag; a claude RC host gets `CLAUDE_CODE_EFFORT_LEVEL` exported into its environment, which the sessions it hosts inherit. Precedence (high → low): in-session `/effort` → flag → env var → settings/config → model default. `--effort ultracode` is not a launch value — ultracode is a harness session-mode; set it with `/effort` in-session.
+- **claude RC host is the exception:** the `claude remote-control` subcommand takes no top-level flags, so an RC host always runs the pod-default model (Fable); its effort still applies via the env var. Use `--local` for a flag-controlled model + effort.
+- **codex remote-control is deferred.** Codex *does* have an in-pod remote-control host (`codex remote-control` / `codex app-server`, driven from the ChatGPT app / Codex web) — the true analog of claude's RC host, **not** `codex cloud` (which runs in OpenAI's cloud, not this pod). But it requires the **standalone** Codex install (`~/.codex/packages/standalone`), and this pod ships the npm install, so `remote-control start` can't run here. Until the dev-env image bakes the standalone in (and the relay egress is allowlisted), codex interactive is a local TUI — model + effort still work there.
 - **History:** before 2026-07 nothing set effort at all — no flag reached RC hosts and no settings key existed — so every session silently ran at the model default (`high` for Fable). It's now deterministically `xhigh`.
 
 ## How isolation works


### PR DESCRIPTION
## What

**`agent-run run` is now fully picker-driven** — bare `agent-run run` walks you through every choice, so you never need to remember exact repo names:

1. **repo** — your GitHub repos, newest activity first (`gh repo list` via the bot token, REST `/installation/repositories` fallback for the app token, local clones as offline fallback)
2. **agent** — `claude` / `codex`
3. **mode** — `interactive? [Y/n]` (n → type a task prompt for fire-and-forget)
4. **effort** — claude only, `xhigh` preselected

`agent-run run <repo>` positional shorthand added. Flags still skip every prompt, so scripted/agent callers see zero behavior change apart from the new effort default.

**Effort is deterministic now — default `xhigh` in every mode.** Until now *nothing* set effort (no flag reached RC hosts, no settings key, no env var), so all sessions silently ran at the model default (`high` for Fable). Now:
- `-p` / `--local` runs get the top-level `--effort` flag (as before, but defaulted)
- **RC hosts get `CLAUDE_CODE_EFFORT_LEVEL` exported in the launch env** — the `remote-control` subcommand takes no top-level flags, but hosted sessions inherit the env var (precedence: `/effort` > `--effort` > env var > settings.json, per code.claude.com/docs/en/env-vars)
- `--model` remains `-p`/`--local`-only; the note now says so without lumping effort in

**README rewritten as a manual**: quick start + tmux keys + task management up top, reference (flags, model/effort semantics, isolation, cleanup, tooling, gotchas) below the fold. Paragraphs unwrapped to single lines so VS Code soft-wraps — roughly half the vertical height.

## Testing

- `bash -n` clean; `kubectl kustomize` of the app builds
- `repo_rows` exercised with a mocked `gh` (GitHub path + local-clone fallback, activity ordering, UTC→local timestamps)
- Fully-flagged `run` verified prompt-free end-to-end (no TTY): proceeds straight to clone with effort silently defaulted
- Validation order verified: bad `--effort`/extra positional/missing mode all die before any side effect

## Deploy note

**Hold as draft until you're ready** — merge bounces the dev-env pod via reloader (configmap change), which kills live tmux sessions. Worktrees/branches/logs survive on the PVC; `agent-run prune` clears the stranded remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)