### PR TITLE
feat(observability): dns-canary — catch NODATA A-answers behind the egress blips

### DIFF
--- a/kubernetes/main/apps/observability/dns-canary/app/deployment.yaml
+++ b/kubernetes/main/apps/observability/dns-canary/app/deployment.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/apps/deployment_v1.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dns-canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dns-canary
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dns-canary
+    spec:
+      containers:
+        - name: canary
+          image: ghcr.io/nicolaka/netshoot:v0.16
+          command: ["/bin/bash", "/opt/canary/canary.sh"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: script
+              mountPath: /opt/canary
+      volumes:
+        - name: script
+          configMap:
+            name: dns-canary-script

--- a/kubernetes/main/apps/observability/dns-canary/app/kustomization.yaml
+++ b/kubernetes/main/apps/observability/dns-canary/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+configMapGenerator:
+  - name: dns-canary-script
+    files:
+      - canary.sh=./resources/canary.sh

--- a/kubernetes/main/apps/observability/dns-canary/app/resources/canary.sh
+++ b/kubernetes/main/apps/observability/dns-canary/app/resources/canary.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# DNS A-record loss canary (2026-08-01, diagnostic — remove when solved).
+#
+# Hunts the chronic ~0.1% egress-fetch failures where Flux controllers end up
+# dialing an IPv6-only address list ("dial tcp [2606:...]: network is
+# unreachable", instant failure => the A answer was missing at that moment;
+# see the 2026-07-30 dragonfly incident). WAN counters, CoreDNS SERVFAILs and
+# spot probes are all clean, so the suspect is an invisible NOERROR-empty
+# (NODATA) A response. This canary queries the affected chart hosts via BOTH
+# the cluster DNS path (what real pods use) AND the UDM directly, and logs
+# ONLY anomalies plus a 15-minute heartbeat. Promtail ships it to Loki.
+#
+# Correlate with:
+#   {namespace="observability", pod=~"dns-canary.*"} |= "ANOMALY"
+#   {namespace="flux-system"} |= "network is unreachable"
+# cluster-hit + udm-clean  => CoreDNS/cache layer
+# both-hit                 => UDM upstream resolver
+# canary-clean while flux still errors => not DNS; look at conntrack/dial path
+set -u
+
+HOSTS="${CANARY_HOSTS:-charts.goauthentik.io helm.openwebui.com raw.githubusercontent.com}"
+UPSTREAM="${CANARY_UPSTREAM:-192.168.0.1}"
+INTERVAL="${CANARY_INTERVAL_SECONDS:-15}"
+HEARTBEAT_EVERY=$(( 900 / INTERVAL ))
+
+ts() { date -u +%FT%TZ; }
+
+# $1 resolver-label, $2 host, $3 dig server arg ("" = pod resolv.conf path).
+# On anomaly, also grab the AAAA answer at the same instant — the flux failure
+# mode is exactly "AAAA present, A missing", so this captures the asymmetry.
+probe() {
+  local out rcode aaaa
+  out="$(dig +time=2 +tries=1 A "$2" $3 2>/dev/null)"
+  rcode="$(printf '%s' "$out" | sed -n 's/.*status: \([A-Z]*\).*/\1/p' | head -1)"
+  if [ "$rcode" = "NOERROR" ] && printf '%s' "$out" | grep -qE 'IN[[:space:]]+A[[:space:]]+[0-9]'; then
+    return 0
+  fi
+  aaaa="$(dig +short +time=2 +tries=1 AAAA "$2" $3 2>/dev/null | head -1)"
+  if [ "$rcode" = "NOERROR" ]; then
+    echo "$(ts) ANOMALY resolver=$1 host=$2 kind=empty-A-NODATA aaaa=${aaaa:-none}"
+  else
+    echo "$(ts) ANOMALY resolver=$1 host=$2 kind=${rcode:-timeout} aaaa=${aaaa:-none}"
+  fi
+  return 1
+}
+
+i=0; anomalies=0; total=0
+echo "$(ts) dns-canary start hosts=[$HOSTS] upstream=$UPSTREAM interval=${INTERVAL}s"
+while true; do
+  for h in $HOSTS; do
+    probe cluster "$h" ""           || anomalies=$((anomalies+1))
+    probe udm     "$h" "@$UPSTREAM" || anomalies=$((anomalies+1))
+    total=$((total+2))
+  done
+  i=$((i+1))
+  if [ $(( i % HEARTBEAT_EVERY )) -eq 0 ]; then
+    echo "$(ts) heartbeat queries=$total anomalies=$anomalies"
+    anomalies=0; total=0
+  fi
+  sleep "$INTERVAL"
+done

--- a/kubernetes/main/apps/observability/dns-canary/ks.yaml
+++ b/kubernetes/main/apps/observability/dns-canary/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dns-canary
+  namespace: observability
+spec:
+  targetNamespace: observability
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/main/apps/observability/dns-canary/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: haynes-ops
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 5m
+  timeout: 5m

--- a/kubernetes/main/apps/observability/kustomization.yaml
+++ b/kubernetes/main/apps/observability/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - ./mcp-unifi/ks.yaml
   - ./unpoller/ks.yaml
   - ./prometheus-pve-exporter/ks.yaml
+  - ./dns-canary/ks.yaml


### PR DESCRIPTION
Diagnostic deployment (deliberately trivial to revert) for the chronic low-rate egress-fetch failures (130/day, every hour, fully cache-absorbed since #2313).

Evidence so far: WAN/ISP clean (unpoller: zero drops/errors), CoreDNS ~zero SERVFAIL, 3×120 spot probes clean — yet flux controllers keep dialing v6-only address lists with instant failures, meaning the A answer vanishes at that moment. The only mechanism invisible to all of the above is a **NOERROR-empty (NODATA) A response**.

The canary queries the three affected chart hosts every 15s via **cluster DNS** and via the **UDM directly** (192.168.0.1), logs only anomalies (capturing the same-instant AAAA answer — the asymmetry that matters) plus a 15-minute heartbeat. Promtail ships to Loki.

Readout after ~24h:
- `{namespace="observability", pod=~"dns-canary.*"} |= "ANOMALY"` vs `{namespace="flux-system"} |= "network is unreachable"`
- cluster-hit + udm-clean → CoreDNS/cache layer; both-hit → UDM upstream; canary-clean while flux errors continue → not DNS, look at conntrack/dial path.

No UniFi cloud (Site Manager) dependency — purely in-cluster + LAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZfBkmvcXLGLGKAfQWGiZF