### PR TITLE
fix(network): move traefik charts to official OCI repo — helm.traefik.io is dead

### DIFF
--- a/kubernetes/main/apps/network/traefik/traefik-external/app/helmrelease.yaml
+++ b/kubernetes/main/apps/network/traefik/traefik-external/app/helmrelease.yaml
@@ -3,13 +3,9 @@ kind: HelmRelease
 metadata:
   name: traefik-external
 spec:
-  chart:
-    spec:
-      chart: traefik
-      version: 41.2.0
-      sourceRef:
-        kind: HelmRepository
-        name: traefik-external
+  chartRef:
+    kind: OCIRepository
+    name: traefik-external-oci
   interval: 15m
   timeout: 5m
   releaseName: traefik-external

--- a/kubernetes/main/apps/network/traefik/traefik-external/app/helmrepository.yaml
+++ b/kubernetes/main/apps/network/traefik/traefik-external/app/helmrepository.yaml
@@ -1,9 +1,17 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1beta1.json
+# UNUSED as of 2026-08-12: the HelmRelease pulls the chart via the
+# traefik-external-oci OCIRepository now (helm.traefik.io started returning 404
+# upstream and was replaced). This manifest is retained ONLY because the
+# traefik-external Flux Kustomization runs prune:false — deleting the file
+# would strand the live HelmRepository in a failing state and keep the
+# FluxReconciliationFailure page firing. Remove this file and
+# `kubectl delete helmrepository traefik-external -n network` in the same
+# change once cluster access allows it.
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: traefik-external
 spec:
   interval: 15m
-  url: https://helm.traefik.io/traefik
+  url: https://traefik.github.io/charts

--- a/kubernetes/main/apps/network/traefik/traefik-external/app/kustomization.yaml
+++ b/kubernetes/main/apps/network/traefik/traefik-external/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrepository.yaml
+  - ./ocirepository.yaml
   - ./helmrelease.yaml

--- a/kubernetes/main/apps/network/traefik/traefik-external/app/ocirepository.yaml
+++ b/kubernetes/main/apps/network/traefik/traefik-external/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: traefik-external-oci
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 41.2.0
+  url: oci://ghcr.io/traefik/helm/traefik

--- a/kubernetes/main/apps/network/traefik/traefik-internal/app/helmrelease.yaml
+++ b/kubernetes/main/apps/network/traefik/traefik-internal/app/helmrelease.yaml
@@ -3,13 +3,9 @@ kind: HelmRelease
 metadata:
   name: traefik-internal
 spec:
-  chart:
-    spec:
-      chart: traefik
-      version: 41.2.0
-      sourceRef:
-        kind: HelmRepository
-        name: traefik-internal
+  chartRef:
+    kind: OCIRepository
+    name: traefik-internal-oci
   interval: 15m
   timeout: 5m
   releaseName: traefik-internal

--- a/kubernetes/main/apps/network/traefik/traefik-internal/app/helmrepository.yaml
+++ b/kubernetes/main/apps/network/traefik/traefik-internal/app/helmrepository.yaml
@@ -1,9 +1,17 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1beta1.json
+# UNUSED as of 2026-08-12: the HelmRelease pulls the chart via the
+# traefik-internal-oci OCIRepository now (helm.traefik.io started returning 404
+# upstream and was replaced). This manifest is retained ONLY because the
+# traefik-internal Flux Kustomization runs prune:false — deleting the file
+# would strand the live HelmRepository in a failing state and keep the
+# FluxReconciliationFailure page firing. Remove this file and
+# `kubectl delete helmrepository traefik-internal -n network` in the same
+# change once cluster access allows it.
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: traefik-internal
 spec:
   interval: 15m
-  url: https://helm.traefik.io/traefik
+  url: https://traefik.github.io/charts

--- a/kubernetes/main/apps/network/traefik/traefik-internal/app/kustomization.yaml
+++ b/kubernetes/main/apps/network/traefik/traefik-internal/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrepository.yaml
+  - ./ocirepository.yaml
   - ./helmrelease.yaml

--- a/kubernetes/main/apps/network/traefik/traefik-internal/app/ocirepository.yaml
+++ b/kubernetes/main/apps/network/traefik/traefik-internal/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: traefik-internal-oci
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 41.2.0
+  url: oci://ghcr.io/traefik/helm/traefik


### PR DESCRIPTION
## What

`helm.traefik.io` (legacy Traefik chart repo) started returning **404** upstream at ~08:30 ET today — confirmed dead from both the cluster and outside. That failed both traefik HelmRepositories → both traefik Kustomizations (`wait: true` waits on all inventory) → `headlamp` (dependsOn traefik-internal). Four critical FluxReconciliationFailure pages.

## Fix

- Both HelmReleases switch to `chartRef` → `OCIRepository` at `oci://ghcr.io/traefik/helm/traefik`, tag **41.2.0** (matches what Renovate deployed in #2380/#2381; verified present in the official OCI registry — the home-operations charts-mirror does not carry traefik). Same version as deployed → no-op upgrade, no pod restart expected.
- The old HelmRepository manifests are **retained** but re-pointed at the working `https://traefik.github.io/charts`: both traefik Kustomizations run `prune: false`, so deleting the manifests would strand the live objects failing forever (and keep paging). They're commented UNUSED with paired removal instructions for when kubectl access allows deleting the live CRs.

## Risk

Running Traefik is unaffected either way — chart 41.2.0 is already deployed; this only restores Flux source refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fyb8Pnny2jdMLnzvYxywsj