### PR TITLE
fix(dev-env): 1h node-blip tolerations (HELD — merge bounces the pod)

### DIFF
--- a/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
+++ b/kubernetes/main/apps/dev/dev-env/app/helmrelease.yaml
@@ -168,6 +168,29 @@ spec:
         options:
           - name: ndots
             value: "1"
+      # Node-blip survival (2026-07-29 20:25 ET incident): a <60s control-plane
+      # heartbeat stall tainted every node and killed the live agent session.
+      # Interactive singleton on an RWO PVC — eviction NEVER helps (the
+      # replacement can't attach until the old node releases the volume), so:
+      # - NoExecute tolerationSeconds 3600 replaces the 300s defaults: rides out
+      #   any blip/flap up to 1h; genuine node death still self-recovers after.
+      # - NoSchedule tolerations stop the descheduler treating a transient taint
+      #   as a violation (belt-and-braces with the descheduler excludedTaints fix).
+      tolerations:
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 3600
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 3600
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
+          effect: NoSchedule
+        - key: node.kubernetes.io/unreachable
+          operator: Exists
+          effect: NoSchedule
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## What
Explicit tolerations on the dev-env pod (`defaultPodOptions`):
- `not-ready`/`unreachable` **NoExecute** with `tolerationSeconds: 3600` — replaces the 300s admission defaults; the pod rides out any node flap up to 1h instead of being evicted.
- Same keys with **NoSchedule** — the descheduler no longer counts a transient lifecycle taint as a violation (defense in depth alongside #2302).

## Why
2026-07-29 20:25 ET: a <60s control-plane heartbeat blip tainted all nodes; the descheduler evicted the dev-env pod and killed the live agent session. dev-env is an interactive singleton on an RWO PVC — eviction never helps it (the replacement pod can't attach the volume until the old node lets go), while the running containers would have survived the blip untouched.

## ⚠️ Merge timing
Pod-template change → **merging bounces the dev-env pod and kills any live sessions**. Merge at the next idle window (same rule as every dev-env pod-spec PR).

## Verify after merge
`kubectl get pod -n dev -l app.kubernetes.io/name=dev-env -o jsonpath='{.items[0].spec.tolerations}'` shows the 3600s + NoSchedule entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoExdcvFykpatk56z21cTC