### PR TITLE
fix(descheduler): exclude node-lifecycle taints from RemovePodsViolatingNodeTaints

### DIFF
--- a/kubernetes/main/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/main/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -29,6 +29,19 @@ spec:
                 nodeAffinityType:
                   - requiredDuringSchedulingIgnoredDuringExecution
             - name: RemovePodsViolatingNodeTaints
+              args:
+                # Transient node-lifecycle taints are already handled by the
+                # taint-eviction controller WITH the pods' tolerationSeconds grace
+                # (default 300s). Without this exclusion the descheduler re-judges
+                # them with ZERO grace: a <60s control-plane heartbeat blip
+                # (2026-07-29 20:25 ET) tainted every node and the descheduler's
+                # sweep landed inside the window, evicting dev-env (killed a live
+                # agent session), the cloudnative-pg operator, and others — the
+                # Gatus multi-service outage was descheduler evictions, not the
+                # blip itself.
+                excludedTaints:
+                  - node.kubernetes.io/not-ready
+                  - node.kubernetes.io/unreachable
             - name: RemovePodsViolatingTopologySpreadConstraint
               args:
                 constraints:


### PR DESCRIPTION
## What
Adds `excludedTaints: [node.kubernetes.io/not-ready, node.kubernetes.io/unreachable]` to the descheduler's `RemovePodsViolatingNodeTaints` plugin (main cluster).

## Why
2026-07-29 20:25 ET: a <60s control-plane heartbeat blip marked all six nodes NotReady. The descheduler's periodic sweep landed inside that window and evicted every pod "violating" the transient `not-ready:NoSchedule` taint — including the dev-env pod (killing a live agent session), the cloudnative-pg operator, bazarr, omni, and more. The resulting Gatus multi-service page was descheduler evictions, not the blip itself.

The taint-eviction controller already handles these lifecycle taints correctly, honoring each pod's `tolerationSeconds` (default 300s). The descheduler re-judging them with zero grace turns any sub-minute blip into a cluster-wide eviction storm.

## Blast radius
Descheduler-only behavior change; its pods restart on merge. No workload pods are touched. All other plugins (anti-affinity, node-affinity, topology-spread) unchanged.

Companion PR (draft, bounces the pod, user-timed merge): dev-env explicit blip tolerations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoExdcvFykpatk56z21cTC