### PR TITLE
fix(dragonfly): stamp CRD with prune-guard + helm adoption metadata (1/2)

### DIFF
--- a/kubernetes/main/apps/database/dragonfly/app/kustomization.yaml
+++ b/kubernetes/main/apps/database/dragonfly/app/kustomization.yaml
@@ -9,4 +9,21 @@ resources:
   - https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/v1.6.1/manifests/crd.yaml
   - ./helmrelease.yaml
   - ./rbac.yaml
+patches:
+  # Migration prep (PR 1 of 2): the CRD moves from this Kustomization's inventory
+  # to the official dragonfly-operator Helm chart next PR. prune=disabled keeps
+  # Flux from deleting it (which would cascade-delete every Dragonfly CR) when it
+  # leaves this build; the meta.helm.sh/* + managed-by stamps let Helm adopt it
+  # instead of refusing with an invalid-ownership-metadata error.
+  - patch: |-
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      metadata:
+        name: dragonflies.dragonflydb.io
+        annotations:
+          kustomize.toolkit.fluxcd.io/prune: disabled
+          meta.helm.sh/release-name: dragonfly-operator
+          meta.helm.sh/release-namespace: database
+        labels:
+          app.kubernetes.io/managed-by: Helm
   


### PR DESCRIPTION
Prep PR (1 of 2) for eliminating the repo's only **build-time remote fetch**: the dragonfly Kustomization pulls the operator CRD from `raw.githubusercontent.com` on every kustomize build, uncached — during this morning's intermittent egress blip (05:59–09:42 ET) that made `database/dragonfly` the only Kustomization in the cluster to go red and page (`FluxReconciliationFailure`, ~90 min, 30m retry interval).

This PR only stamps the live CRD via a kustomize patch:

- `kustomize.toolkit.fluxcd.io/prune: disabled` — so Flux cannot prune it when it leaves this Kustomization's inventory in PR 2 (pruning a CRD cascade-deletes every `Dragonfly` CR → the cache StatefulSet).
- `meta.helm.sh/release-name/-namespace` + `app.kubernetes.io/managed-by: Helm` — so Helm can adopt the existing object when PR 2 moves CRD ownership to the official `dragonfly-operator` chart (templated CRD, upgraded on every chart bump, `helm.sh/resource-policy: keep`).

PR 2 swaps the operator HR from app-template to `oci://ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator` (kills the remote CRD fetch **and** the hand-mirrored ClusterRole that bit us at v1.6.x) and adds `retryInterval: 5m` to the dragonfly Kustomizations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZfBkmvcXLGLGKAfQWGiZF